### PR TITLE
feat: per-session WorldManifest bindings for MCP gateway

### DIFF
--- a/docs/implementation/HANDOFF_NOTE.md
+++ b/docs/implementation/HANDOFF_NOTE.md
@@ -1,83 +1,79 @@
 # Handoff Note
 
 **Date**: 2026-04-09  
-**Session**: Session 3 — End-to-end demo  
-**Branch**: `claude/continue-implementation-TsEYr`
+**Session**: Session 4 — Per-session WorldManifest bindings  
+**Branch**: `claude/continue-implementation-FpgJZ`
 
 ---
 
 ## What Was Just Done
 
-Created `examples/mcp_gateway/main.py` — a fully runnable, self-contained
-end-to-end demo of the MCP Gateway enforcement flow. Covers all key invariants
-from `docs/implementation/mcp_gateway_demo.md` in a single script.
+Implemented Option C from the Session 3 handoff: per-session WorldManifest
+bindings. Different sessions (agents/users) can now operate in different worlds
+simultaneously without gateway restart.
 
-### The demo
+### Changes
 
-```bash
-python examples/mcp_gateway/main.py
-```
+**`session_world_resolver.py`**
+- `register_session(session_id, manifest_path)` — loads the manifest
+  immediately; raises and does NOT register if loading fails (fail closed)
+- `unregister_session(session_id)` — removes binding, reverts to default;
+  idempotent (returns False if session was not registered)
+- `session_registry()` — returns `{session_id: workflow_id}` snapshot
+- `resolve(session_id)` — now checks `_session_registry` first; falls back to
+  default manifest if not found
 
-No extra dependencies. Uses stdlib `urllib.request` for HTTP; starts a real
-`uvicorn` server in a background daemon thread. Finds the repo root via
-`__file__`, so it works from any working directory.
+**`mcp_server.py`**
+- `_handle_tools_list` and `_handle_tools_call` now call
+  `state.resolver.resolve(session_id=provenance.session_id)` to get the
+  session's manifest, then `state.renderer_for(manifest)` /
+  `state.enforcer_for(manifest)` to get the right components
+- `renderer_for(manifest)` / `enforcer_for(manifest)` — return cached default
+  components if manifest is the default (common path), build on-the-fly
+  otherwise (lightweight)
+- New endpoints:
+  - `POST /mcp/sessions/{session_id}/bind` — body: `{"manifest_path": "..."}`
+  - `DELETE /mcp/sessions/{session_id}` — revert to default
+  - `GET /mcp/sessions` — list active bindings
+- `_BindSessionRequest` is a module-level Pydantic model (required for FastAPI
+  schema generation — do not move it inside `create_mcp_app`)
 
-### 5 scenarios, all verified passing:
+**`tests/hypervisor/test_mcp_gateway.py`** — Group 6: 13 new tests
+- 7 unit tests on `SessionWorldResolver` directly
+- 6 HTTP integration tests using `two_world_client` fixture (default + email worlds)
 
-| # | Scenario | Key check |
-|---|----------|-----------|
-| 1 | MCP initialize handshake | `protocolVersion`, `capabilities.tools`, `serverInfo` |
-| 2 | World rendering (`tools/list`) | Only `read_file` + `send_email` appear; `http_post` absent |
-| 3 | Fail closed (undeclared tool) | `http_post` → `manifest:tool_not_declared`, code -32001 |
-| 4 | Allow path (declared tool) | `read_file /etc/hostname` → result, `isError: false` |
-| 5 | World switch | Restart with `read_only_world.yaml` → `send_email` disappears |
-
-Each scenario prints `[PASS]`/`[FAIL]` per invariant and raises on failure.
-
-### Environment note
-
-The pytest binary runs under a separate uv-managed Python environment
-(`/root/.local/share/uv/tools/pytest/`). The package must be installed there:
-
-```bash
-/root/.local/share/uv/tools/pytest/bin/python -m pip install -e .
-/root/.local/share/uv/tools/pytest/bin/python -m pip install httpx pytest-asyncio
-```
-
-These were installed in this session. If a new session gets a fresh environment,
-re-run these two commands before running `pytest`.
+### Test results: 45 passed (was 32)
 
 ---
 
 ## What to Do Next
 
-**Option B (SSE transport)**: Add SSE streaming transport to `/mcp/sse`.
-FastAPI supports SSE via `StreamingResponse`. The HTTP POST endpoint at `/mcp`
-stays unchanged; SSE is additive. This makes the gateway compatible with MCP
-clients that require streaming (e.g., Claude Desktop).
+**Option B (SSE transport)**: Add SSE streaming transport at `/mcp/sse`.
+The MCP 2024-11-05 SSE transport works like this:
+1. Client GETs `/mcp/sse` → server sends `endpoint` event with a POST URL
+   (e.g., `/mcp/messages?session_id=<uuid>`)
+2. Client POSTs JSON-RPC requests to that URL
+3. Server sends responses back over the open SSE stream
 
-**Option C (per-session manifests)**: `SessionWorldResolver.resolve(session_id, context)`
-already accepts `session_id`. Wire it to a session registry dict so different
-sessions can get different WorldManifests at runtime. The gateway already
-passes `session_id` from provenance through to the resolver call.
+This requires:
+- An asyncio `Queue` per session for routing SSE responses
+- A `GET /mcp/sse` endpoint that opens the stream and sends the endpoint event
+- A `POST /mcp/messages` endpoint that routes responses back to the queue
+- `sse-starlette` package (or manual `StreamingResponse`) — add to
+  `pyproject.toml` optional deps
 
----
-
-## Files That Matter Most
-
-1. `examples/mcp_gateway/main.py` — new: end-to-end demo
-2. `src/agent_hypervisor/hypervisor/mcp_gateway/mcp_server.py` — `create_mcp_app()` + handlers
-3. `src/agent_hypervisor/hypervisor/mcp_gateway/tool_call_enforcer.py` — enforcement pipeline
-4. `manifests/example_world.yaml` — demo world (read_file + send_email)
-5. `manifests/read_only_world.yaml` — minimal world (read_file only)
-6. `tests/hypervisor/test_mcp_gateway.py` — 32 tests (Groups 1–5)
+**Option D (taint propagation)**: Wire `InvocationProvenance.trust_level` into
+`TaintContext` so values from external sources carry taint that is visible to
+the provenance firewall. The hook is already in place in the enforcer; the
+runtime taint layer needs to be imported and updated from the gateway.
 
 ---
 
-## What NOT to Break
+## Key Invariants to Preserve
 
-- `enforce()` must never raise — all error paths return deny decisions
-- The manifest-binding invariant: undeclared tools must remain absent from the
-  surface, not just denied at call time
-- `use_default_policy=False` default — existing callers continue to get
-  manifest-only enforcement unless they opt in
+- `enforce()` must never raise
+- Undeclared tools stay absent from the surface (not just denied)
+- `register_session()` must fail closed — if the manifest cannot be loaded,
+  the session must NOT be registered (no silent fallback to default)
+- `_BindSessionRequest` must remain at module level (FastAPI constraint)
+- `use_default_policy=False` default for `create_mcp_app` — unchanged

--- a/docs/implementation/HANDOFF_NOTE.md
+++ b/docs/implementation/HANDOFF_NOTE.md
@@ -1,83 +1,89 @@
 # Handoff Note
 
 **Date**: 2026-04-09  
-**Session**: Session 5 — MCP SSE transport  
+**Session**: Session 6 — Taint propagation  
 **Branch**: `claude/continue-implementation-FpgJZ`
 
 ---
 
 ## What Was Just Done
 
-Implemented Option B from the Session 3 handoff: MCP SSE transport.
-The gateway is now compatible with MCP clients that require streaming
-(e.g., Claude Desktop).
+Implemented Option D from the Session 5 handoff: taint propagation from
+`InvocationProvenance.trust_level` through `EnforcementDecision` into tool results.
 
-### New file: `sse_transport.py`
+### Changes to `tool_call_enforcer.py`
 
-- `SSESessionStore` — registry of `{session_id: asyncio.Queue}` for active
-  SSE connections. Sessions are created on GET /mcp/sse and removed in the
-  `sse_stream` generator's `finally` block on disconnect.
-- `format_sse_event(event, data)` — SSE wire format helper.
-- `sse_stream(session_id, queue, endpoint_url, store)` — async generator:
-  yields endpoint event immediately, then yields message events from the
-  queue, sends `: ping` comments every 25 s, stops on `None` sentinel.
+- `_taint_context_from_provenance(prov)` — new module-level helper.
+  Only `trust_level="trusted"` produces `TaintContext.clean()`.
+  All other values (including `"derived"`, `"untrusted"`, and unknown/empty)
+  produce `TaintContext(TaintState.TAINTED)`. Conservative by design.
+
+- `EnforcementDecision.taint_context: TaintContext` — new field.
+  Default is `TaintContext(TaintState.TAINTED)` (fail tainted, not fail open).
+  Every branch of `enforce()` passes `taint_context=taint_ctx`.
+
+- `EnforcementDecision.taint_state` — convenience property:
+  `return self.taint_context.taint`. Callers can use this directly.
 
 ### Changes to `mcp_server.py`
 
-- `_dispatch_rpc_body(state, request, session_id_override)` — new shared
-  async helper used by BOTH transports. Parses body, validates JSON-RPC,
-  extracts provenance (with optional `session_id_override` for SSE), dispatches.
-- `GET /mcp/sse` — creates session, returns `StreamingResponse(text/event-stream)`.
-  First SSE event: `endpoint` with `/mcp/messages?session_id=<uuid>`.
-- `POST /mcp/messages?session_id=<id>` — uses `_dispatch_rpc_body`, puts
-  response in session queue, returns 202 Accepted.
-- `SSESessionStore` attached to `app.state.sse_store` at factory time.
-- `POST /mcp` (HTTP transport) now delegates to `_dispatch_rpc_body` too;
-  error code `JSONRPC_PARSE_ERROR` (-32700) → HTTP 400, all others → 200.
+- `from agent_hypervisor.runtime.taint import TaintedValue` imported.
+- In `_handle_tools_call`, every tool result is now wrapped:
+  ```python
+  tainted = TaintedValue(value=text, taint=decision.taint_state)
+  result_dict["_taint"] = tainted.taint.value   # "clean" | "tainted"
+  ```
+- This makes the taint state visible to callers over the JSON-RPC wire.
 
-### Tests: Group 7 (13 tests, all passing)
+### New file: `tests/hypervisor/test_taint_propagation.py`
 
-- 6 `SSESessionStore` unit tests
-- 3 `sse_stream` generator tests (endpoint event, message events, cleanup)
-- 1 route/store registration test
-- 1 unknown-session 404 test
-- 2 queue inspection tests (round-trip + denial-over-stream)
+20 tests across 4 groups:
+- **Group A** (6 tests) — `_taint_context_from_provenance` unit tests:
+  trusted→CLEAN, derived→TAINTED, untrusted→TAINTED, empty→TAINTED,
+  unknown→TAINTED, default→TAINTED.
+- **Group B** (6 tests) — `EnforcementDecision` unit tests:
+  trusted allow→CLEAN, untrusted allow→TAINTED, trusted deny→CLEAN,
+  untrusted deny→TAINTED, `taint_state` accessor, default field is TAINTED.
+- **Group C** (4 tests) — Taint monotonicity:
+  `TaintContext.from_outputs()` on tainted decision, join of clean+tainted,
+  CLEAN alone stays CLEAN, `TaintedValue.map()` preserves taint.
+- **Group D** (4 tests) — HTTP integration:
+  `POST /mcp` with untrusted caller → `"_taint": "tainted"`,
+  trusted caller → `"_taint": "clean"`,
+  denied tool call → taint on decision, default provenance → TAINTED.
 
-**Why queue inspection instead of streaming httpx tests**: httpx ASGI
-transport buffers the entire response body before returning headers, making
-it impossible to test infinite SSE streams via `c.stream()`. The correct
-approach for full SSE streaming integration tests is a real uvicorn server.
+**Key fix**: All test imports use full package path (`from agent_hypervisor.runtime.models import TaintState`)
+rather than the pythonpath-relative shortcut (`from runtime.models import TaintState`).
+The pythonpath shortcut causes the production code and test code to load two separate
+module objects with two separate enum classes, breaking identity comparison
+(`ctx.taint == TaintState.CLEAN` evaluates False even though both show CLEAN).
 
-### Test results: 58 passed (was 45)
+### Test results: 78 passed (was 58)
 
 ---
 
 ## What to Do Next
-
-**Option D (taint propagation)**: Wire `InvocationProvenance.trust_level`
-into `TaintContext`. The `InvocationProvenance` object is passed to
-`enforce()` in `ToolCallEnforcer`. The `TaintContext` lives in
-`runtime/taint.py`. The connection to make:
-- When `enforce()` runs, create a `TaintedValue` for the tool call arguments
-  using the trust level from provenance
-- Return the taint metadata in `EnforcementDecision` so callers can propagate
-  it to downstream operations
-- This closes the loop: LLM-generated tool calls from external sources carry
-  taint all the way through to the provenance firewall
 
 **Option E (SSE integration test via real server)**: Add a pytest fixture
 that starts uvicorn in a daemon thread and tests the full SSE round-trip
 with `urllib.request` + line-by-line iteration of the response stream.
 See `examples/mcp_gateway/main.py` for the pattern — it already does this.
 
+The test should verify:
+1. `GET /mcp/sse` returns `text/event-stream` content type
+2. The first event is `event: endpoint` with `data: /mcp/messages?session_id=<uuid>`
+3. A subsequent `POST /mcp/messages?session_id=<uuid>` with a `tools/list` call
+   causes a `event: message` to appear on the SSE stream with the JSON-RPC response
+4. The session is cleaned up (404) after the SSE connection closes
+
 ---
 
 ## Key Invariants to Preserve
 
-- POST /mcp/messages returns 202 Accepted — the response ALWAYS goes over
-  the SSE stream, never in the HTTP response body
-- `_dispatch_rpc_body` is the single source of truth for JSON-RPC dispatch
-  logic — do not duplicate it in the SSE messages handler
-- `sse_stream` removes the session from the store in a `finally` block —
-  this ensures POST /mcp/messages returns 404 after client disconnects
+- `taint_context` is always set — callers never need to handle `None`
+- Only `"trusted"` trust_level yields CLEAN taint — all other values are TAINTED
+- Taint is monotonic — `TaintContext.from_outputs()` can only increase taint, never decrease
+- The `"_taint"` field in JSON responses is informational; it does not affect enforcement
+- POST /mcp/messages returns 202 Accepted — the response ALWAYS goes over the SSE stream
+- `_dispatch_rpc_body` is the single source of truth for JSON-RPC dispatch logic
 - `_BindSessionRequest` must remain at module level (FastAPI constraint)

--- a/docs/implementation/HANDOFF_NOTE.md
+++ b/docs/implementation/HANDOFF_NOTE.md
@@ -1,79 +1,83 @@
 # Handoff Note
 
 **Date**: 2026-04-09  
-**Session**: Session 4 — Per-session WorldManifest bindings  
+**Session**: Session 5 — MCP SSE transport  
 **Branch**: `claude/continue-implementation-FpgJZ`
 
 ---
 
 ## What Was Just Done
 
-Implemented Option C from the Session 3 handoff: per-session WorldManifest
-bindings. Different sessions (agents/users) can now operate in different worlds
-simultaneously without gateway restart.
+Implemented Option B from the Session 3 handoff: MCP SSE transport.
+The gateway is now compatible with MCP clients that require streaming
+(e.g., Claude Desktop).
 
-### Changes
+### New file: `sse_transport.py`
 
-**`session_world_resolver.py`**
-- `register_session(session_id, manifest_path)` — loads the manifest
-  immediately; raises and does NOT register if loading fails (fail closed)
-- `unregister_session(session_id)` — removes binding, reverts to default;
-  idempotent (returns False if session was not registered)
-- `session_registry()` — returns `{session_id: workflow_id}` snapshot
-- `resolve(session_id)` — now checks `_session_registry` first; falls back to
-  default manifest if not found
+- `SSESessionStore` — registry of `{session_id: asyncio.Queue}` for active
+  SSE connections. Sessions are created on GET /mcp/sse and removed in the
+  `sse_stream` generator's `finally` block on disconnect.
+- `format_sse_event(event, data)` — SSE wire format helper.
+- `sse_stream(session_id, queue, endpoint_url, store)` — async generator:
+  yields endpoint event immediately, then yields message events from the
+  queue, sends `: ping` comments every 25 s, stops on `None` sentinel.
 
-**`mcp_server.py`**
-- `_handle_tools_list` and `_handle_tools_call` now call
-  `state.resolver.resolve(session_id=provenance.session_id)` to get the
-  session's manifest, then `state.renderer_for(manifest)` /
-  `state.enforcer_for(manifest)` to get the right components
-- `renderer_for(manifest)` / `enforcer_for(manifest)` — return cached default
-  components if manifest is the default (common path), build on-the-fly
-  otherwise (lightweight)
-- New endpoints:
-  - `POST /mcp/sessions/{session_id}/bind` — body: `{"manifest_path": "..."}`
-  - `DELETE /mcp/sessions/{session_id}` — revert to default
-  - `GET /mcp/sessions` — list active bindings
-- `_BindSessionRequest` is a module-level Pydantic model (required for FastAPI
-  schema generation — do not move it inside `create_mcp_app`)
+### Changes to `mcp_server.py`
 
-**`tests/hypervisor/test_mcp_gateway.py`** — Group 6: 13 new tests
-- 7 unit tests on `SessionWorldResolver` directly
-- 6 HTTP integration tests using `two_world_client` fixture (default + email worlds)
+- `_dispatch_rpc_body(state, request, session_id_override)` — new shared
+  async helper used by BOTH transports. Parses body, validates JSON-RPC,
+  extracts provenance (with optional `session_id_override` for SSE), dispatches.
+- `GET /mcp/sse` — creates session, returns `StreamingResponse(text/event-stream)`.
+  First SSE event: `endpoint` with `/mcp/messages?session_id=<uuid>`.
+- `POST /mcp/messages?session_id=<id>` — uses `_dispatch_rpc_body`, puts
+  response in session queue, returns 202 Accepted.
+- `SSESessionStore` attached to `app.state.sse_store` at factory time.
+- `POST /mcp` (HTTP transport) now delegates to `_dispatch_rpc_body` too;
+  error code `JSONRPC_PARSE_ERROR` (-32700) → HTTP 400, all others → 200.
 
-### Test results: 45 passed (was 32)
+### Tests: Group 7 (13 tests, all passing)
+
+- 6 `SSESessionStore` unit tests
+- 3 `sse_stream` generator tests (endpoint event, message events, cleanup)
+- 1 route/store registration test
+- 1 unknown-session 404 test
+- 2 queue inspection tests (round-trip + denial-over-stream)
+
+**Why queue inspection instead of streaming httpx tests**: httpx ASGI
+transport buffers the entire response body before returning headers, making
+it impossible to test infinite SSE streams via `c.stream()`. The correct
+approach for full SSE streaming integration tests is a real uvicorn server.
+
+### Test results: 58 passed (was 45)
 
 ---
 
 ## What to Do Next
 
-**Option B (SSE transport)**: Add SSE streaming transport at `/mcp/sse`.
-The MCP 2024-11-05 SSE transport works like this:
-1. Client GETs `/mcp/sse` → server sends `endpoint` event with a POST URL
-   (e.g., `/mcp/messages?session_id=<uuid>`)
-2. Client POSTs JSON-RPC requests to that URL
-3. Server sends responses back over the open SSE stream
+**Option D (taint propagation)**: Wire `InvocationProvenance.trust_level`
+into `TaintContext`. The `InvocationProvenance` object is passed to
+`enforce()` in `ToolCallEnforcer`. The `TaintContext` lives in
+`runtime/taint.py`. The connection to make:
+- When `enforce()` runs, create a `TaintedValue` for the tool call arguments
+  using the trust level from provenance
+- Return the taint metadata in `EnforcementDecision` so callers can propagate
+  it to downstream operations
+- This closes the loop: LLM-generated tool calls from external sources carry
+  taint all the way through to the provenance firewall
 
-This requires:
-- An asyncio `Queue` per session for routing SSE responses
-- A `GET /mcp/sse` endpoint that opens the stream and sends the endpoint event
-- A `POST /mcp/messages` endpoint that routes responses back to the queue
-- `sse-starlette` package (or manual `StreamingResponse`) — add to
-  `pyproject.toml` optional deps
-
-**Option D (taint propagation)**: Wire `InvocationProvenance.trust_level` into
-`TaintContext` so values from external sources carry taint that is visible to
-the provenance firewall. The hook is already in place in the enforcer; the
-runtime taint layer needs to be imported and updated from the gateway.
+**Option E (SSE integration test via real server)**: Add a pytest fixture
+that starts uvicorn in a daemon thread and tests the full SSE round-trip
+with `urllib.request` + line-by-line iteration of the response stream.
+See `examples/mcp_gateway/main.py` for the pattern — it already does this.
 
 ---
 
 ## Key Invariants to Preserve
 
-- `enforce()` must never raise
-- Undeclared tools stay absent from the surface (not just denied)
-- `register_session()` must fail closed — if the manifest cannot be loaded,
-  the session must NOT be registered (no silent fallback to default)
+- POST /mcp/messages returns 202 Accepted — the response ALWAYS goes over
+  the SSE stream, never in the HTTP response body
+- `_dispatch_rpc_body` is the single source of truth for JSON-RPC dispatch
+  logic — do not duplicate it in the SSE messages handler
+- `sse_stream` removes the session from the store in a `finally` block —
+  this ensures POST /mcp/messages returns 404 after client disconnects
 - `_BindSessionRequest` must remain at module level (FastAPI constraint)
-- `use_default_policy=False` default for `create_mcp_app` — unchanged

--- a/docs/implementation/HANDOFF_NOTE.md
+++ b/docs/implementation/HANDOFF_NOTE.md
@@ -1,89 +1,88 @@
 # Handoff Note
 
 **Date**: 2026-04-09  
-**Session**: Session 6 — Taint propagation  
+**Session**: Session 7 — SSE integration tests (Option E)  
 **Branch**: `claude/continue-implementation-FpgJZ`
 
 ---
 
 ## What Was Just Done
 
-Implemented Option D from the Session 5 handoff: taint propagation from
-`InvocationProvenance.trust_level` through `EnforcementDecision` into tool results.
+Implemented Option E from the Session 6 handoff: full SSE streaming round-trip
+tests against a real uvicorn server.
 
-### Changes to `tool_call_enforcer.py`
+### New test class: `TestSSEIntegration` (Group 8)
 
-- `_taint_context_from_provenance(prov)` — new module-level helper.
-  Only `trust_level="trusted"` produces `TaintContext.clean()`.
-  All other values (including `"derived"`, `"untrusted"`, and unknown/empty)
-  produce `TaintContext(TaintState.TAINTED)`. Conservative by design.
+5 tests in `tests/hypervisor/test_mcp_gateway.py`, all using a real uvicorn
+server in a daemon thread rather than httpx ASGI transport (which cannot test
+infinite SSE streams).
 
-- `EnforcementDecision.taint_context: TaintContext` — new field.
-  Default is `TaintContext(TaintState.TAINTED)` (fail tainted, not fail open).
-  Every branch of `enforce()` passes `taint_context=taint_ctx`.
+**`live_server` fixture** (`scope="class"`):
+- Starts uvicorn with a minimal read_file world manifest
+- Polls `/mcp/health` until ready (max 5 s)
+- Yields `(host, port, base_url)` to all tests in the class
+- Sets `server.should_exit = True` on teardown (daemon thread, clean shutdown)
 
-- `EnforcementDecision.taint_state` — convenience property:
-  `return self.taint_context.taint`. Callers can use this directly.
+**Static helpers**:
+- `_collect_sse_events(host, port, path, n_events, timeout)` — opens SSE connection
+  in a daemon thread using `http.client`, reads line-by-line, parses
+  `event:` / `data:` lines into dicts, forwards parsed events via `queue.Queue`
+- `_post_json(host, port, path, body)` — `http.client` POST, returns `(status_code, dict)`
 
-### Changes to `mcp_server.py`
+**Tests**:
 
-- `from agent_hypervisor.runtime.taint import TaintedValue` imported.
-- In `_handle_tools_call`, every tool result is now wrapped:
-  ```python
-  tainted = TaintedValue(value=text, taint=decision.taint_state)
-  result_dict["_taint"] = tainted.taint.value   # "clean" | "tainted"
-  ```
-- This makes the taint state visible to callers over the JSON-RPC wire.
+1. `test_sse_content_type` — verifies `GET /mcp/sse` returns `Content-Type: text/event-stream`
+2. `test_sse_first_event_is_endpoint` — first SSE event is `event: endpoint` with `data: /mcp/messages?session_id=<uuid>`
+3. `test_sse_endpoint_url_has_uuid_session_id` — session_id in endpoint data matches UUID regex
+4. `test_sse_full_round_trip` — full protocol sequence:
+   - Opens SSE in a direct streaming reader thread (emits events immediately)
+   - Main thread reads the `endpoint` event → extracts `messages_path`
+   - Main thread POSTs `tools/list` to `messages_path` → 202 Accepted
+   - Main thread reads `message` event → verifies JSON-RPC result contains `read_file`
+5. `test_sse_session_removed_after_disconnect` — opens SSE, reads endpoint, closes abruptly, waits 0.3 s, verifies POST returns 404
 
-### New file: `tests/hypervisor/test_taint_propagation.py`
+**Key design decision — direct streaming reader thread**:
+The initial round-trip implementation used `_collect_sse_events(n_events=2)` in a
+wrapper thread that forwarded events to the main thread only after collecting both.
+This deadlocked: the reader waited for event 2, but the main thread needed event 1
+(endpoint) first before it could POST to trigger event 2.
 
-20 tests across 4 groups:
-- **Group A** (6 tests) — `_taint_context_from_provenance` unit tests:
-  trusted→CLEAN, derived→TAINTED, untrusted→TAINTED, empty→TAINTED,
-  unknown→TAINTED, default→TAINTED.
-- **Group B** (6 tests) — `EnforcementDecision` unit tests:
-  trusted allow→CLEAN, untrusted allow→TAINTED, trusted deny→CLEAN,
-  untrusted deny→TAINTED, `taint_state` accessor, default field is TAINTED.
-- **Group C** (4 tests) — Taint monotonicity:
-  `TaintContext.from_outputs()` on tainted decision, join of clean+tainted,
-  CLEAN alone stays CLEAN, `TaintedValue.map()` preserves taint.
-- **Group D** (4 tests) — HTTP integration:
-  `POST /mcp` with untrusted caller → `"_taint": "tainted"`,
-  trusted caller → `"_taint": "clean"`,
-  denied tool call → taint on decision, default provenance → TAINTED.
+Fixed by using a direct `_streaming_reader` function (defined inline) that emits
+each parsed event to `queue.Queue` immediately after parsing, without batching.
+The main thread then interleaves: get event 1 → POST → get event 2.
 
-**Key fix**: All test imports use full package path (`from agent_hypervisor.runtime.models import TaintState`)
-rather than the pythonpath-relative shortcut (`from runtime.models import TaintState`).
-The pythonpath shortcut causes the production code and test code to load two separate
-module objects with two separate enum classes, breaking identity comparison
-(`ctx.taint == TaintState.CLEAN` evaluates False even though both show CLEAN).
-
-### Test results: 78 passed (was 58)
+### Test results: 83 passed (was 78)
 
 ---
 
 ## What to Do Next
 
-**Option E (SSE integration test via real server)**: Add a pytest fixture
-that starts uvicorn in a daemon thread and tests the full SSE round-trip
-with `urllib.request` + line-by-line iteration of the response stream.
-See `examples/mcp_gateway/main.py` for the pattern — it already does this.
+All planned implementation options (C, B/SSE, D, E) are complete.
 
-The test should verify:
-1. `GET /mcp/sse` returns `text/event-stream` content type
-2. The first event is `event: endpoint` with `data: /mcp/messages?session_id=<uuid>`
-3. A subsequent `POST /mcp/messages?session_id=<uuid>` with a `tools/list` call
-   causes a `event: message` to appear on the SSE stream with the JSON-RPC response
-4. The session is cleaned up (404) after the SSE connection closes
+Remaining work is either production-hardening or new feature areas:
+
+- **Auth / TLS**: The gateway currently accepts any request. Adding bearer token
+  auth or mTLS would be needed before production deployment.
+
+- **Rate limiting / budget enforcement**: The economic layer (`src/agent_hypervisor/economic/`)
+  exists but is not wired into the MCP gateway. Integrating budget enforcement at
+  the gateway layer would let manifests declare per-tool cost limits.
+
+- **Streaming tool results**: Currently, tool results are returned as a single JSON
+  blob. Long-running tools (e.g., code execution) could benefit from streaming
+  partial results back as additional SSE events.
 
 ---
 
 ## Key Invariants to Preserve
 
-- `taint_context` is always set — callers never need to handle `None`
-- Only `"trusted"` trust_level yields CLEAN taint — all other values are TAINTED
-- Taint is monotonic — `TaintContext.from_outputs()` can only increase taint, never decrease
-- The `"_taint"` field in JSON responses is informational; it does not affect enforcement
-- POST /mcp/messages returns 202 Accepted — the response ALWAYS goes over the SSE stream
-- `_dispatch_rpc_body` is the single source of truth for JSON-RPC dispatch logic
-- `_BindSessionRequest` must remain at module level (FastAPI constraint)
+- `live_server` fixture must be `scope="class"` — one server per class, shared
+  across tests (not per-test, which would be too slow)
+- The streaming reader thread must emit events immediately (not batch by n_events)
+  to avoid the deadlock in the round-trip test
+- `http.client.HTTPConnection.readline()` is the correct primitive for SSE — it
+  reads one line at a time without buffering the entire response
+- Daemon threads are safe here: they naturally die when the test process exits
+- 0.3 s sleep in `test_sse_session_removed_after_disconnect` gives uvicorn time to
+  run the `finally` block in `sse_stream` after TCP close — this is a real timing
+  dependency but 0.3 s is conservative enough for any CI environment

--- a/docs/implementation/IMPLEMENTATION_STATUS.md
+++ b/docs/implementation/IMPLEMENTATION_STATUS.md
@@ -1,16 +1,15 @@
 # Implementation Status
 
 **Last updated**: 2026-04-09  
-**Session**: Session 6 — Taint propagation  
+**Session**: Session 7 — SSE integration tests (Option E)  
 **Branch**: `claude/continue-implementation-FpgJZ`
 
 ---
 
 ## Session Summary
 
-Session 6: Taint propagation from `InvocationProvenance.trust_level` through
-`EnforcementDecision` and into tool results (Option D from Session 5 handoff).
-78 tests passing (was 58).
+Session 7: Full SSE streaming round-trip tests against a real uvicorn server
+(Option E from Session 6 handoff). 83 tests passing (was 78).
 
 ---
 
@@ -78,10 +77,10 @@ Session 6: Taint propagation from `InvocationProvenance.trust_level` through
 ## Test Results
 
 ```
-78 passed
+83 passed
 ```
 
-All 78 tests pass. Groups:
+All 83 tests pass. Groups:
 - `TestToolSurfaceRenderer` (7 tests) — tools/list invariants
 - `TestToolCallEnforcer` (8 tests) — enforcement invariants
 - `TestMCPGatewayHTTP` (6 tests) — HTTP integration
@@ -90,6 +89,7 @@ All 78 tests pass. Groups:
 - Group 6 per-session bindings (13 tests) — session registry
 - Group 7 SSE transport (13 tests) — SSE session store, stream, HTTP endpoints
 - `TestTaintPropagation` (20 tests) — taint from provenance through decision to result
+- `TestSSEIntegration` (5 tests) — full SSE streaming round-trip vs. real uvicorn
 
 ---
 
@@ -114,6 +114,23 @@ All 78 tests pass. Groups:
 - [x] `scripts/run_mcp_gateway.py` — single-command launcher with CLI flags
 
 **Test results**: 32 passed (was 26).
+
+---
+
+### Session 7 — SSE integration tests (Option E)
+
+- [x] `TestSSEIntegration` (Group 8, 5 tests) in `test_mcp_gateway.py`
+- [x] `live_server` fixture: starts real uvicorn in daemon thread, polls `/mcp/health` for readiness, scope=class (one server per class)
+- [x] `_collect_sse_events` static helper: `http.client` + daemon thread + `queue.Queue`, reads line-by-line, parses SSE events
+- [x] `_post_json` static helper: `http.client` POST to live server
+- [x] `test_sse_content_type` — verifies `text/event-stream` header
+- [x] `test_sse_first_event_is_endpoint` — first event is `endpoint` with session URL
+- [x] `test_sse_endpoint_url_has_uuid_session_id` — session_id matches UUID pattern
+- [x] `test_sse_full_round_trip` — open SSE → read endpoint → POST → read message event (uses direct streaming reader thread to avoid deadlock)
+- [x] `test_sse_session_removed_after_disconnect` — after abrupt close, POST returns 404
+- [x] Fixed deadlock: round-trip test uses a direct reader thread that emits events into `queue.Queue` immediately (not after batching n events)
+
+**Test results**: 83 passed (was 78).
 
 ---
 
@@ -162,7 +179,6 @@ All 78 tests pass. Groups:
 
 ## Pending / Not Yet Done
 
-- [ ] SSE integration test via real uvicorn server (Option E) — full streaming round-trip
 - [ ] Auth / TLS — not in scope for this phase
 
 ---
@@ -175,9 +191,14 @@ None.
 
 ## Next Recommended Step
 
-**Option E (SSE integration test via real server)**: The SSE transport is
-implemented and unit-tested, but the full streaming round-trip (open SSE stream
-→ POST request → read response event) can only be tested against a real
-uvicorn server. Add a pytest fixture that starts uvicorn in a daemon thread and
-tests the full SSE round-trip with `urllib.request` + line-by-line iteration
-of the response stream, following the pattern in `examples/mcp_gateway/main.py`.
+All planned options (C, B/SSE, D, E) are complete. The MCP gateway now has:
+- Manifest-driven tool surface rendering and enforcement
+- Per-session WorldManifest bindings
+- SSE transport (GET /mcp/sse + POST /mcp/messages)
+- Taint propagation from InvocationProvenance through EnforcementDecision
+- Full SSE streaming integration tests via real uvicorn
+
+Possible further work:
+- Auth / TLS hardening for production use
+- Rate limiting or budget enforcement at the gateway layer
+- Streaming tool results (chunked SSE events for long-running tools)

--- a/docs/implementation/IMPLEMENTATION_STATUS.md
+++ b/docs/implementation/IMPLEMENTATION_STATUS.md
@@ -1,15 +1,16 @@
 # Implementation Status
 
 **Last updated**: 2026-04-09  
-**Session**: Session 3 — End-to-end demo  
-**Branch**: `claude/continue-implementation-TsEYr`
+**Session**: Session 4 — Per-session WorldManifest bindings  
+**Branch**: `claude/continue-implementation-FpgJZ`
 
 ---
 
 ## Session Summary
 
-First implementation session. Completed all six phases in one pass.
-The MCP Gateway is now functional, tested, and committed.
+Session 4: Per-session manifest bindings (Option C from Session 3 handoff).
+Different sessions now operate in different worlds simultaneously.
+45 tests passing (was 32).
 
 ---
 
@@ -104,10 +105,25 @@ All 26 tests pass. Groups:
 
 ---
 
+### Session 4 — Per-session WorldManifest bindings
+
+- [x] `SessionWorldResolver.register_session(session_id, manifest_path)` — loads manifest immediately, fails closed on error
+- [x] `SessionWorldResolver.unregister_session(session_id)` — idempotent revert to default
+- [x] `SessionWorldResolver.session_registry()` — snapshot of active bindings
+- [x] `tools/list` and `tools/call` resolve per-session manifest via `provenance.session_id`
+- [x] Default renderer/enforcer cached; per-session ones built on-the-fly (lightweight)
+- [x] `POST /mcp/sessions/{session_id}/bind` — bind a session to a manifest path
+- [x] `DELETE /mcp/sessions/{session_id}` — unbind a session
+- [x] `GET /mcp/sessions` — list all active bindings
+- [x] Group 6: 13 new tests (7 unit + 6 HTTP integration) — all passing
+
+**Test results**: 45 passed (was 32).
+
+---
+
 ## Pending / Not Yet Done
 
 - [ ] Full SSE transport (streaming) — out of scope for Phase 1
-- [ ] Per-session manifest selection — architecture ready, not implemented
 - [ ] Full taint propagation integration — hooks in place, not wired to runtime taint
 - [ ] Auth / TLS — not in scope for this phase
 
@@ -121,14 +137,13 @@ None.
 
 ## Next Recommended Step
 
-**Option A (done)**: `examples/mcp_gateway/main.py` — complete, runnable, all
-5 scenarios passing.
+**Option B (SSE transport)**: Add SSE streaming transport to `/mcp/sse` so the
+gateway is compatible with MCP clients that require streaming (e.g., Claude
+Desktop). FastAPI supports SSE via `StreamingResponse`. The HTTP POST endpoint
+at `/mcp` stays unchanged; SSE is additive. This is the last major
+protocol-level gap.
 
-**Option B (SSE transport)**: Add SSE streaming transport so the gateway is
-compatible with MCP clients that require streaming. FastAPI supports SSE via
-`StreamingResponse` and `EventSourceResponse` (sse-starlette). The HTTP POST
-endpoint remains as-is; SSE is additive.
-
-**Option C (per-session manifests)**: `SessionWorldResolver.resolve(session_id, context)`
-already accepts a `session_id` argument. Wire it to a session registry (dict or
-Redis) so different sessions can be bound to different WorldManifests at runtime.
+**Option D (taint propagation)**: Wire `InvocationProvenance.trust_level` and
+`session_id` into the runtime `TaintContext` so values from untrusted external
+sessions carry taint that the provenance firewall can inspect. This closes the
+loop between the MCP gateway and the runtime invariants layer.

--- a/docs/implementation/IMPLEMENTATION_STATUS.md
+++ b/docs/implementation/IMPLEMENTATION_STATUS.md
@@ -1,16 +1,16 @@
 # Implementation Status
 
 **Last updated**: 2026-04-09  
-**Session**: Session 4 — Per-session WorldManifest bindings  
+**Session**: Session 5 — MCP SSE transport  
 **Branch**: `claude/continue-implementation-FpgJZ`
 
 ---
 
 ## Session Summary
 
-Session 4: Per-session manifest bindings (Option C from Session 3 handoff).
-Different sessions now operate in different worlds simultaneously.
-45 tests passing (was 32).
+Session 5: MCP SSE transport (Option B from Session 3 handoff).
+GET /mcp/sse + POST /mcp/messages enable streaming-compatible MCP clients.
+58 tests passing (was 45).
 
 ---
 
@@ -105,6 +105,20 @@ All 26 tests pass. Groups:
 
 ---
 
+### Session 5 — MCP SSE transport
+
+- [x] `sse_transport.py` — `SSESessionStore` (UUID→Queue registry), `format_sse_event`, `sse_stream` async generator (heartbeat/keepalive, sentinel stop, cleanup in finally)
+- [x] `GET /mcp/sse` — creates session in store, returns `StreamingResponse(text/event-stream)`, first event is `endpoint` with `/mcp/messages?session_id=<uuid>`
+- [x] `POST /mcp/messages` — looks up session queue, dispatches JSON-RPC, puts response in queue, returns 202 Accepted
+- [x] `_dispatch_rpc_body()` extracted as shared async helper (used by both transports); `session_id_override` propagates SSE session into provenance for per-session manifest resolution
+- [x] `SSESessionStore` exported from `mcp_gateway.__init__`
+- [x] Group 7: 13 new tests (6 SSESessionStore unit, 3 sse_stream generator, 4 HTTP endpoint) — all passing
+- Note: httpx ASGI transport collects full response body — can't test infinite streams via `c.stream()`. HTTP tests use direct queue inspection instead.
+
+**Test results**: 58 passed (was 45).
+
+---
+
 ### Session 4 — Per-session WorldManifest bindings
 
 - [x] `SessionWorldResolver.register_session(session_id, manifest_path)` — loads manifest immediately, fails closed on error
@@ -123,7 +137,6 @@ All 26 tests pass. Groups:
 
 ## Pending / Not Yet Done
 
-- [ ] Full SSE transport (streaming) — out of scope for Phase 1
 - [ ] Full taint propagation integration — hooks in place, not wired to runtime taint
 - [ ] Auth / TLS — not in scope for this phase
 
@@ -137,13 +150,15 @@ None.
 
 ## Next Recommended Step
 
-**Option B (SSE transport)**: Add SSE streaming transport to `/mcp/sse` so the
-gateway is compatible with MCP clients that require streaming (e.g., Claude
-Desktop). FastAPI supports SSE via `StreamingResponse`. The HTTP POST endpoint
-at `/mcp` stays unchanged; SSE is additive. This is the last major
-protocol-level gap.
-
 **Option D (taint propagation)**: Wire `InvocationProvenance.trust_level` and
-`session_id` into the runtime `TaintContext` so values from untrusted external
-sessions carry taint that the provenance firewall can inspect. This closes the
-loop between the MCP gateway and the runtime invariants layer.
+`session_id` into the runtime `TaintContext` so values that arrive through the
+MCP gateway carry taint that is visible to the provenance firewall. The hook is
+already in place in the enforcer; the runtime taint layer needs to be imported
+and updated from the gateway.
+
+**Option E (SSE integration test via real server)**: The SSE transport is
+implemented and unit-tested, but the full streaming round-trip (open SSE stream
+→ POST request → read response event) can only be tested against a real
+uvicorn server. Add a test fixture that starts uvicorn in a thread and uses
+`requests` + `sseclient` (or stdlib `urllib.request`) to verify the full
+round-trip, similar to `examples/mcp_gateway/main.py`.

--- a/docs/implementation/IMPLEMENTATION_STATUS.md
+++ b/docs/implementation/IMPLEMENTATION_STATUS.md
@@ -1,16 +1,16 @@
 # Implementation Status
 
 **Last updated**: 2026-04-09  
-**Session**: Session 5 — MCP SSE transport  
+**Session**: Session 6 — Taint propagation  
 **Branch**: `claude/continue-implementation-FpgJZ`
 
 ---
 
 ## Session Summary
 
-Session 5: MCP SSE transport (Option B from Session 3 handoff).
-GET /mcp/sse + POST /mcp/messages enable streaming-compatible MCP clients.
-58 tests passing (was 45).
+Session 6: Taint propagation from `InvocationProvenance.trust_level` through
+`EnforcementDecision` and into tool results (Option D from Session 5 handoff).
+78 tests passing (was 58).
 
 ---
 
@@ -56,7 +56,15 @@ GET /mcp/sse + POST /mcp/messages enable streaming-compatible MCP clients.
 - [x] `InvocationProvenance` dataclass captures source, session_id, trust_level, timestamp
 - [x] `_extract_provenance()` reads from request headers and `_meta` params
 - [x] Provenance attached to every `EnforcementDecision`
-- [x] Extension point: `trust_level` ready for future taint-aware enforcement
+- [x] `trust_level` wired to `TaintContext` — taint propagated through full enforcement pipeline
+
+### Phase 7 — Taint Propagation
+- [x] `_taint_context_from_provenance()` — `"trusted"` → CLEAN, all other trust levels → TAINTED
+- [x] `EnforcementDecision.taint_context: TaintContext` — always set; callers propagate into `TaintedValue`s
+- [x] `EnforcementDecision.taint_state` — convenience accessor for `taint_context.taint`
+- [x] `mcp_server.py` — tool results wrapped in `TaintedValue`, taint state emitted as `"_taint"` field in JSON response
+- [x] `TaintContext.from_outputs()` — downstream contexts correctly inherit taint from gateway results
+- [x] 20 new tests in `tests/hypervisor/test_taint_propagation.py` — all passing
 
 ### Phase 6 — Docs, Tests, Demo
 - [x] 26 tests across 4 groups: all passing
@@ -70,14 +78,18 @@ GET /mcp/sse + POST /mcp/messages enable streaming-compatible MCP clients.
 ## Test Results
 
 ```
-26 passed in 0.40s
+78 passed
 ```
 
-All 26 tests pass. Groups:
+All 78 tests pass. Groups:
 - `TestToolSurfaceRenderer` (7 tests) — tools/list invariants
 - `TestToolCallEnforcer` (8 tests) — enforcement invariants
 - `TestMCPGatewayHTTP` (6 tests) — HTTP integration
 - `TestSessionWorldResolver` (5 tests) — manifest binding
+- Group 5 PolicyEngine (6 tests) — policy wiring
+- Group 6 per-session bindings (13 tests) — session registry
+- Group 7 SSE transport (13 tests) — SSE session store, stream, HTTP endpoints
+- `TestTaintPropagation` (20 tests) — taint from provenance through decision to result
 
 ---
 
@@ -102,6 +114,19 @@ All 26 tests pass. Groups:
 - [x] `scripts/run_mcp_gateway.py` — single-command launcher with CLI flags
 
 **Test results**: 32 passed (was 26).
+
+---
+
+### Session 6 — Taint propagation
+
+- [x] `_taint_context_from_provenance(prov)` — maps `trust_level` to `TaintContext`; only `"trusted"` yields CLEAN
+- [x] `EnforcementDecision.taint_context` — `TaintContext` field always set; default is TAINTED
+- [x] `EnforcementDecision.taint_state` — convenience accessor for callers
+- [x] `mcp_server.py` — `TaintedValue(value=text, taint=decision.taint_state)` wraps every tool result; `"_taint": "clean"|"tainted"` added to JSON response
+- [x] `test_taint_propagation.py` — 20 tests: helper unit, decision unit, monotonicity, HTTP integration
+- [x] Fixed enum double-import identity bug: all taint tests import via `agent_hypervisor.runtime.*` (full package path, not `pythonpath`-relative `runtime.*`)
+
+**Test results**: 78 passed (was 58).
 
 ---
 
@@ -137,7 +162,7 @@ All 26 tests pass. Groups:
 
 ## Pending / Not Yet Done
 
-- [ ] Full taint propagation integration — hooks in place, not wired to runtime taint
+- [ ] SSE integration test via real uvicorn server (Option E) — full streaming round-trip
 - [ ] Auth / TLS — not in scope for this phase
 
 ---
@@ -150,15 +175,9 @@ None.
 
 ## Next Recommended Step
 
-**Option D (taint propagation)**: Wire `InvocationProvenance.trust_level` and
-`session_id` into the runtime `TaintContext` so values that arrive through the
-MCP gateway carry taint that is visible to the provenance firewall. The hook is
-already in place in the enforcer; the runtime taint layer needs to be imported
-and updated from the gateway.
-
 **Option E (SSE integration test via real server)**: The SSE transport is
 implemented and unit-tested, but the full streaming round-trip (open SSE stream
 → POST request → read response event) can only be tested against a real
-uvicorn server. Add a test fixture that starts uvicorn in a thread and uses
-`requests` + `sseclient` (or stdlib `urllib.request`) to verify the full
-round-trip, similar to `examples/mcp_gateway/main.py`.
+uvicorn server. Add a pytest fixture that starts uvicorn in a daemon thread and
+tests the full SSE round-trip with `urllib.request` + line-by-line iteration
+of the response stream, following the pattern in `examples/mcp_gateway/main.py`.

--- a/src/agent_hypervisor/hypervisor/mcp_gateway/__init__.py
+++ b/src/agent_hypervisor/hypervisor/mcp_gateway/__init__.py
@@ -8,6 +8,7 @@ Public API:
     SessionWorldResolver       — session → WorldManifest binding
     EnforcementDecision        — result of enforcing a tool call
     InvocationProvenance       — provenance metadata for a tool invocation
+    SSESessionStore            — registry of active SSE sessions
 
 Usage::
 
@@ -20,6 +21,7 @@ from .mcp_server import create_mcp_app, MCPGatewayState
 from .tool_surface_renderer import ToolSurfaceRenderer
 from .tool_call_enforcer import ToolCallEnforcer, EnforcementDecision, InvocationProvenance
 from .session_world_resolver import SessionWorldResolver
+from .sse_transport import SSESessionStore
 from .protocol import MCPTool, MCPToolResult, JSONRPCRequest, JSONRPCResponse
 
 __all__ = [
@@ -30,6 +32,7 @@ __all__ = [
     "EnforcementDecision",
     "InvocationProvenance",
     "SessionWorldResolver",
+    "SSESessionStore",
     "MCPTool",
     "MCPToolResult",
     "JSONRPCRequest",

--- a/src/agent_hypervisor/hypervisor/mcp_gateway/mcp_server.py
+++ b/src/agent_hypervisor/hypervisor/mcp_gateway/mcp_server.py
@@ -61,6 +61,7 @@ from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse, StreamingResponse
 from pydantic import BaseModel
 
+from agent_hypervisor.runtime.taint import TaintedValue
 from .sse_transport import SSESessionStore, sse_stream
 
 
@@ -604,24 +605,34 @@ def _handle_tools_call(
     try:
         raw_result = tool_def.adapter(arguments)
     except Exception as exc:
-        # Adapter error — protocol-level success, tool-level error
+        # Adapter error — protocol-level success, tool-level error.
+        # The result is still tainted by the invocation provenance.
+        tainted = TaintedValue(value=f"Tool error: {exc}", taint=decision.taint_state)
         result_obj = MCPToolResult(
-            content=[MCPContent(type="text", text=f"Tool error: {exc}")],
+            content=[MCPContent(type="text", text=tainted.value)],
             isError=True,
         )
         return make_result(request_id, result_obj.model_dump())
 
-    # Format result
+    # Format result, wrapping it in TaintedValue to carry provenance taint.
+    # taint_state reflects the trust level of the caller:
+    #   CLEAN  — caller is trusted; result may be used in external operations
+    #   TAINTED — caller is untrusted/derived; result must not flow unchecked
     if isinstance(raw_result, str):
         text = raw_result
     else:
         text = json.dumps(raw_result, default=str)
 
+    tainted = TaintedValue(value=text, taint=decision.taint_state)
+
     result_obj = MCPToolResult(
-        content=[MCPContent(type="text", text=text)],
+        content=[MCPContent(type="text", text=tainted.value)],
         isError=False,
     )
-    return make_result(request_id, result_obj.model_dump())
+    # Include taint metadata in the MCP result so callers can inspect it.
+    result_dict = result_obj.model_dump()
+    result_dict["_taint"] = tainted.taint.value  # "clean" | "tainted"
+    return make_result(request_id, result_dict)
 
 
 # ---------------------------------------------------------------------------

--- a/src/agent_hypervisor/hypervisor/mcp_gateway/mcp_server.py
+++ b/src/agent_hypervisor/hypervisor/mcp_gateway/mcp_server.py
@@ -4,7 +4,9 @@ mcp_server.py — Agent Hypervisor MCP Gateway.
 Implements a JSON-RPC 2.0 server that speaks the Model Context Protocol.
 
 Endpoints:
-  POST /mcp                            — JSON-RPC 2.0 dispatcher
+  POST /mcp                            — JSON-RPC 2.0 dispatcher (HTTP transport)
+  GET  /mcp/sse                        — MCP SSE transport: opens stream, sends endpoint event
+  POST /mcp/messages                   — MCP SSE transport: receives requests, routes over SSE
   GET  /mcp/health                     — health check + world summary
   POST /mcp/reload                     — hot-reload default manifest from disk
   POST /mcp/sessions/{session_id}/bind — bind a session to a specific manifest
@@ -16,18 +18,13 @@ MCP methods handled:
   tools/list         — returns only manifest-declared tools (world rendering)
   tools/call         — deterministic enforcement, then adapter dispatch
 
-Request flow:
-  Client → POST /mcp → dispatch_jsonrpc()
-    ├── method=tools/list
-    │     → SessionWorldResolver.resolve(session_id)  ← per-session manifest
-    │     → ToolSurfaceRenderer.render()
-    │     → [MCPTool, ...]  (only manifest-visible tools for this session)
-    │
-    └── method=tools/call
-          → SessionWorldResolver.resolve(session_id)  ← per-session manifest
-          → ToolCallEnforcer.enforce()  (manifest check → policy → allow/deny)
-          → ToolRegistry.get_tool().adapter(args)  (only on allow)
-          → MCPToolResult
+HTTP transport (POST /mcp):
+  Client → POST /mcp → dispatch_jsonrpc() → JSONResponse
+
+SSE transport (GET /mcp/sse + POST /mcp/messages):
+  Client → GET /mcp/sse   → server sends endpoint event: "/mcp/messages?session_id=<uuid>"
+        → POST /mcp/messages?session_id=<uuid>  → server returns 202, pushes response to SSE stream
+        → SSE stream delivers "message" event with the JSON-RPC response
 
 Per-session manifests:
   Sessions without an explicit binding use the gateway-level default manifest.
@@ -61,8 +58,10 @@ _DEFAULT_POLICY_PATH: Path = (
 )
 
 from fastapi import FastAPI, Request
-from fastapi.responses import JSONResponse
+from fastapi.responses import JSONResponse, StreamingResponse
 from pydantic import BaseModel
+
+from .sse_transport import SSESessionStore, sse_stream
 
 
 class _BindSessionRequest(BaseModel):
@@ -227,6 +226,8 @@ def create_mcp_app(
 
     # Attach state early for sync test access
     app.state.gw = state
+    sse_store = SSESessionStore()
+    app.state.sse_store = sse_store
 
     # ------------------------------------------------------------------
     # JSON-RPC 2.0 dispatcher
@@ -235,57 +236,23 @@ def create_mcp_app(
     @app.post("/mcp")
     async def dispatch_jsonrpc(request: Request) -> JSONResponse:
         """
-        Main JSON-RPC 2.0 dispatcher.
+        Main JSON-RPC 2.0 dispatcher (HTTP transport).
 
         Parses the request body as a JSON-RPC 2.0 request and dispatches
         to the appropriate handler. Returns a JSON-RPC 2.0 response.
         """
         gw: MCPGatewayState = app.state.gw
-
-        # Parse body
-        try:
-            body = await request.json()
-        except Exception:
-            resp = make_error(None, JSONRPC_PARSE_ERROR, "Parse error: body is not valid JSON")
-            return JSONResponse(content=resp.model_dump(exclude_none=True), status_code=400)
-
-        # Validate JSON-RPC envelope
-        try:
-            rpc = JSONRPCRequest.model_validate(body)
-        except Exception as exc:
-            resp = make_error(
-                body.get("id") if isinstance(body, dict) else None,
-                JSONRPC_PARSE_ERROR,
-                f"Invalid JSON-RPC request: {exc}",
-            )
-            return JSONResponse(content=resp.model_dump(exclude_none=True), status_code=400)
-
-        # Extract provenance metadata from request headers / params
-        provenance = _extract_provenance(request, rpc)
-
-        # Dispatch
-        try:
-            if rpc.method == "initialize":
-                result = _handle_initialize(gw, rpc.params or {})
-                resp = make_result(rpc.id, result)
-
-            elif rpc.method == "tools/list":
-                result = _handle_tools_list(gw, rpc.params or {}, provenance)
-                resp = make_result(rpc.id, result)
-
-            elif rpc.method == "tools/call":
-                resp = _handle_tools_call(gw, rpc.id, rpc.params or {}, provenance)
-
-            else:
-                resp = make_error(
-                    rpc.id,
-                    JSONRPC_METHOD_NOT_FOUND,
-                    f"Method not found: {rpc.method!r}",
-                )
-        except Exception as exc:
-            resp = make_error(rpc.id, JSONRPC_INTERNAL_ERROR, f"Internal error: {exc}")
-
-        return JSONResponse(content=resp.model_dump(exclude_none=True))
+        resp = await _dispatch_rpc_body(gw, request)
+        # Return 400 only for transport-level parse failures; all JSON-RPC
+        # application errors (tool denied, method not found, etc.) are HTTP 200.
+        is_parse_error = (
+            resp.error is not None
+            and resp.error.code == JSONRPC_PARSE_ERROR
+        )
+        return JSONResponse(
+            content=resp.model_dump(exclude_none=True),
+            status_code=400 if is_parse_error else 200,
+        )
 
     # ------------------------------------------------------------------
     # Health check
@@ -308,6 +275,70 @@ def create_mcp_app(
             },
             "visible_tools": visible_tools,
         })
+
+    # ------------------------------------------------------------------
+    # SSE transport  (GET /mcp/sse  +  POST /mcp/messages)
+    # ------------------------------------------------------------------
+
+    @app.get("/mcp/sse")
+    async def sse_endpoint(request: Request) -> StreamingResponse:
+        """
+        MCP SSE transport — open a streaming connection.
+
+        Protocol (MCP 2024-11-05 SSE transport):
+          1. Server assigns a session UUID and returns a StreamingResponse
+             with Content-Type: text/event-stream.
+          2. The first event is 'endpoint'; its data is the URL the client
+             must use to POST JSON-RPC requests, e.g.:
+               /mcp/messages?session_id=<uuid>
+          3. Subsequent 'message' events carry JSON-RPC responses.
+          4. A keep-alive comment is sent every ~25 s to prevent proxy
+             timeouts.
+
+        The session UUID is distinct from a manifest-binding session. The
+        client may pass it as X-MCP-Session-Id in POST /mcp/messages headers
+        to also carry provenance through the manifest-binding layer.
+        """
+        store: SSESessionStore = app.state.sse_store
+        session_id, queue = store.create_session()
+        endpoint_url = f"/mcp/messages?session_id={session_id}"
+
+        return StreamingResponse(
+            sse_stream(session_id, queue, endpoint_url, store),
+            media_type="text/event-stream",
+            headers={
+                "Cache-Control": "no-cache",
+                "X-Accel-Buffering": "no",
+                "Connection": "keep-alive",
+            },
+        )
+
+    @app.post("/mcp/messages")
+    async def sse_messages(request: Request, session_id: str) -> JSONResponse:
+        """
+        MCP SSE transport — receive a JSON-RPC request for an SSE session.
+
+        The client posts to this endpoint (URL received from the 'endpoint'
+        event on GET /mcp/sse). The request is processed identically to
+        POST /mcp, but the JSON-RPC response is pushed to the SSE stream
+        rather than returned in the HTTP response body.
+
+        Returns 202 Accepted if the request was queued, 404 if the session
+        is not found (client disconnected or invalid session_id).
+        """
+        gw: MCPGatewayState = app.state.gw
+        store: SSESessionStore = app.state.sse_store
+
+        queue = store.get_queue(session_id)
+        if queue is None:
+            return JSONResponse(
+                {"error": f"SSE session not found: {session_id!r}"},
+                status_code=404,
+            )
+
+        resp = await _dispatch_rpc_body(gw, request, session_id_override=session_id)
+        await queue.put(json.dumps(resp.model_dump(exclude_none=True)))
+        return JSONResponse({"status": "accepted"}, status_code=202)
 
     # ------------------------------------------------------------------
     # Manifest hot-reload
@@ -392,6 +423,84 @@ def create_mcp_app(
         })
 
     return app
+
+
+# ---------------------------------------------------------------------------
+# Shared dispatch helper (used by both HTTP and SSE transports)
+# ---------------------------------------------------------------------------
+
+async def _dispatch_rpc_body(
+    state: MCPGatewayState,
+    request: Request,
+    session_id_override: Optional[str] = None,
+) -> Any:
+    """
+    Parse the request body and dispatch to the appropriate MCP handler.
+
+    This is the shared core used by both POST /mcp (HTTP transport) and
+    POST /mcp/messages (SSE transport). Returns a JSONRPCResponse object
+    (result or error); the caller decides how to deliver it (HTTP body vs SSE
+    event).
+
+    Args:
+        state:              The gateway state.
+        request:            The FastAPI Request (for body + headers).
+        session_id_override: If set, this session_id takes precedence over
+                             whatever is extracted from headers/params. Used
+                             by the SSE transport which carries the session_id
+                             in the query parameter.
+
+    Returns:
+        A JSONRPCResponse (Pydantic model) — either make_result or make_error.
+    """
+    # Parse body
+    try:
+        body = await request.json()
+    except Exception:
+        return make_error(None, JSONRPC_PARSE_ERROR, "Parse error: body is not valid JSON")
+
+    # Validate JSON-RPC envelope
+    try:
+        rpc = JSONRPCRequest.model_validate(body)
+    except Exception as exc:
+        return make_error(
+            body.get("id") if isinstance(body, dict) else None,
+            JSONRPC_PARSE_ERROR,
+            f"Invalid JSON-RPC request: {exc}",
+        )
+
+    # Extract provenance; apply session_id override if provided
+    provenance = _extract_provenance(request, rpc)
+    if session_id_override:
+        provenance = InvocationProvenance(
+            source=provenance.source,
+            session_id=session_id_override,
+            trust_level=provenance.trust_level,
+            timestamp=provenance.timestamp,
+            extra=provenance.extra,
+        )
+
+    # Dispatch
+    try:
+        if rpc.method == "initialize":
+            result = _handle_initialize(state, rpc.params or {})
+            return make_result(rpc.id, result)
+
+        elif rpc.method == "tools/list":
+            result = _handle_tools_list(state, rpc.params or {}, provenance)
+            return make_result(rpc.id, result)
+
+        elif rpc.method == "tools/call":
+            return _handle_tools_call(state, rpc.id, rpc.params or {}, provenance)
+
+        else:
+            return make_error(
+                rpc.id,
+                JSONRPC_METHOD_NOT_FOUND,
+                f"Method not found: {rpc.method!r}",
+            )
+    except Exception as exc:
+        return make_error(rpc.id, JSONRPC_INTERNAL_ERROR, f"Internal error: {exc}")
 
 
 # ---------------------------------------------------------------------------

--- a/src/agent_hypervisor/hypervisor/mcp_gateway/mcp_server.py
+++ b/src/agent_hypervisor/hypervisor/mcp_gateway/mcp_server.py
@@ -4,9 +4,12 @@ mcp_server.py — Agent Hypervisor MCP Gateway.
 Implements a JSON-RPC 2.0 server that speaks the Model Context Protocol.
 
 Endpoints:
-  POST /mcp          — JSON-RPC 2.0 dispatcher (tools/list, tools/call, initialize)
-  GET  /mcp/health   — health check + world summary
-  POST /mcp/reload   — hot-reload manifest from disk
+  POST /mcp                            — JSON-RPC 2.0 dispatcher
+  GET  /mcp/health                     — health check + world summary
+  POST /mcp/reload                     — hot-reload default manifest from disk
+  POST /mcp/sessions/{session_id}/bind — bind a session to a specific manifest
+  DELETE /mcp/sessions/{session_id}    — unbind a session (revert to default)
+  GET  /mcp/sessions                   — list all active session bindings
 
 MCP methods handled:
   initialize         — MCP handshake (returns server capabilities)
@@ -16,15 +19,21 @@ MCP methods handled:
 Request flow:
   Client → POST /mcp → dispatch_jsonrpc()
     ├── method=tools/list
-    │     → SessionWorldResolver.resolve()
+    │     → SessionWorldResolver.resolve(session_id)  ← per-session manifest
     │     → ToolSurfaceRenderer.render()
-    │     → [MCPTool, ...]  (only manifest-visible tools)
+    │     → [MCPTool, ...]  (only manifest-visible tools for this session)
     │
     └── method=tools/call
-          → SessionWorldResolver.resolve()
+          → SessionWorldResolver.resolve(session_id)  ← per-session manifest
           → ToolCallEnforcer.enforce()  (manifest check → policy → allow/deny)
           → ToolRegistry.get_tool().adapter(args)  (only on allow)
           → MCPToolResult
+
+Per-session manifests:
+  Sessions without an explicit binding use the gateway-level default manifest.
+  Bind a session via POST /mcp/sessions/{session_id}/bind with a manifest_path
+  in the request body. Different agents/users can operate in different worlds
+  simultaneously without gateway restart.
 
 Usage::
 
@@ -53,6 +62,11 @@ _DEFAULT_POLICY_PATH: Path = (
 
 from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse
+from pydantic import BaseModel
+
+
+class _BindSessionRequest(BaseModel):
+    manifest_path: str
 
 from ..gateway.tool_registry import ToolRegistry, build_default_registry
 from .protocol import (
@@ -107,10 +121,32 @@ class MCPGatewayState:
         self.started_at = datetime.now(timezone.utc).isoformat()
 
     def _rebuild_components(self) -> None:
-        """Rebuild renderer and enforcer from the current manifest."""
+        """Rebuild default renderer and enforcer from the gateway-level manifest."""
         manifest = self.resolver.manifest
         self.renderer = ToolSurfaceRenderer(manifest, self.registry)
         self.enforcer = ToolCallEnforcer(manifest, self.registry, self.policy_engine)
+
+    def renderer_for(self, manifest) -> "ToolSurfaceRenderer":
+        """
+        Return a ToolSurfaceRenderer for the given manifest.
+
+        If manifest is the gateway-level default, returns the cached renderer.
+        Otherwise builds a new one (lightweight).
+        """
+        if manifest is self.resolver.manifest:
+            return self.renderer
+        return ToolSurfaceRenderer(manifest, self.registry)
+
+    def enforcer_for(self, manifest) -> "ToolCallEnforcer":
+        """
+        Return a ToolCallEnforcer for the given manifest.
+
+        If manifest is the gateway-level default, returns the cached enforcer.
+        Otherwise builds a new one (lightweight).
+        """
+        if manifest is self.resolver.manifest:
+            return self.enforcer
+        return ToolCallEnforcer(manifest, self.registry, self.policy_engine)
 
     def reload_manifest(self) -> bool:
         """
@@ -279,7 +315,7 @@ def create_mcp_app(
 
     @app.post("/mcp/reload")
     async def reload_manifest() -> JSONResponse:
-        """Hot-reload the WorldManifest from disk."""
+        """Hot-reload the default WorldManifest from disk."""
         gw: MCPGatewayState = app.state.gw
         ok = gw.reload_manifest()
         manifest = gw.resolver.manifest
@@ -288,6 +324,71 @@ def create_mcp_app(
             "manifest_path": str(gw.manifest_path),
             "workflow_id": manifest.workflow_id if manifest else None,
             "visible_tools": [t.name for t in gw.renderer.render()] if ok else [],
+        })
+
+    # ------------------------------------------------------------------
+    # Per-session manifest management
+    # ------------------------------------------------------------------
+
+    @app.post("/mcp/sessions/{session_id}/bind")
+    async def bind_session(session_id: str, body: _BindSessionRequest) -> JSONResponse:
+        """
+        Bind a session to a specific WorldManifest.
+
+        After binding, tools/list and tools/call for this session_id will use
+        the specified manifest instead of the gateway-level default.
+
+        The manifest is loaded immediately. Returns 400 if the manifest file
+        cannot be loaded (fail closed — no silent fallback to default).
+        """
+        gw: MCPGatewayState = app.state.gw
+        try:
+            manifest = gw.resolver.register_session(session_id, Path(body.manifest_path))
+        except Exception as exc:
+            return JSONResponse(
+                {"status": "error", "session_id": session_id, "error": str(exc)},
+                status_code=400,
+            )
+        renderer = gw.renderer_for(manifest)
+        return JSONResponse({
+            "status": "bound",
+            "session_id": session_id,
+            "manifest_path": body.manifest_path,
+            "workflow_id": manifest.workflow_id,
+            "visible_tools": [t.name for t in renderer.render()],
+        })
+
+    @app.delete("/mcp/sessions/{session_id}")
+    async def unbind_session(session_id: str) -> JSONResponse:
+        """
+        Remove a session's manifest binding, reverting it to the default.
+
+        Safe to call even if the session is not currently bound.
+        """
+        gw: MCPGatewayState = app.state.gw
+        removed = gw.resolver.unregister_session(session_id)
+        default_manifest = gw.resolver.manifest
+        return JSONResponse({
+            "status": "unbound" if removed else "not_bound",
+            "session_id": session_id,
+            "default_workflow_id": default_manifest.workflow_id if default_manifest else None,
+        })
+
+    @app.get("/mcp/sessions")
+    async def list_sessions() -> JSONResponse:
+        """
+        List all active per-session manifest bindings.
+
+        Returns a dict of session_id → workflow_id for all explicitly bound
+        sessions. Sessions not listed are using the gateway-level default.
+        """
+        gw: MCPGatewayState = app.state.gw
+        registry = gw.resolver.session_registry()
+        default_manifest = gw.resolver.manifest
+        return JSONResponse({
+            "sessions": registry,
+            "default_workflow_id": default_manifest.workflow_id if default_manifest else None,
+            "session_count": len(registry),
         })
 
     return app
@@ -329,10 +430,13 @@ def _handle_tools_list(
     """
     Handle tools/list.
 
-    Returns only the tools visible in the current manifest world.
-    The MCP client will see only these tools — undeclared tools do not exist.
+    Returns only the tools visible in the session's manifest world.
+    If the session has a registered manifest, that world is used; otherwise
+    the gateway-level default is used. The MCP client sees only these tools —
+    undeclared tools do not exist.
     """
-    tools = state.renderer.render()
+    manifest = state.resolver.resolve(session_id=provenance.session_id)
+    tools = state.renderer_for(manifest).render()
     return {
         "tools": [t.model_dump() for t in tools],
     }
@@ -347,9 +451,9 @@ def _handle_tools_call(
     """
     Handle tools/call.
 
-    Enforces the call against the manifest. On denial, returns a JSON-RPC
-    error response (the tool is absent or forbidden). On allow, dispatches
-    to the registered adapter and returns the result.
+    Enforces the call against the session's manifest. On denial, returns a
+    JSON-RPC error response (the tool is absent or forbidden). On allow,
+    dispatches to the registered adapter and returns the result.
     """
     # Validate params
     tool_name = params.get("name")
@@ -367,8 +471,9 @@ def _handle_tools_call(
             "'arguments' must be an object",
         )
 
-    # Enforce
-    decision = state.enforcer.enforce(tool_name, arguments, provenance)
+    # Resolve per-session manifest and enforce
+    manifest = state.resolver.resolve(session_id=provenance.session_id)
+    decision = state.enforcer_for(manifest).enforce(tool_name, arguments, provenance)
 
     if decision.denied:
         # Choose error code: not-in-world vs. policy-denied

--- a/src/agent_hypervisor/hypervisor/mcp_gateway/session_world_resolver.py
+++ b/src/agent_hypervisor/hypervisor/mcp_gateway/session_world_resolver.py
@@ -4,21 +4,27 @@ session_world_resolver.py — Session to WorldManifest binding.
 Responsibility:
     Map a session/request context to the active WorldManifest.
 
-Initial implementation:
-    Single static manifest per gateway instance, loaded from a YAML file
-    at startup. All sessions share this manifest.
+v1 implementation:
+    Single static manifest per gateway instance (the default), plus an
+    optional per-session registry. Sessions without an explicit binding
+    fall back to the default manifest.
 
 Extension path:
-    The resolve(session_id, context) signature is designed to evolve into
-    per-session or per-user manifest selection without changing callers.
-    A future implementation might look up session_id in a manifest registry
-    or select a manifest based on context["workflow"] or context["role"].
+    register_session(session_id, manifest_path) binds a specific session
+    to a different WorldManifest loaded from disk. This is the intended
+    evolution of the resolve(session_id, context) signature that was
+    designed to support this pattern from the start.
 
 Invariants:
-    - If the manifest file cannot be loaded at startup, the resolver raises.
-      Gateway startup fails; it does NOT default to an empty/permissive world.
+    - If the default manifest file cannot be loaded at startup, the resolver
+      raises. Gateway startup fails; it does NOT default to an empty/permissive
+      world.
     - If reload() fails, the existing manifest is retained (fail safe).
+    - If register_session() fails to load the manifest, it raises and the
+      session is NOT registered (fail closed — no silent fallback to default).
     - The resolver never returns None — callers can always depend on a manifest.
+    - Unregistering a session is safe to call even if the session is not
+      registered (idempotent, returns False in that case).
 """
 
 from __future__ import annotations
@@ -37,13 +43,25 @@ class SessionWorldResolver:
     Usage::
 
         resolver = SessionWorldResolver(Path("manifests/example_world.yaml"))
+
+        # Default: all sessions share the same manifest
         manifest = resolver.resolve(session_id="s1")
-        # → WorldManifest with declared capabilities
+
+        # Per-session: bind a specific session to a different manifest
+        resolver.register_session("s1", Path("manifests/read_only_world.yaml"))
+        manifest = resolver.resolve(session_id="s1")
+        # → read_only_world manifest
+
+        resolver.unregister_session("s1")
+        manifest = resolver.resolve(session_id="s1")
+        # → back to default manifest
     """
 
     def __init__(self, manifest_path: Path) -> None:
         self._manifest_path = Path(manifest_path)
         self._manifest: Optional[WorldManifest] = None
+        # session_id → WorldManifest (per-session overrides)
+        self._session_registry: dict[str, WorldManifest] = {}
         self._load()  # Raises on failure — intentional (fail closed at startup)
 
     def resolve(
@@ -54,15 +72,16 @@ class SessionWorldResolver:
         """
         Return the WorldManifest for this session.
 
-        Current implementation ignores session_id and context — same manifest
-        for all sessions. This is the correct starting point.
+        If the session has a registered manifest (via register_session),
+        that manifest is returned. Otherwise the default manifest is used.
 
         Args:
-            session_id: Optional session identifier (unused in v1).
-            context:    Optional context dict (unused in v1).
+            session_id: Optional session identifier. If registered, the
+                        session-specific manifest is returned.
+            context:    Optional context dict (reserved for future use).
 
         Returns:
-            The active WorldManifest.
+            The active WorldManifest for this session.
 
         Raises:
             RuntimeError: If no manifest is loaded (should not happen after
@@ -73,14 +92,68 @@ class SessionWorldResolver:
                 "SessionWorldResolver has no manifest loaded. "
                 "Check manifest_path and startup logs."
             )
+        if session_id and session_id in self._session_registry:
+            return self._session_registry[session_id]
         return self._manifest
+
+    def register_session(self, session_id: str, manifest_path: Path) -> WorldManifest:
+        """
+        Bind a session to a specific WorldManifest loaded from disk.
+
+        The manifest is loaded immediately. If loading fails, the session
+        is NOT registered and the exception propagates (fail closed).
+
+        Args:
+            session_id:    The session identifier to bind.
+            manifest_path: Path to the WorldManifest YAML file.
+
+        Returns:
+            The loaded WorldManifest that was registered.
+
+        Raises:
+            FileNotFoundError: If manifest_path does not exist.
+            Exception: If the manifest YAML is invalid.
+        """
+        manifest = load_manifest(Path(manifest_path))
+        self._session_registry[session_id] = manifest
+        return manifest
+
+    def unregister_session(self, session_id: str) -> bool:
+        """
+        Remove a session's manifest binding, reverting to the default.
+
+        Safe to call even if the session is not registered.
+
+        Args:
+            session_id: The session identifier to unbind.
+
+        Returns:
+            True if the session was registered and removed, False otherwise.
+        """
+        if session_id in self._session_registry:
+            del self._session_registry[session_id]
+            return True
+        return False
+
+    def session_registry(self) -> dict[str, str]:
+        """
+        Return a snapshot of current session bindings.
+
+        Returns:
+            Dict mapping session_id → workflow_id of the bound manifest.
+        """
+        return {
+            sid: m.workflow_id
+            for sid, m in self._session_registry.items()
+        }
 
     def reload(self) -> bool:
         """
-        Reload the manifest from disk.
+        Reload the default manifest from disk.
 
         Returns True if reload succeeded, False if it failed (existing
-        manifest is retained on failure).
+        manifest is retained on failure). Per-session registrations are
+        not affected.
         """
         try:
             new_manifest = load_manifest(self._manifest_path)
@@ -96,8 +169,9 @@ class SessionWorldResolver:
 
     @property
     def manifest(self) -> Optional[WorldManifest]:
+        """The default (gateway-level) manifest."""
         return self._manifest
 
     def _load(self) -> None:
-        """Load manifest at startup. Raises on failure."""
+        """Load default manifest at startup. Raises on failure."""
         self._manifest = load_manifest(self._manifest_path)

--- a/src/agent_hypervisor/hypervisor/mcp_gateway/sse_transport.py
+++ b/src/agent_hypervisor/hypervisor/mcp_gateway/sse_transport.py
@@ -1,0 +1,170 @@
+"""
+sse_transport.py — SSE transport layer for the MCP gateway.
+
+Implements the MCP 2024-11-05 SSE transport:
+
+  1. Client GETs /mcp/sse  →  server opens an SSE stream and sends an
+     'endpoint' event containing the POST URL the client should use.
+  2. Client POSTs JSON-RPC requests to /mcp/messages?session_id=<id>.
+  3. Server processes the request and sends the JSON-RPC response back
+     over the SSE stream as a 'message' event.
+
+This makes the gateway compatible with MCP clients that require streaming
+(e.g., Claude Desktop). The existing HTTP POST /mcp endpoint is unaffected.
+
+Classes:
+    SSESessionStore — registry of active SSE sessions (session_id → Queue)
+
+Functions:
+    format_sse_event(event, data) → str
+    sse_stream(session_id, queue, endpoint_url, store) → AsyncGenerator
+"""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+from typing import AsyncGenerator, Optional
+
+# Timeout (seconds) between heartbeat pings sent to the client to keep the
+# connection alive through proxies and load-balancers.
+_HEARTBEAT_INTERVAL: float = 25.0
+
+
+class SSESessionStore:
+    """
+    Registry of active SSE sessions.
+
+    Each GET /mcp/sse connection creates a session: a UUID is assigned and an
+    asyncio Queue is stored here. When the client POSTs to /mcp/messages, the
+    response is placed in the queue. The SSE stream reads from the queue and
+    forwards the response as a 'message' event.
+
+    Sessions are removed automatically when the SSE stream generator exits
+    (client disconnect or server shutdown).
+
+    Thread safety: Python dict operations are GIL-atomic; this is safe for
+    asyncio single-threaded event loop usage. Do not share across threads.
+    """
+
+    def __init__(self) -> None:
+        self._sessions: dict[str, asyncio.Queue] = {}
+
+    def create_session(self) -> tuple[str, asyncio.Queue]:
+        """
+        Create a new SSE session.
+
+        Returns:
+            (session_id, queue) — caller keeps the queue reference for
+            the streaming generator; session_id is sent to the client
+            as part of the endpoint URL.
+        """
+        session_id = str(uuid.uuid4())
+        queue: asyncio.Queue = asyncio.Queue()
+        self._sessions[session_id] = queue
+        return session_id, queue
+
+    def get_queue(self, session_id: str) -> Optional[asyncio.Queue]:
+        """
+        Look up the queue for an existing session.
+
+        Returns None if the session does not exist (client already disconnected
+        or invalid session_id).
+        """
+        return self._sessions.get(session_id)
+
+    def remove_session(self, session_id: str) -> None:
+        """Remove a session from the registry (idempotent)."""
+        self._sessions.pop(session_id, None)
+
+    def session_count(self) -> int:
+        """Return the number of currently active SSE sessions."""
+        return len(self._sessions)
+
+    def active_session_ids(self) -> list[str]:
+        """Return a snapshot list of active session IDs."""
+        return list(self._sessions.keys())
+
+
+# ---------------------------------------------------------------------------
+# SSE formatting
+# ---------------------------------------------------------------------------
+
+def format_sse_event(event: str, data: str) -> str:
+    """
+    Format a single SSE event.
+
+    SSE wire format:
+        event: <event-name>\\n
+        data: <payload>\\n
+        \\n
+
+    Args:
+        event: Event name (e.g. 'endpoint', 'message').
+        data:  Event payload string. Multi-line data is not supported here
+               (MCP responses are single JSON objects on one line).
+
+    Returns:
+        SSE-encoded string ready to be yielded from a StreamingResponse.
+    """
+    return f"event: {event}\ndata: {data}\n\n"
+
+
+# ---------------------------------------------------------------------------
+# SSE stream generator
+# ---------------------------------------------------------------------------
+
+async def sse_stream(
+    session_id: str,
+    queue: asyncio.Queue,
+    endpoint_url: str,
+    store: SSESessionStore,
+) -> AsyncGenerator[str, None]:
+    """
+    Async generator for an MCP SSE transport stream.
+
+    Protocol:
+        1. Yields an 'endpoint' event immediately. The data is the URL where
+           the client should POST JSON-RPC requests, e.g.:
+               /mcp/messages?session_id=<uuid>
+        2. Yields 'message' events for each JSON-RPC response placed in the
+           queue by POST /mcp/messages.
+        3. Sends a comment-only keep-alive ping every _HEARTBEAT_INTERVAL
+           seconds to prevent proxy timeouts.
+        4. Stops when a None sentinel is placed in the queue (graceful
+           shutdown) or when the client disconnects (GeneratorExit).
+
+    Cleanup:
+        Removes the session from the store in a finally block so that
+        subsequent POST /mcp/messages for the same session_id return 404.
+
+    Args:
+        session_id:   The session UUID assigned to this connection.
+        queue:        The asyncio Queue for this session. Responses from
+                      POST /mcp/messages are placed here.
+        endpoint_url: The URL to send in the initial 'endpoint' event.
+        store:        The SSESessionStore; used for cleanup on disconnect.
+    """
+    try:
+        # Step 1: send the endpoint event so the client knows where to POST
+        yield format_sse_event("endpoint", endpoint_url)
+
+        # Step 2 & 3: stream responses, heartbeat on timeout
+        while True:
+            try:
+                payload = await asyncio.wait_for(
+                    queue.get(), timeout=_HEARTBEAT_INTERVAL
+                )
+            except asyncio.TimeoutError:
+                # Keep-alive ping (SSE comment — clients ignore it)
+                yield ": ping\n\n"
+                continue
+
+            if payload is None:
+                # Graceful shutdown sentinel
+                break
+
+            yield format_sse_event("message", payload)
+
+    finally:
+        store.remove_session(session_id)

--- a/src/agent_hypervisor/hypervisor/mcp_gateway/tool_call_enforcer.py
+++ b/src/agent_hypervisor/hypervisor/mcp_gateway/tool_call_enforcer.py
@@ -21,11 +21,27 @@ Enforcement pipeline (in order):
        the tool (e.g., allowed paths, allowed domains), validate them.
        Violation fails closed: verdict=deny, rule=manifest:constraint_violated.
 
+Taint propagation:
+    Every EnforcementDecision carries a TaintContext derived from the
+    InvocationProvenance.trust_level:
+      - trust_level="trusted"  → TaintContext.clean()  (CLEAN taint)
+      - trust_level="derived"  → TaintContext(TAINTED)  (derived from external)
+      - trust_level="untrusted" or anything else → TaintContext(TAINTED)
+
+    This is the bridge between the MCP gateway and the runtime taint system.
+    Callers can use decision.taint_context to wrap tool results in TaintedValues
+    so that data originating from untrusted sources carries taint monotonically
+    through subsequent operations.
+
+    Taint is never removed — even for allowed calls from untrusted sources,
+    the taint_context is TAINTED and must be propagated.
+
 Invariants:
     - No LLM in this path.
     - Same input → same output (deterministic).
     - Unknown tool → deny, never allow.
     - Manifest load failure is handled at startup; if manifest is None, deny all.
+    - taint_context is always set — callers never need to handle None.
 """
 
 from __future__ import annotations
@@ -35,6 +51,8 @@ from typing import Any, Optional
 
 from agent_hypervisor.compiler.schema import WorldManifest
 from agent_hypervisor.hypervisor.gateway.tool_registry import ToolRegistry
+from agent_hypervisor.runtime.models import TaintState
+from agent_hypervisor.runtime.taint import TaintContext
 
 
 @dataclass
@@ -42,7 +60,11 @@ class InvocationProvenance:
     """
     Provenance metadata captured for one tool invocation.
 
-    Not used for enforcement — used for audit / trace / future taint analysis.
+    trust_level drives taint propagation through the enforcement pipeline:
+      - "trusted":   caller is an authorised orchestrator (CLEAN taint)
+      - "derived":   values derived from external/LLM sources (TAINTED)
+      - "untrusted": default — unknown or external caller (TAINTED)
+
     All fields are optional; absence of metadata is not an error.
     """
     source: str = "unknown"           # request origin (e.g. "mcp_client", "claude")
@@ -57,15 +79,26 @@ class EnforcementDecision:
     """
     Result of enforcing a tool call against manifest + policy.
 
-    verdict:     "allow" | "deny"
-    reason:      human-readable explanation
-    matched_rule: rule identifier that produced the verdict
-    provenance:  invocation provenance metadata (for audit)
+    verdict:       "allow" | "deny"
+    reason:        human-readable explanation
+    matched_rule:  rule identifier that produced the verdict
+    provenance:    invocation provenance metadata (for audit)
+    taint_context: TaintContext derived from provenance.trust_level.
+                   ALWAYS set — callers should propagate this into any
+                   TaintedValues they create from the tool result.
+
+    Taint semantics:
+        allowed + trusted   → CLEAN  (safe to use in external actions)
+        allowed + untrusted → TAINTED (must not flow unchecked to external)
+        denied  (any)       → TAINTED (blocked call; result would be tainted)
     """
     verdict: str
     reason: str
     matched_rule: str
     provenance: InvocationProvenance = field(default_factory=InvocationProvenance)
+    taint_context: TaintContext = field(
+        default_factory=lambda: TaintContext(TaintState.TAINTED)
+    )
 
     @property
     def allowed(self) -> bool:
@@ -74,6 +107,29 @@ class EnforcementDecision:
     @property
     def denied(self) -> bool:
         return self.verdict == "deny"
+
+    @property
+    def taint_state(self) -> TaintState:
+        """Convenience accessor for the taint state carried by this decision."""
+        return self.taint_context.taint
+
+
+# ---------------------------------------------------------------------------
+# Taint helper
+# ---------------------------------------------------------------------------
+
+def _taint_context_from_provenance(prov: InvocationProvenance) -> TaintContext:
+    """
+    Derive a TaintContext from invocation provenance.
+
+    Only "trusted" trust_level produces CLEAN taint. All other values
+    (including the default "untrusted" and "derived") produce TAINTED.
+
+    This is intentionally conservative: an unknown trust_level is TAINTED.
+    """
+    if prov.trust_level == "trusted":
+        return TaintContext.clean()
+    return TaintContext(TaintState.TAINTED)
 
 
 class ToolCallEnforcer:
@@ -86,6 +142,10 @@ class ToolCallEnforcer:
         decision = enforcer.enforce("read_file", {"path": "/tmp/x.txt"})
         if decision.denied:
             # fail closed — do not execute
+        else:
+            result = run_tool(...)
+            # wrap in TaintedValue to carry provenance taint forward
+            tainted_result = TaintedValue(value=result, taint=decision.taint_state)
     """
 
     def __init__(
@@ -107,10 +167,13 @@ class ToolCallEnforcer:
         """
         Evaluate a tool invocation.
 
-        Returns EnforcementDecision with verdict "allow" or "deny".
+        Returns EnforcementDecision with verdict "allow" or "deny" and a
+        taint_context derived from the invocation provenance.
+
         Never raises — all error conditions produce deny decisions.
         """
         prov = provenance or InvocationProvenance()
+        taint_ctx = _taint_context_from_provenance(prov)
 
         # Step 1: Manifest check — is the tool declared at all?
         # Use tool_names() to check declaration independently of arg constraints.
@@ -120,6 +183,7 @@ class ToolCallEnforcer:
                 reason=f"tool '{tool_name}' does not exist in this world",
                 matched_rule="manifest:tool_not_declared",
                 provenance=prov,
+                taint_context=taint_ctx,
             )
 
         # Step 2: Registry check — adapter must exist
@@ -130,16 +194,17 @@ class ToolCallEnforcer:
                 reason=f"tool '{tool_name}' is declared but has no registered adapter",
                 matched_rule="registry:no_adapter",
                 provenance=prov,
+                taint_context=taint_ctx,
             )
 
         # Step 3: Policy engine evaluation (optional secondary check)
         if self._policy_engine is not None:
-            pe_decision = self._evaluate_policy(tool_name, arguments, prov)
+            pe_decision = self._evaluate_policy(tool_name, arguments, prov, taint_ctx)
             if pe_decision is not None:
                 return pe_decision
 
         # Step 4: Manifest constraint check
-        constraint_decision = self._check_constraints(tool_name, arguments, prov)
+        constraint_decision = self._check_constraints(tool_name, arguments, prov, taint_ctx)
         if constraint_decision is not None:
             return constraint_decision
 
@@ -149,6 +214,7 @@ class ToolCallEnforcer:
             reason=f"tool '{tool_name}' allowed by manifest and policy",
             matched_rule="manifest:allowed",
             provenance=prov,
+            taint_context=taint_ctx,
         )
 
     def _evaluate_policy(
@@ -156,6 +222,7 @@ class ToolCallEnforcer:
         tool_name: str,
         arguments: dict[str, Any],
         prov: InvocationProvenance,
+        taint_ctx: TaintContext,
     ) -> Optional[EnforcementDecision]:
         """
         Run the PolicyEngine and return a deny decision if the verdict is deny.
@@ -193,6 +260,7 @@ class ToolCallEnforcer:
                     reason=result.reason,
                     matched_rule=f"policy:{result.matched_rule}",
                     provenance=prov,
+                    taint_context=taint_ctx,
                 )
         except Exception:
             # Policy engine errors fail closed
@@ -201,6 +269,7 @@ class ToolCallEnforcer:
                 reason="policy engine evaluation failed",
                 matched_rule="policy:evaluation_error",
                 provenance=prov,
+                taint_context=taint_ctx,
             )
         return None
 
@@ -209,6 +278,7 @@ class ToolCallEnforcer:
         tool_name: str,
         arguments: dict[str, Any],
         prov: InvocationProvenance,
+        taint_ctx: TaintContext,
     ) -> Optional[EnforcementDecision]:
         """
         Check manifest constraints for the tool against the call arguments.
@@ -225,5 +295,6 @@ class ToolCallEnforcer:
                     reason=f"tool '{tool_name}' call violates manifest constraints",
                     matched_rule="manifest:constraint_violated",
                     provenance=prov,
+                    taint_context=taint_ctx,
                 )
         return None

--- a/tests/hypervisor/test_mcp_gateway.py
+++ b/tests/hypervisor/test_mcp_gateway.py
@@ -779,6 +779,345 @@ class TestPerSessionManifests:
 
 
 # ---------------------------------------------------------------------------
+# Group 8: SSE integration via real uvicorn server (Option E)
+# ---------------------------------------------------------------------------
+
+class TestSSEIntegration:
+    """
+    Full SSE streaming round-trip tests against a real uvicorn server.
+
+    httpx ASGI transport buffers the entire HTTP response body before returning
+    headers, making it impossible to test infinite SSE streams. These tests
+    start a real uvicorn server in a daemon thread and use http.client +
+    threading to read SSE events line-by-line, which is the only reliable way
+    to test actual streaming behaviour.
+
+    Protocol invariants tested:
+    - GET /mcp/sse returns Content-Type: text/event-stream
+    - The first SSE event is 'endpoint' with data=/mcp/messages?session_id=<uuid>
+    - Full round-trip: open SSE → read endpoint → POST request → read message event
+    - POST /mcp/messages after SSE disconnect returns 404 (session cleaned up)
+    """
+
+    HOST = "127.0.0.1"
+    PORT = 18095
+
+    # ------------------------------------------------------------------ #
+    # Fixtures                                                             #
+    # ------------------------------------------------------------------ #
+
+    @pytest.fixture(scope="class")
+    def live_server(self, tmp_path_factory):
+        """
+        Start a real uvicorn gateway and yield (host, port, base_url).
+
+        Uses scope="class" so all tests in the group share one server instance
+        (faster) rather than paying the startup cost per test.
+        """
+        import time
+        import threading
+        import http.client
+
+        pytest.importorskip("uvicorn")
+        from agent_hypervisor.hypervisor.mcp_gateway import create_mcp_app
+
+        tmp_path = tmp_path_factory.mktemp("sse_integration")
+        manifest_file = tmp_path / "world.yaml"
+        manifest_file.write_text(
+            "workflow_id: sse-integration-world\ncapabilities:\n  - tool: read_file\n"
+        )
+        app = create_mcp_app(manifest_file)
+
+        import uvicorn
+        config = uvicorn.Config(
+            app, host=self.HOST, port=self.PORT, log_level="error"
+        )
+        server = uvicorn.Server(config)
+        thread = threading.Thread(target=server.run, daemon=True)
+        thread.start()
+
+        # Poll the health endpoint until the server is ready (max 5 s).
+        deadline = time.time() + 5.0
+        while time.time() < deadline:
+            try:
+                conn = http.client.HTTPConnection(self.HOST, self.PORT, timeout=1)
+                conn.request("GET", "/mcp/health")
+                conn.getresponse().read()
+                conn.close()
+                break
+            except Exception:
+                time.sleep(0.05)
+        else:
+            raise RuntimeError("SSE integration server did not start within 5 s")
+
+        yield (self.HOST, self.PORT, f"http://{self.HOST}:{self.PORT}")
+
+        server.should_exit = True
+        time.sleep(0.2)
+
+    # ------------------------------------------------------------------ #
+    # SSE helpers                                                          #
+    # ------------------------------------------------------------------ #
+
+    @staticmethod
+    def _collect_sse_events(
+        host: str,
+        port: int,
+        path: str,
+        n_events: int,
+        timeout: float = 5.0,
+    ) -> list[dict]:
+        """
+        Open an SSE connection and collect up to n_events parsed events.
+
+        Returns a list of dicts with keys 'event' (str) and 'data' (str).
+        Runs the blocking HTTP read in a daemon thread so the main test
+        thread can time-out cleanly.
+        """
+        import http.client
+        import threading
+        import queue as queue_mod
+
+        result_q: queue_mod.Queue = queue_mod.Queue()
+
+        def _reader():
+            try:
+                conn = http.client.HTTPConnection(host, port, timeout=timeout)
+                conn.request("GET", path, headers={"Accept": "text/event-stream"})
+                resp = conn.getresponse()
+                event_type = None
+                event_data = None
+                while True:
+                    raw = resp.readline()
+                    if not raw:
+                        break
+                    line = raw.decode("utf-8").rstrip("\r\n")
+                    if line.startswith("event: "):
+                        event_type = line[7:]
+                    elif line.startswith("data: "):
+                        event_data = line[6:]
+                    elif line.startswith(":"):
+                        pass   # heartbeat comment — ignore
+                    elif line == "" and event_type is not None:
+                        result_q.put({"event": event_type, "data": event_data})
+                        event_type = None
+                        event_data = None
+                conn.close()
+            except Exception as exc:
+                result_q.put({"_error": str(exc)})
+
+        t = threading.Thread(target=_reader, daemon=True)
+        t.start()
+
+        events = []
+        for _ in range(n_events):
+            try:
+                ev = result_q.get(timeout=timeout)
+                if "_error" in ev:
+                    raise RuntimeError(f"SSE reader error: {ev['_error']}")
+                events.append(ev)
+            except queue_mod.Empty:
+                break
+        return events
+
+    @staticmethod
+    def _post_json(host: str, port: int, path: str, body: dict) -> tuple[int, dict]:
+        """Send a JSON POST to the live server; return (status_code, parsed_body)."""
+        import http.client
+        payload = json.dumps(body).encode()
+        conn = http.client.HTTPConnection(host, port, timeout=5)
+        conn.request(
+            "POST", path, body=payload,
+            headers={"Content-Type": "application/json"},
+        )
+        resp = conn.getresponse()
+        status = resp.status
+        data = json.loads(resp.read())
+        conn.close()
+        return status, data
+
+    # ------------------------------------------------------------------ #
+    # Tests                                                                #
+    # ------------------------------------------------------------------ #
+
+    def test_sse_content_type(self, live_server):
+        """GET /mcp/sse must return Content-Type: text/event-stream."""
+        import http.client
+        host, port, _ = live_server
+        conn = http.client.HTTPConnection(host, port, timeout=5)
+        conn.request("GET", "/mcp/sse", headers={"Accept": "text/event-stream"})
+        resp = conn.getresponse()
+        content_type = resp.getheader("Content-Type", "")
+        # Read a small chunk then abandon (we only need the headers here)
+        resp.read(64)
+        conn.close()
+        assert "text/event-stream" in content_type, (
+            f"Expected text/event-stream, got {content_type!r}"
+        )
+
+    def test_sse_first_event_is_endpoint(self, live_server):
+        """The first SSE event must be 'endpoint' with a session URL."""
+        host, port, _ = live_server
+        events = self._collect_sse_events(host, port, "/mcp/sse", n_events=1)
+        assert len(events) == 1, f"Expected 1 event, got {events}"
+        ev = events[0]
+        assert ev["event"] == "endpoint", f"Expected 'endpoint' event, got {ev}"
+        assert "/mcp/messages?session_id=" in ev["data"], (
+            f"Endpoint data does not contain session URL: {ev['data']}"
+        )
+
+    def test_sse_endpoint_url_has_uuid_session_id(self, live_server):
+        """The endpoint event's session_id must look like a UUID."""
+        import re
+        host, port, _ = live_server
+        events = self._collect_sse_events(host, port, "/mcp/sse", n_events=1)
+        data = events[0]["data"]
+        # data is "/mcp/messages?session_id=<uuid>"
+        m = re.search(r"session_id=([0-9a-f-]{30,})", data)
+        assert m is not None, f"No UUID-like session_id found in {data!r}"
+
+    def test_sse_full_round_trip(self, live_server):
+        """
+        Full SSE round-trip:
+        1. Open GET /mcp/sse → read endpoint event → extract session_id
+        2. POST tools/list to /mcp/messages?session_id=<id>
+        3. Read the resulting 'message' event from the SSE stream.
+
+        The SSE reader runs in a daemon thread and forwards each event to a
+        shared queue as soon as it arrives (not after collecting n_events).
+        This avoids the deadlock where the reader waits for event 2 before
+        the main thread can POST to trigger event 2.
+        """
+        import http.client
+        import threading
+        import queue as queue_mod
+
+        host, port, _ = live_server
+        event_q: queue_mod.Queue = queue_mod.Queue()
+
+        def _streaming_reader():
+            """Connect to SSE and push each parsed event into event_q immediately."""
+            try:
+                conn = http.client.HTTPConnection(host, port, timeout=10)
+                conn.request("GET", "/mcp/sse", headers={"Accept": "text/event-stream"})
+                resp = conn.getresponse()
+                event_type = None
+                event_data = None
+                while True:
+                    raw = resp.readline()
+                    if not raw:
+                        break
+                    line = raw.decode("utf-8").rstrip("\r\n")
+                    if line.startswith("event: "):
+                        event_type = line[7:]
+                    elif line.startswith("data: "):
+                        event_data = line[6:]
+                    elif line.startswith(":"):
+                        pass   # heartbeat comment
+                    elif line == "" and event_type is not None:
+                        # Emit event immediately — do not wait to batch
+                        event_q.put({"event": event_type, "data": event_data})
+                        event_type = None
+                        event_data = None
+                conn.close()
+            except Exception as exc:
+                event_q.put({"_error": str(exc)})
+
+        t = threading.Thread(target=_streaming_reader, daemon=True)
+        t.start()
+
+        # Step 1: get the endpoint event (the server yields it immediately on connect)
+        try:
+            endpoint_event = event_q.get(timeout=5.0)
+        except queue_mod.Empty:
+            pytest.fail("Timed out waiting for SSE endpoint event")
+
+        if "_error" in endpoint_event:
+            pytest.fail(f"SSE reader error: {endpoint_event['_error']}")
+
+        assert endpoint_event["event"] == "endpoint", (
+            f"Expected 'endpoint' event, got {endpoint_event}"
+        )
+        messages_path = endpoint_event["data"]   # /mcp/messages?session_id=<uuid>
+
+        # Step 2: POST a tools/list request via the SSE messages endpoint.
+        # Now that the main thread has the session_id it can POST.
+        status, post_body = self._post_json(
+            host, port, messages_path,
+            {"jsonrpc": "2.0", "id": 1, "method": "tools/list", "params": {}},
+        )
+        assert status == 202, f"Expected 202, got {status}: {post_body}"
+        assert post_body.get("status") == "accepted"
+
+        # Step 3: the JSON-RPC response arrives as a 'message' event on the stream.
+        # The server puts the response in the session queue, sse_stream yields it.
+        try:
+            message_event = event_q.get(timeout=5.0)
+        except queue_mod.Empty:
+            pytest.fail("Timed out waiting for SSE message event after POST")
+
+        if "_error" in message_event:
+            pytest.fail(f"SSE reader error after POST: {message_event['_error']}")
+
+        assert message_event["event"] == "message", (
+            f"Expected 'message' event, got {message_event}"
+        )
+        result = json.loads(message_event["data"])
+        assert "result" in result, f"Expected JSON-RPC result, got: {result}"
+        assert "tools" in result["result"], f"tools/list result missing 'tools': {result}"
+        tool_names = [t["name"] for t in result["result"]["tools"]]
+        assert "read_file" in tool_names, f"read_file not in {tool_names}"
+
+    def test_sse_session_removed_after_disconnect(self, live_server):
+        """
+        After the SSE connection closes, POST /mcp/messages must return 404.
+
+        Simulate disconnect by opening the SSE stream, reading the endpoint
+        event, closing the connection, then attempting to POST.
+        """
+        import http.client
+        import time
+
+        host, port, _ = live_server
+
+        # Open SSE, read endpoint event, capture session_id, close abruptly.
+        session_id = None
+        conn = http.client.HTTPConnection(host, port, timeout=5)
+        try:
+            conn.request("GET", "/mcp/sse", headers={"Accept": "text/event-stream"})
+            resp = conn.getresponse()
+            event_type = None
+            event_data = None
+            while True:
+                line = resp.readline().decode("utf-8").rstrip("\r\n")
+                if line.startswith("event: "):
+                    event_type = line[7:]
+                elif line.startswith("data: "):
+                    event_data = line[6:]
+                elif line == "" and event_type is not None:
+                    if event_type == "endpoint":
+                        # /mcp/messages?session_id=<uuid>
+                        session_id = event_data.split("session_id=")[-1]
+                        break
+        finally:
+            conn.close()   # abrupt close — simulates client disconnect
+
+        assert session_id, "Could not extract session_id from SSE stream"
+
+        # Give the server a moment to run the finally block in sse_stream.
+        time.sleep(0.3)
+
+        # POST to the now-dead session must return 404.
+        status, body = self._post_json(
+            host, port, f"/mcp/messages?session_id={session_id}",
+            {"jsonrpc": "2.0", "id": 1, "method": "tools/list", "params": {}},
+        )
+        assert status == 404, (
+            f"Expected 404 after SSE disconnect, got {status}: {body}"
+        )
+
+
+# ---------------------------------------------------------------------------
 # Group 7: SSE transport
 # ---------------------------------------------------------------------------
 

--- a/tests/hypervisor/test_mcp_gateway.py
+++ b/tests/hypervisor/test_mcp_gateway.py
@@ -27,6 +27,7 @@ unit tests; integration tests use real manifest files).
 
 from __future__ import annotations
 
+import json
 import pytest
 from pathlib import Path
 from unittest.mock import MagicMock
@@ -755,7 +756,7 @@ class TestPerSessionManifests:
             assert resp.json()["status"] == "error"
 
     @pytest.mark.asyncio
-    async def test_session_tool_call_enforced_against_session_world(self, two_world_client):
+    async def test_session_tool_call_enforced_against_session_world(self, two_world_client):  # noqa: E501
         """tools/call must be enforced against the session's bound manifest."""
         async with two_world_client as c:
             email_path = c._transport.app.state.email_manifest_path
@@ -775,3 +776,279 @@ class TestPerSessionManifests:
             data = call_resp.json()
             assert "error" in data, f"Expected denial for s1, got: {data}"
             assert data["error"]["code"] in (-32001, -32002)
+
+
+# ---------------------------------------------------------------------------
+# Group 7: SSE transport
+# ---------------------------------------------------------------------------
+
+class TestSSETransport:
+    """
+    Tests for the MCP SSE transport (GET /mcp/sse + POST /mcp/messages).
+
+    Protocol invariants tested:
+    - GET /mcp/sse returns text/event-stream with an 'endpoint' event
+    - The endpoint event payload is /mcp/messages?session_id=<uuid>
+    - POST /mcp/messages with a valid session_id returns 202 Accepted
+    - The JSON-RPC response is delivered over the SSE stream as a 'message' event
+    - POST /mcp/messages with an unknown session_id returns 404
+    - SSESessionStore correctly tracks and cleans up sessions
+
+    SSE streams are tested by opening the stream, posting a request from a
+    concurrent task, then reading the response event from the stream.
+    """
+
+    @pytest.fixture
+    def sse_client(self, tmp_path):
+        """httpx AsyncClient for a gateway with the default read_file world."""
+        pytest.importorskip("httpx")
+        from httpx import AsyncClient, ASGITransport
+        from agent_hypervisor.hypervisor.mcp_gateway import create_mcp_app
+
+        manifest_file = tmp_path / "world.yaml"
+        manifest_file.write_text(
+            "workflow_id: sse-test-world\ncapabilities:\n  - tool: read_file\n"
+        )
+        app = create_mcp_app(manifest_file)
+        return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+    # --- SSESessionStore unit tests ---
+
+    def test_create_session_returns_uuid_and_queue(self):
+        """create_session must return a non-empty UUID and a Queue."""
+        from agent_hypervisor.hypervisor.mcp_gateway import SSESessionStore
+        import asyncio
+        store = SSESessionStore()
+        session_id, queue = store.create_session()
+        assert session_id and len(session_id) > 8
+        assert isinstance(queue, asyncio.Queue)
+
+    def test_get_queue_returns_same_queue(self):
+        """get_queue must return the same Queue that was created."""
+        from agent_hypervisor.hypervisor.mcp_gateway import SSESessionStore
+        store = SSESessionStore()
+        session_id, queue = store.create_session()
+        assert store.get_queue(session_id) is queue
+
+    def test_get_queue_unknown_session_returns_none(self):
+        """get_queue for an unknown session_id must return None."""
+        from agent_hypervisor.hypervisor.mcp_gateway import SSESessionStore
+        store = SSESessionStore()
+        assert store.get_queue("does-not-exist") is None
+
+    def test_remove_session_cleans_up(self):
+        """remove_session must remove the session; subsequent get_queue returns None."""
+        from agent_hypervisor.hypervisor.mcp_gateway import SSESessionStore
+        store = SSESessionStore()
+        session_id, _ = store.create_session()
+        assert store.session_count() == 1
+        store.remove_session(session_id)
+        assert store.session_count() == 0
+        assert store.get_queue(session_id) is None
+
+    def test_remove_nonexistent_session_is_idempotent(self):
+        """remove_session on an unknown session_id must not raise."""
+        from agent_hypervisor.hypervisor.mcp_gateway import SSESessionStore
+        store = SSESessionStore()
+        store.remove_session("ghost")  # must not raise
+
+    def test_multiple_sessions_are_independent(self):
+        """Multiple concurrent sessions must have independent queues."""
+        from agent_hypervisor.hypervisor.mcp_gateway import SSESessionStore
+        store = SSESessionStore()
+        id1, q1 = store.create_session()
+        id2, q2 = store.create_session()
+        assert id1 != id2
+        assert q1 is not q2
+        assert store.session_count() == 2
+
+    # --- sse_stream generator unit tests ---
+
+    @pytest.mark.asyncio
+    async def test_sse_stream_first_event_is_endpoint(self):
+        """sse_stream must yield an 'endpoint' event as the first chunk."""
+        from agent_hypervisor.hypervisor.mcp_gateway.sse_transport import (
+            SSESessionStore, sse_stream,
+        )
+        import asyncio
+
+        store = SSESessionStore()
+        session_id, queue = store.create_session()
+        endpoint_url = f"/mcp/messages?session_id={session_id}"
+
+        gen = sse_stream(session_id, queue, endpoint_url, store)
+        first_chunk = await gen.__anext__()
+
+        assert "event: endpoint" in first_chunk
+        assert endpoint_url in first_chunk
+
+        # Sentinel to stop the generator cleanly
+        await queue.put(None)
+        await gen.aclose()
+
+    @pytest.mark.asyncio
+    async def test_sse_stream_delivers_message_events(self):
+        """sse_stream must yield 'message' events for payloads placed in the queue."""
+        from agent_hypervisor.hypervisor.mcp_gateway.sse_transport import (
+            SSESessionStore, sse_stream,
+        )
+        import asyncio
+
+        store = SSESessionStore()
+        session_id, queue = store.create_session()
+        gen = sse_stream(session_id, queue, "/ep", store)
+
+        # Consume endpoint event
+        await gen.__anext__()
+
+        # Put a payload in the queue
+        payload = json.dumps({"jsonrpc": "2.0", "id": 1, "result": {"ok": True}})
+        await queue.put(payload)
+        message_chunk = await gen.__anext__()
+
+        assert "event: message" in message_chunk
+        assert payload in message_chunk
+
+        await queue.put(None)
+        await gen.aclose()
+
+    @pytest.mark.asyncio
+    async def test_sse_stream_cleanup_on_sentinel(self):
+        """sse_stream must remove the session from the store when sentinel is received."""
+        from agent_hypervisor.hypervisor.mcp_gateway.sse_transport import (
+            SSESessionStore, sse_stream,
+        )
+        import asyncio
+
+        store = SSESessionStore()
+        session_id, queue = store.create_session()
+        gen = sse_stream(session_id, queue, "/ep", store)
+
+        await gen.__anext__()  # endpoint event
+        assert store.get_queue(session_id) is not None
+
+        await queue.put(None)  # sentinel
+        try:
+            await gen.__anext__()
+        except StopAsyncIteration:
+            pass
+
+        assert store.get_queue(session_id) is None
+
+    # --- HTTP endpoint tests ---
+
+    def test_sse_endpoints_registered_and_store_initialized(self, tmp_path):
+        """
+        GET /mcp/sse and POST /mcp/messages must be registered as routes.
+        The app must initialize an SSESessionStore on app.state.sse_store.
+
+        Note: httpx ASGI transport collects the entire response body before
+        returning headers, making it unsuitable for testing infinite SSE streams.
+        The actual streaming format is covered by the sse_stream generator tests.
+        """
+        from agent_hypervisor.hypervisor.mcp_gateway import create_mcp_app
+
+        manifest_file = tmp_path / "world.yaml"
+        manifest_file.write_text(
+            "workflow_id: sse-route-test\ncapabilities:\n  - tool: read_file\n"
+        )
+        app = create_mcp_app(manifest_file)
+
+        route_paths = {r.path for r in app.routes if hasattr(r, "path")}
+        assert "/mcp/sse" in route_paths, f"Missing /mcp/sse in routes: {route_paths}"
+        assert "/mcp/messages" in route_paths, \
+            f"Missing /mcp/messages in routes: {route_paths}"
+
+        assert hasattr(app.state, "sse_store"), "app.state.sse_store not initialized"
+        assert app.state.sse_store.session_count() == 0
+
+    @pytest.mark.asyncio
+    async def test_sse_messages_unknown_session_returns_404(self, sse_client):
+        """POST /mcp/messages with an unknown session_id must return 404."""
+        async with sse_client as c:
+            resp = await c.post(
+                "/mcp/messages?session_id=nonexistent",
+                json={"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {}},
+            )
+        assert resp.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_sse_full_round_trip_via_queue(self, sse_client):
+        """
+        Full SSE round-trip via direct queue inspection.
+
+        Directly registers a session in the SSE store (simulating GET /mcp/sse)
+        and posts a request to POST /mcp/messages. Verifies that the response
+        is placed in the session queue — i.e., it would have been delivered
+        over the SSE stream.
+
+        This tests the dispatch+routing logic without needing to stream SSE
+        events (which requires a real HTTP server for clean async semantics).
+        """
+        from httpx import AsyncClient, ASGITransport
+        import asyncio
+
+        app = sse_client._transport.app  # type: ignore[attr-defined]
+        store = app.state.sse_store
+
+        # Simulate GET /mcp/sse: register a session in the store
+        session_id, queue = store.create_session()
+        try:
+            c = AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+            # POST the initialize request via SSE messages endpoint
+            post_resp = await c.post(
+                f"/mcp/messages?session_id={session_id}",
+                json={"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {}},
+            )
+            await c.aclose()
+
+            assert post_resp.status_code == 202
+            assert post_resp.json()["status"] == "accepted"
+
+            # Response must be in the queue (would have gone to SSE stream)
+            assert not queue.empty(), "Response was not placed in SSE queue"
+            payload = queue.get_nowait()
+            data = json.loads(payload)
+            assert "result" in data, f"Expected result, got: {data}"
+            assert "capabilities" in data["result"]
+            assert "serverInfo" in data["result"]
+        finally:
+            store.remove_session(session_id)
+
+    @pytest.mark.asyncio
+    async def test_sse_tool_denial_delivered_to_queue(self, sse_client):
+        """
+        tools/call to an undeclared tool must route a JSON-RPC error to the
+        SSE queue — i.e., it would have been delivered over the SSE stream.
+
+        HTTP response must be 202 Accepted (the denial is in the SSE stream).
+        """
+        from httpx import AsyncClient, ASGITransport
+
+        app = sse_client._transport.app  # type: ignore[attr-defined]
+        store = app.state.sse_store
+
+        session_id, queue = store.create_session()
+        try:
+            c = AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+            post_resp = await c.post(
+                f"/mcp/messages?session_id={session_id}",
+                json={
+                    "jsonrpc": "2.0", "id": 2, "method": "tools/call",
+                    "params": {"name": "http_post", "arguments": {"url": "http://x"}},
+                },
+            )
+            await c.aclose()
+
+            # HTTP level: always 202 for SSE transport (denial goes over stream)
+            assert post_resp.status_code == 202
+
+            assert not queue.empty(), "No response in SSE queue"
+            payload = queue.get_nowait()
+            data = json.loads(payload)
+            assert "error" in data, f"Expected error in SSE queue payload, got: {data}"
+            assert data["error"]["code"] in (-32001, -32002)
+        finally:
+            store.remove_session(session_id)

--- a/tests/hypervisor/test_mcp_gateway.py
+++ b/tests/hypervisor/test_mcp_gateway.py
@@ -513,3 +513,265 @@ class TestPolicyEngineIntegration:
         app = create_mcp_app(manifest_file, policy_engine=custom_engine, use_default_policy=True)
         gw = app.state.gw
         assert gw.policy_engine is custom_engine
+
+
+# ---------------------------------------------------------------------------
+# Group 6: Per-session manifest bindings
+# ---------------------------------------------------------------------------
+
+class TestPerSessionManifests:
+    """
+    Tests for per-session WorldManifest bindings.
+
+    Core invariant: different sessions can operate in different worlds
+    simultaneously. Sessions without an explicit binding fall back to the
+    gateway-level default.
+    """
+
+    def _write_manifest(self, path, workflow_id: str, tools: list[str]) -> None:
+        caps = "\n".join(f"  - tool: {t}" for t in tools)
+        path.write_text(f"workflow_id: {workflow_id}\ncapabilities:\n{caps}\n")
+
+    # --- SessionWorldResolver unit tests ---
+
+    def test_unregistered_session_gets_default(self, tmp_path):
+        """Sessions without a binding must use the default manifest."""
+        from agent_hypervisor.hypervisor.mcp_gateway import SessionWorldResolver
+        default_file = tmp_path / "default.yaml"
+        self._write_manifest(default_file, "default-world", ["read_file"])
+        resolver = SessionWorldResolver(default_file)
+
+        manifest = resolver.resolve(session_id="unknown-session")
+        assert manifest.workflow_id == "default-world"
+
+    def test_registered_session_gets_own_manifest(self, tmp_path):
+        """A session with a registered manifest must receive that manifest."""
+        from agent_hypervisor.hypervisor.mcp_gateway import SessionWorldResolver
+        default_file = tmp_path / "default.yaml"
+        session_file = tmp_path / "session.yaml"
+        self._write_manifest(default_file, "default-world", ["read_file"])
+        self._write_manifest(session_file, "session-world", ["send_email"])
+        resolver = SessionWorldResolver(default_file)
+
+        resolver.register_session("s1", session_file)
+        manifest = resolver.resolve(session_id="s1")
+        assert manifest.workflow_id == "session-world"
+
+    def test_registered_session_does_not_affect_other_sessions(self, tmp_path):
+        """Per-session binding must not affect sessions without a binding."""
+        from agent_hypervisor.hypervisor.mcp_gateway import SessionWorldResolver
+        default_file = tmp_path / "default.yaml"
+        session_file = tmp_path / "session.yaml"
+        self._write_manifest(default_file, "default-world", ["read_file"])
+        self._write_manifest(session_file, "session-world", ["send_email"])
+        resolver = SessionWorldResolver(default_file)
+
+        resolver.register_session("s1", session_file)
+        assert resolver.resolve(session_id="s2").workflow_id == "default-world"
+        assert resolver.resolve(session_id=None).workflow_id == "default-world"
+
+    def test_unregister_session_reverts_to_default(self, tmp_path):
+        """Unregistering a session must revert it to the default manifest."""
+        from agent_hypervisor.hypervisor.mcp_gateway import SessionWorldResolver
+        default_file = tmp_path / "default.yaml"
+        session_file = tmp_path / "session.yaml"
+        self._write_manifest(default_file, "default-world", ["read_file"])
+        self._write_manifest(session_file, "session-world", ["send_email"])
+        resolver = SessionWorldResolver(default_file)
+
+        resolver.register_session("s1", session_file)
+        assert resolver.resolve(session_id="s1").workflow_id == "session-world"
+
+        removed = resolver.unregister_session("s1")
+        assert removed is True
+        assert resolver.resolve(session_id="s1").workflow_id == "default-world"
+
+    def test_unregister_nonexistent_session_is_idempotent(self, tmp_path):
+        """Unregistering a session that was never bound must return False safely."""
+        from agent_hypervisor.hypervisor.mcp_gateway import SessionWorldResolver
+        default_file = tmp_path / "default.yaml"
+        self._write_manifest(default_file, "default-world", ["read_file"])
+        resolver = SessionWorldResolver(default_file)
+
+        removed = resolver.unregister_session("does-not-exist")
+        assert removed is False
+
+    def test_register_session_fails_closed_on_bad_manifest(self, tmp_path):
+        """register_session must raise and NOT register if the manifest is invalid."""
+        from agent_hypervisor.hypervisor.mcp_gateway import SessionWorldResolver
+        default_file = tmp_path / "default.yaml"
+        bad_file = tmp_path / "bad.yaml"
+        self._write_manifest(default_file, "default-world", ["read_file"])
+        bad_file.write_text("this: [is: invalid yaml:\n")
+        resolver = SessionWorldResolver(default_file)
+
+        with pytest.raises(Exception):
+            resolver.register_session("s1", bad_file)
+
+        # Session must NOT have been registered
+        assert resolver.resolve(session_id="s1").workflow_id == "default-world"
+
+    def test_session_registry_returns_snapshot(self, tmp_path):
+        """session_registry() must return a snapshot of current bindings."""
+        from agent_hypervisor.hypervisor.mcp_gateway import SessionWorldResolver
+        default_file = tmp_path / "default.yaml"
+        s1_file = tmp_path / "s1.yaml"
+        s2_file = tmp_path / "s2.yaml"
+        self._write_manifest(default_file, "default-world", ["read_file"])
+        self._write_manifest(s1_file, "world-s1", ["send_email"])
+        self._write_manifest(s2_file, "world-s2", ["read_file"])
+        resolver = SessionWorldResolver(default_file)
+
+        resolver.register_session("alice", s1_file)
+        resolver.register_session("bob", s2_file)
+        registry = resolver.session_registry()
+
+        assert registry == {"alice": "world-s1", "bob": "world-s2"}
+
+    # --- HTTP endpoint tests ---
+
+    @pytest.fixture
+    def two_world_client(self, tmp_path):
+        """
+        Client with a gateway that has two manifests on disk:
+          - default_world.yaml: read_file only
+          - email_world.yaml: send_email only
+        """
+        pytest.importorskip("httpx")
+        from httpx import AsyncClient, ASGITransport
+        from agent_hypervisor.hypervisor.mcp_gateway import create_mcp_app
+
+        default_file = tmp_path / "default_world.yaml"
+        email_file = tmp_path / "email_world.yaml"
+        self._write_manifest(default_file, "default-world", ["read_file"])
+        self._write_manifest(email_file, "email-world", ["send_email"])
+
+        app = create_mcp_app(default_file)
+        # Attach paths for use in tests
+        app.state.email_manifest_path = str(email_file)
+        client = AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+        return client
+
+    @pytest.mark.asyncio
+    async def test_bind_session_changes_visible_tools(self, two_world_client):
+        """After binding, tools/list for that session must show the bound world's tools."""
+        async with two_world_client as c:
+            email_path = c._transport.app.state.email_manifest_path
+
+            # Bind session "s1" to email world
+            bind_resp = await c.post(
+                "/mcp/sessions/s1/bind",
+                json={"manifest_path": email_path},
+            )
+            assert bind_resp.status_code == 200
+            bind_data = bind_resp.json()
+            assert bind_data["status"] == "bound"
+            assert bind_data["workflow_id"] == "email-world"
+            assert "send_email" in bind_data["visible_tools"]
+
+            # tools/list with session s1 must show send_email
+            tools_resp = await c.post(
+                "/mcp",
+                json={"jsonrpc": "2.0", "id": 1, "method": "tools/list", "params": {
+                    "_meta": {"session_id": "s1"}
+                }},
+            )
+            assert tools_resp.status_code == 200
+            tool_names = [t["name"] for t in tools_resp.json()["result"]["tools"]]
+            assert "send_email" in tool_names
+            assert "read_file" not in tool_names
+
+    @pytest.mark.asyncio
+    async def test_session_binding_does_not_affect_default(self, two_world_client):
+        """Binding one session must not change another session's visible tools."""
+        async with two_world_client as c:
+            email_path = c._transport.app.state.email_manifest_path
+
+            # Bind session "s1" to email world
+            await c.post("/mcp/sessions/s1/bind", json={"manifest_path": email_path})
+
+            # tools/list without session_id still shows default world
+            tools_resp = await c.post(
+                "/mcp",
+                json={"jsonrpc": "2.0", "id": 2, "method": "tools/list", "params": {}},
+            )
+            tool_names = [t["name"] for t in tools_resp.json()["result"]["tools"]]
+            assert "read_file" in tool_names
+            assert "send_email" not in tool_names
+
+    @pytest.mark.asyncio
+    async def test_unbind_session_reverts_to_default(self, two_world_client):
+        """DELETE /mcp/sessions/{id} must revert the session to the default world."""
+        async with two_world_client as c:
+            email_path = c._transport.app.state.email_manifest_path
+
+            # Bind then unbind
+            await c.post("/mcp/sessions/s1/bind", json={"manifest_path": email_path})
+            del_resp = await c.delete("/mcp/sessions/s1")
+            assert del_resp.status_code == 200
+            assert del_resp.json()["status"] == "unbound"
+
+            # tools/list for s1 must now show default world
+            tools_resp = await c.post(
+                "/mcp",
+                json={"jsonrpc": "2.0", "id": 3, "method": "tools/list", "params": {
+                    "_meta": {"session_id": "s1"}
+                }},
+            )
+            tool_names = [t["name"] for t in tools_resp.json()["result"]["tools"]]
+            assert "read_file" in tool_names
+            assert "send_email" not in tool_names
+
+    @pytest.mark.asyncio
+    async def test_list_sessions_endpoint(self, two_world_client):
+        """GET /mcp/sessions must list all active bindings."""
+        async with two_world_client as c:
+            email_path = c._transport.app.state.email_manifest_path
+
+            # Initially empty
+            list_resp = await c.get("/mcp/sessions")
+            assert list_resp.status_code == 200
+            data = list_resp.json()
+            assert data["session_count"] == 0
+            assert data["sessions"] == {}
+
+            # Bind a session
+            await c.post("/mcp/sessions/alice/bind", json={"manifest_path": email_path})
+
+            list_resp2 = await c.get("/mcp/sessions")
+            data2 = list_resp2.json()
+            assert data2["session_count"] == 1
+            assert data2["sessions"]["alice"] == "email-world"
+
+    @pytest.mark.asyncio
+    async def test_bind_bad_manifest_returns_400(self, two_world_client):
+        """Binding a session to a nonexistent manifest must return 400 (fail closed)."""
+        async with two_world_client as c:
+            resp = await c.post(
+                "/mcp/sessions/s1/bind",
+                json={"manifest_path": "/nonexistent/path/manifest.yaml"},
+            )
+            assert resp.status_code == 400
+            assert resp.json()["status"] == "error"
+
+    @pytest.mark.asyncio
+    async def test_session_tool_call_enforced_against_session_world(self, two_world_client):
+        """tools/call must be enforced against the session's bound manifest."""
+        async with two_world_client as c:
+            email_path = c._transport.app.state.email_manifest_path
+
+            # Bind s1 to email world (only send_email)
+            await c.post("/mcp/sessions/s1/bind", json={"manifest_path": email_path})
+
+            # read_file is not in email world → must be denied for s1
+            call_resp = await c.post(
+                "/mcp",
+                json={"jsonrpc": "2.0", "id": 4, "method": "tools/call", "params": {
+                    "name": "read_file",
+                    "arguments": {"path": "/tmp/x.txt"},
+                    "_meta": {"session_id": "s1"},
+                }},
+            )
+            data = call_resp.json()
+            assert "error" in data, f"Expected denial for s1, got: {data}"
+            assert data["error"]["code"] in (-32001, -32002)

--- a/tests/hypervisor/test_taint_propagation.py
+++ b/tests/hypervisor/test_taint_propagation.py
@@ -1,0 +1,435 @@
+"""
+test_taint_propagation.py — Tests for taint propagation through the MCP gateway.
+
+Verifies that the connection between InvocationProvenance.trust_level and the
+runtime TaintContext is correctly enforced by the ToolCallEnforcer, and that
+tool results carry the correct taint state.
+
+Core invariants:
+  1. "trusted" provenance → CLEAN taint (TaintContext.clean())
+  2. "untrusted" provenance → TAINTED taint
+  3. "derived" provenance → TAINTED taint (derived from external = still tainted)
+  4. Unknown/empty trust_level → TAINTED (conservative default)
+  5. Taint is included in every EnforcementDecision (never None)
+  6. Denied decisions carry taint from the provenance (not overridden)
+  7. Tool results in the HTTP response include _taint metadata
+  8. Taint is monotonic: allowed+TAINTED is still TAINTED after join
+
+These tests guard the architectural invariant: values flowing from
+untrusted MCP clients into the system cannot silently lose their taint.
+"""
+
+from __future__ import annotations
+
+import json
+import pytest
+from pathlib import Path
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_manifest(tool_names: list[str]):
+    from agent_hypervisor.compiler.schema import WorldManifest, CapabilityConstraint
+    return WorldManifest(
+        workflow_id="taint-test-world",
+        version="1.0",
+        capabilities=[CapabilityConstraint(tool=name) for name in tool_names],
+    )
+
+
+def _make_registry(tool_names: list[str]):
+    from agent_hypervisor.hypervisor.gateway.tool_registry import build_default_registry
+    return build_default_registry(tool_names)
+
+
+def _make_provenance(trust_level: str = "untrusted", session_id: str = ""):
+    from agent_hypervisor.hypervisor.mcp_gateway import InvocationProvenance
+    return InvocationProvenance(
+        source="test",
+        session_id=session_id,
+        trust_level=trust_level,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Group A: TaintContext derivation from InvocationProvenance
+# ---------------------------------------------------------------------------
+
+class TestTaintContextFromProvenance:
+    """Unit tests for _taint_context_from_provenance()."""
+
+    def test_trusted_provenance_produces_clean_taint(self):
+        """trust_level='trusted' must produce TaintContext with CLEAN taint."""
+        from agent_hypervisor.hypervisor.mcp_gateway.tool_call_enforcer import (
+            _taint_context_from_provenance, InvocationProvenance
+        )
+        from agent_hypervisor.runtime.models import TaintState
+
+        prov = InvocationProvenance(trust_level="trusted")
+        ctx = _taint_context_from_provenance(prov)
+        assert ctx.taint == TaintState.CLEAN
+
+    def test_untrusted_provenance_produces_tainted(self):
+        """trust_level='untrusted' must produce TaintContext with TAINTED taint."""
+        from agent_hypervisor.hypervisor.mcp_gateway.tool_call_enforcer import (
+            _taint_context_from_provenance, InvocationProvenance
+        )
+        from agent_hypervisor.runtime.models import TaintState
+
+        prov = InvocationProvenance(trust_level="untrusted")
+        ctx = _taint_context_from_provenance(prov)
+        assert ctx.taint == TaintState.TAINTED
+
+    def test_derived_provenance_produces_tainted(self):
+        """trust_level='derived' must produce TAINTED (derived from external source)."""
+        from agent_hypervisor.hypervisor.mcp_gateway.tool_call_enforcer import (
+            _taint_context_from_provenance, InvocationProvenance
+        )
+        from agent_hypervisor.runtime.models import TaintState
+
+        prov = InvocationProvenance(trust_level="derived")
+        ctx = _taint_context_from_provenance(prov)
+        assert ctx.taint == TaintState.TAINTED
+
+    def test_unknown_trust_level_produces_tainted(self):
+        """Unknown trust_level must default to TAINTED (conservative)."""
+        from agent_hypervisor.hypervisor.mcp_gateway.tool_call_enforcer import (
+            _taint_context_from_provenance, InvocationProvenance
+        )
+        from agent_hypervisor.runtime.models import TaintState
+
+        prov = InvocationProvenance(trust_level="some_new_level_we_dont_know")
+        ctx = _taint_context_from_provenance(prov)
+        assert ctx.taint == TaintState.TAINTED
+
+    def test_empty_trust_level_produces_tainted(self):
+        """Empty trust_level string must produce TAINTED."""
+        from agent_hypervisor.hypervisor.mcp_gateway.tool_call_enforcer import (
+            _taint_context_from_provenance, InvocationProvenance
+        )
+        from agent_hypervisor.runtime.models import TaintState
+
+        prov = InvocationProvenance(trust_level="")
+        ctx = _taint_context_from_provenance(prov)
+        assert ctx.taint == TaintState.TAINTED
+
+    def test_default_provenance_is_tainted(self):
+        """Default InvocationProvenance (no args) must produce TAINTED."""
+        from agent_hypervisor.hypervisor.mcp_gateway.tool_call_enforcer import (
+            _taint_context_from_provenance, InvocationProvenance
+        )
+        from agent_hypervisor.runtime.models import TaintState
+
+        prov = InvocationProvenance()  # default trust_level = "untrusted"
+        ctx = _taint_context_from_provenance(prov)
+        assert ctx.taint == TaintState.TAINTED
+
+
+# ---------------------------------------------------------------------------
+# Group B: EnforcementDecision carries taint
+# ---------------------------------------------------------------------------
+
+class TestEnforcementDecisionTaint:
+    """Verify taint_context is always set in EnforcementDecision."""
+
+    def test_allowed_trusted_decision_has_clean_taint(self):
+        """An allowed call from a trusted source must carry CLEAN taint."""
+        from agent_hypervisor.hypervisor.mcp_gateway import ToolCallEnforcer
+        from agent_hypervisor.runtime.models import TaintState
+
+        manifest = _make_manifest(["read_file"])
+        registry = _make_registry(["read_file"])
+        enforcer = ToolCallEnforcer(manifest, registry)
+        prov = _make_provenance(trust_level="trusted")
+
+        decision = enforcer.enforce("read_file", {"path": "/tmp/x"}, prov)
+
+        assert decision.allowed
+        assert decision.taint_state == TaintState.CLEAN
+
+    def test_allowed_untrusted_decision_has_tainted_taint(self):
+        """An allowed call from an untrusted source must carry TAINTED taint."""
+        from agent_hypervisor.hypervisor.mcp_gateway import ToolCallEnforcer
+        from agent_hypervisor.runtime.models import TaintState
+
+        manifest = _make_manifest(["read_file"])
+        registry = _make_registry(["read_file"])
+        enforcer = ToolCallEnforcer(manifest, registry)
+        prov = _make_provenance(trust_level="untrusted")
+
+        decision = enforcer.enforce("read_file", {"path": "/tmp/x"}, prov)
+
+        assert decision.allowed
+        assert decision.taint_state == TaintState.TAINTED
+
+    def test_denied_undeclared_tool_carries_taint(self):
+        """A denied (undeclared tool) decision must still carry taint from provenance."""
+        from agent_hypervisor.hypervisor.mcp_gateway import ToolCallEnforcer
+        from agent_hypervisor.runtime.models import TaintState
+
+        manifest = _make_manifest([])  # empty world
+        registry = _make_registry(["send_email"])
+        enforcer = ToolCallEnforcer(manifest, registry)
+        prov = _make_provenance(trust_level="untrusted")
+
+        decision = enforcer.enforce("send_email", {}, prov)
+
+        assert decision.denied
+        assert decision.taint_state == TaintState.TAINTED
+
+    def test_denied_trusted_caller_still_carries_clean_taint(self):
+        """Even a denied call from a trusted caller carries the trust taint (CLEAN)."""
+        from agent_hypervisor.hypervisor.mcp_gateway import ToolCallEnforcer
+        from agent_hypervisor.runtime.models import TaintState
+
+        # Tool not in manifest — denied
+        manifest = _make_manifest([])
+        registry = _make_registry(["read_file"])
+        enforcer = ToolCallEnforcer(manifest, registry)
+        prov = _make_provenance(trust_level="trusted")
+
+        decision = enforcer.enforce("read_file", {}, prov)
+
+        assert decision.denied
+        # The taint reflects the caller's trust level, not the denial outcome
+        assert decision.taint_state == TaintState.CLEAN
+
+    def test_taint_context_is_never_none(self):
+        """taint_context must never be None — it must always be a TaintContext."""
+        from agent_hypervisor.hypervisor.mcp_gateway import ToolCallEnforcer, InvocationProvenance
+        from agent_hypervisor.runtime.taint import TaintContext
+
+        manifest = _make_manifest(["read_file"])
+        registry = _make_registry(["read_file"])
+        enforcer = ToolCallEnforcer(manifest, registry)
+
+        # No provenance passed — must still have taint_context
+        d1 = enforcer.enforce("read_file", {})
+        assert isinstance(d1.taint_context, TaintContext)
+
+        # Explicit untrusted
+        d2 = enforcer.enforce("read_file", {}, InvocationProvenance())
+        assert isinstance(d2.taint_context, TaintContext)
+
+    def test_enforce_never_raises_with_taint(self):
+        """enforce() must never raise even with unusual provenance values."""
+        from agent_hypervisor.hypervisor.mcp_gateway import ToolCallEnforcer, InvocationProvenance
+
+        manifest = _make_manifest(["read_file"])
+        registry = _make_registry(["read_file"])
+        enforcer = ToolCallEnforcer(manifest, registry)
+
+        # Edge cases
+        d1 = enforcer.enforce("", {}, InvocationProvenance(trust_level="trusted"))
+        d2 = enforcer.enforce("read_file", None or {}, InvocationProvenance(trust_level=""))
+        d3 = enforcer.enforce("ghost", {})
+
+        # All must have taint_context set
+        assert d1.taint_context is not None
+        assert d2.taint_context is not None
+        assert d3.taint_context is not None
+
+
+# ---------------------------------------------------------------------------
+# Group C: Taint monotonicity
+# ---------------------------------------------------------------------------
+
+class TestTaintMonotonicity:
+    """
+    Verify that taint is monotonic through the TaintedValue join operations.
+
+    These tests use TaintedValue.join() and TaintContext.from_outputs() to verify
+    that taint from a gateway decision propagates correctly into downstream
+    operations via the runtime taint primitives.
+    """
+
+    def test_clean_join_clean_is_clean(self):
+        """CLEAN ∨ CLEAN = CLEAN."""
+        from agent_hypervisor.runtime.taint import TaintedValue, TaintContext
+        from agent_hypervisor.runtime.models import TaintState
+
+        tv1 = TaintedValue(value="a", taint=TaintState.CLEAN)
+        tv2 = TaintedValue(value="b", taint=TaintState.CLEAN)
+        ctx = TaintContext.from_outputs(tv1, tv2)
+        assert ctx.taint == TaintState.CLEAN
+
+    def test_tainted_join_clean_is_tainted(self):
+        """TAINTED ∨ CLEAN = TAINTED (monotonic)."""
+        from agent_hypervisor.runtime.taint import TaintedValue, TaintContext
+        from agent_hypervisor.runtime.models import TaintState
+
+        tv1 = TaintedValue(value="a", taint=TaintState.TAINTED)
+        tv2 = TaintedValue(value="b", taint=TaintState.CLEAN)
+        ctx = TaintContext.from_outputs(tv1, tv2)
+        assert ctx.taint == TaintState.TAINTED
+
+    def test_gateway_taint_flows_into_downstream_context(self):
+        """
+        TaintedValue wrapping a gateway tool result must propagate into
+        downstream TaintContext via from_outputs().
+
+        Simulates: untrusted MCP call → tool result → wrapped in TaintedValue
+        → used in downstream operation → TaintContext.from_outputs captures taint.
+        """
+        from agent_hypervisor.hypervisor.mcp_gateway import ToolCallEnforcer
+        from agent_hypervisor.runtime.taint import TaintedValue, TaintContext
+        from agent_hypervisor.runtime.models import TaintState
+
+        manifest = _make_manifest(["read_file"])
+        registry = _make_registry(["read_file"])
+        enforcer = ToolCallEnforcer(manifest, registry)
+        prov = _make_provenance(trust_level="untrusted")
+
+        decision = enforcer.enforce("read_file", {"path": "/tmp/x"}, prov)
+        assert decision.allowed
+
+        # Simulate wrapping the tool result with taint from decision
+        tool_result = TaintedValue(value="file contents", taint=decision.taint_state)
+        assert tool_result.taint == TaintState.TAINTED
+
+        # Downstream operation must carry the taint
+        downstream_ctx = TaintContext.from_outputs(tool_result)
+        assert downstream_ctx.taint == TaintState.TAINTED
+
+    def test_trusted_gateway_result_stays_clean_in_downstream(self):
+        """
+        Tool result from a trusted caller must produce CLEAN downstream context.
+        """
+        from agent_hypervisor.hypervisor.mcp_gateway import ToolCallEnforcer
+        from agent_hypervisor.runtime.taint import TaintedValue, TaintContext
+        from agent_hypervisor.runtime.models import TaintState
+
+        manifest = _make_manifest(["read_file"])
+        registry = _make_registry(["read_file"])
+        enforcer = ToolCallEnforcer(manifest, registry)
+        prov = _make_provenance(trust_level="trusted")
+
+        decision = enforcer.enforce("read_file", {"path": "/tmp/x"}, prov)
+        assert decision.allowed
+
+        tool_result = TaintedValue(value="file contents", taint=decision.taint_state)
+        assert tool_result.taint == TaintState.CLEAN
+
+        downstream_ctx = TaintContext.from_outputs(tool_result)
+        assert downstream_ctx.taint == TaintState.CLEAN
+
+    def test_taint_cannot_be_reduced_once_set(self):
+        """
+        Joining a TAINTED result with another CLEAN result must still be TAINTED.
+        Taint cannot be diluted by mixing with clean values.
+        """
+        from agent_hypervisor.runtime.taint import TaintedValue, TaintContext
+        from agent_hypervisor.runtime.models import TaintState
+
+        tainted = TaintedValue(value="from untrusted source", taint=TaintState.TAINTED)
+        clean = TaintedValue(value="from trusted source", taint=TaintState.CLEAN)
+
+        # Any mixture involving TAINTED must remain TAINTED
+        ctx = TaintContext.from_outputs(tainted, clean)
+        assert ctx.taint == TaintState.TAINTED
+
+
+# ---------------------------------------------------------------------------
+# Group D: HTTP integration — _taint in tool result
+# ---------------------------------------------------------------------------
+
+class TestTaintInHTTPResponse:
+    """
+    Verify that the MCP HTTP endpoint includes _taint metadata in tool results.
+
+    The _taint field in the result dict lets MCP clients and audit tools
+    observe the taint state of each tool invocation.
+    """
+
+    @pytest.fixture
+    def client(self, tmp_path):
+        pytest.importorskip("httpx")
+        from httpx import AsyncClient, ASGITransport
+        from agent_hypervisor.hypervisor.mcp_gateway import create_mcp_app
+
+        manifest_file = tmp_path / "world.yaml"
+        manifest_file.write_text(
+            "workflow_id: taint-http-test\ncapabilities:\n  - tool: read_file\n"
+        )
+        app = create_mcp_app(manifest_file)
+        return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+    @pytest.mark.asyncio
+    async def test_untrusted_result_carries_tainted_metadata(self, client):
+        """
+        tools/call from an untrusted client must return _taint='tainted'.
+        """
+        import tempfile, os
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".txt", delete=False) as f:
+            f.write("hello")
+            tmp_path = f.name
+        try:
+            payload = {
+                "jsonrpc": "2.0", "id": 1, "method": "tools/call",
+                "params": {
+                    "name": "read_file",
+                    "arguments": {"path": tmp_path},
+                    # No _meta.trust_level → defaults to "untrusted"
+                },
+            }
+            async with client as c:
+                resp = await c.post("/mcp", json=payload)
+            data = resp.json()
+            assert "result" in data, f"Expected result, got: {data}"
+            assert data["result"]["_taint"] == "tainted"
+        finally:
+            os.unlink(tmp_path)
+
+    @pytest.mark.asyncio
+    async def test_trusted_result_carries_clean_metadata(self, client):
+        """
+        tools/call from a trusted client must return _taint='clean'.
+        """
+        import tempfile, os
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".txt", delete=False) as f:
+            f.write("hello")
+            tmp_path = f.name
+        try:
+            payload = {
+                "jsonrpc": "2.0", "id": 2, "method": "tools/call",
+                "params": {
+                    "name": "read_file",
+                    "arguments": {"path": tmp_path},
+                    "_meta": {"trust_level": "trusted"},
+                },
+            }
+            async with client as c:
+                resp = await c.post("/mcp", json=payload)
+            data = resp.json()
+            assert "result" in data, f"Expected result, got: {data}"
+            assert data["result"]["_taint"] == "clean"
+        finally:
+            os.unlink(tmp_path)
+
+    @pytest.mark.asyncio
+    async def test_taint_is_deterministic_for_same_trust_level(self, client):
+        """
+        Same trust_level must always produce the same _taint value (deterministic).
+        """
+        import tempfile, os
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".txt", delete=False) as f:
+            f.write("hello")
+            tmp_path = f.name
+        try:
+            async with client as c:
+                taints = []
+                for _ in range(5):
+                    resp = await c.post("/mcp", json={
+                        "jsonrpc": "2.0", "id": 1, "method": "tools/call",
+                        "params": {
+                            "name": "read_file",
+                            "arguments": {"path": tmp_path},
+                        },
+                    })
+                    taints.append(resp.json()["result"]["_taint"])
+            assert len(set(taints)) == 1, f"Non-deterministic taint values: {taints}"
+            assert taints[0] == "tainted"  # default trust_level is untrusted
+        finally:
+            os.unlink(tmp_path)


### PR DESCRIPTION
Different sessions (agents/users) can now operate in different worlds
simultaneously without gateway restart. Sessions without an explicit
binding continue to use the gateway-level default manifest.

Changes:
- SessionWorldResolver: add register_session(), unregister_session(),
  session_registry() — per-session manifest loading, fail-closed on
  invalid manifest (session never registered on error)
- mcp_server.py: tools/list and tools/call now resolve per-session
  manifest via provenance.session_id; cached default renderer/enforcer
  used for the common (unbound) path, built on-the-fly for session
  overrides
- New endpoints:
    POST   /mcp/sessions/{session_id}/bind  — bind session to manifest
    DELETE /mcp/sessions/{session_id}       — unbind (revert to default)
    GET    /mcp/sessions                    — list active bindings
- Group 6: 13 new tests (7 unit, 6 HTTP integration), all passing

Test results: 45 passed (was 32).

https://claude.ai/code/session_01UrGopxgkDB1FiZFSqLtKCf