### PR TITLE
feat(phase8): implement multi-scope approval system

### DIFF
--- a/docs/implementation/CONTROL_PLANE_PLAN.md
+++ b/docs/implementation/CONTROL_PLANE_PLAN.md
@@ -109,6 +109,36 @@ Files modified:
 Files created:
 - `tests/hypervisor/test_gateway_wiring.py` — 23 integration tests
 
+### Phase 8 — Multi-Scope Approval System ✅
+**Branch**: `claude/phase-8-multi-scope-approvals-irzP0`
+
+Files modified:
+- `src/agent_hypervisor/control_plane/domain.py`
+  - Added `APPROVAL_SCOPE_ONE_OFF / SESSION / WORLD` constants
+  - Added `APPROVAL_STATUS_PARTIALLY_RESOLVED / RESOLVED` constants
+  - Added `ScopedVerdict` dataclass: `{scope, verdict, participant_id, timestamp}`
+  - Added `ParticipantRegistration` dataclass: `{participant_id, session_id, roles}`
+  - Extended `ActionApproval` with `scoped_verdicts: list[ScopedVerdict]`
+- `src/agent_hypervisor/control_plane/approval_service.py`
+  - Added `respond()`: scoped verdict processing with idempotency and side effects
+  - Added `has_explicit_allow()`: stricter check for gateway pre-check
+  - Updated `check_expired()` to sweep `partially_resolved` approvals
+- `src/agent_hypervisor/control_plane/api.py`
+  - `ControlPlaneState` now includes `participant_registry` and `broadcaster` fields
+  - New endpoints: `POST/DELETE/GET /control/participants`, `PATCH /control/approvals/{id}/respond`
+  - `POST /control/approvals/{id}/resolve` retained for backwards compat
+- `src/agent_hypervisor/hypervisor/mcp_gateway/mcp_server.py`
+  - `create_mcp_app()` wires `broadcaster.set_sse_store(sse_store)` when CP present
+  - `_handle_tools_call()` pre-checks `has_explicit_allow()` before approval workflow
+  - Broadcasts `approval_requested` to participants on new approval creation
+
+Files created:
+- `src/agent_hypervisor/control_plane/participant_registry.py` — ParticipantRegistry
+- `src/agent_hypervisor/control_plane/approval_broadcaster.py` — ApprovalBroadcaster
+- `tests/control_plane/test_phase8.py` — 52 new tests
+
+**Test totals**: 176 passing across all control plane + gateway wiring suites.
+
 ---
 
 ## Non-Goals (this phase)

--- a/docs/implementation/HANDOFF_NOTE.md
+++ b/docs/implementation/HANDOFF_NOTE.md
@@ -1,3 +1,172 @@
+# Handoff Note — Session 11
+
+**Date**: 2026-04-10  
+**Branch**: `claude/phase-8-multi-scope-approvals-irzP0`  
+**Session**: Multi-Scope Approval System (Phase 8)
+
+---
+
+## What Was Done
+
+Implemented the complete multi-scope approval system. A single approval request can
+now receive verdicts at three scopes simultaneously (one_off / session / world), each
+firing its own side effect immediately. The originating session receives an SSE
+notification when any allow verdict arrives, enabling retry without polling.
+
+### Files Modified
+
+```
+src/agent_hypervisor/control_plane/domain.py        ← ScopedVerdict, ParticipantRegistration, new constants
+src/agent_hypervisor/control_plane/approval_service.py  ← respond(), has_explicit_allow()
+src/agent_hypervisor/control_plane/api.py            ← participant endpoints, PATCH /respond, ControlPlaneState
+src/agent_hypervisor/hypervisor/mcp_gateway/mcp_server.py  ← broadcaster wiring, pre-check
+```
+
+### Files Created
+
+```
+src/agent_hypervisor/control_plane/participant_registry.py   ← ParticipantRegistry
+src/agent_hypervisor/control_plane/approval_broadcaster.py   ← ApprovalBroadcaster
+tests/control_plane/test_phase8.py                           ← 52 new tests, all passing
+```
+
+---
+
+## Changes in Detail
+
+### domain.py
+
+- Added `APPROVAL_SCOPE_ONE_OFF`, `APPROVAL_SCOPE_SESSION`, `APPROVAL_SCOPE_WORLD` constants
+- Added `APPROVAL_STATUS_PARTIALLY_RESOLVED`, `APPROVAL_STATUS_RESOLVED` constants
+- Added `ScopedVerdict` dataclass: `{scope, verdict, participant_id, timestamp}`
+- Added `ParticipantRegistration` dataclass: `{participant_id, session_id, roles, registered_at}`
+- Extended `ActionApproval` with `scoped_verdicts: list[ScopedVerdict]` (default empty)
+- Updated `ActionApproval.to_dict()` to include `scoped_verdicts`
+
+### participant_registry.py (new)
+
+- `ParticipantRegistry` — in-memory registry keyed by session_id (SSE session)
+- `register(session_id, roles)` → ParticipantRegistration (upsert semantics)
+- `unregister(session_id)` → bool
+- `get(session_id)` → Optional[ParticipantRegistration]
+- `list_all()` → list sorted by registered_at
+
+### approval_broadcaster.py (new)
+
+- `ApprovalBroadcaster` — fan-out to SSE queues via `put_nowait()` (sync-safe)
+- `set_sse_store(sse_store)` — wired by `create_mcp_app()` after sse_store creation
+- `broadcast_approval_requested(approval, participant_registry)` → int (count notified)
+- `notify_originator(session_id, approval, effective_verdict)` → bool
+- Fail-open: all queue write failures are logged and swallowed
+
+### approval_service.py
+
+- Added `respond(approval_id, verdicts, overlay_service, session_store, event_store)`:
+  - Idempotent per scope (first verdict wins)
+  - one_off allow → recorded; `has_explicit_allow()` returns True for retry
+  - session allow → creates `SessionOverlay(reveal_tools=[tool_name])`
+  - world allow → stub no-op
+  - Expired approval → marks expired, applies no verdicts
+  - Status: `pending` → `partially_resolved` (first verdict) → `resolved` (all 3 scopes)
+  - Raises `RuntimeError` if called on terminal state (resolved/expired/etc.)
+- Added `has_explicit_allow(session_id, tool_name, args)`:
+  - Returns True if status=ALLOWED (old resolve() path) OR one_off allow scoped verdict
+  - Used by gateway pre-check to determine if retry should skip approval workflow
+- Updated `check_expired()` to sweep `partially_resolved` approvals too
+- Preserved `is_action_approved()` (checks PENDING + ALLOWED, backward compat)
+
+### api.py
+
+- Added `participant_registry: ParticipantRegistry` and `broadcaster: ApprovalBroadcaster`
+  to `ControlPlaneState` (with defaults via `field(default_factory=...)`)
+- Updated `ControlPlaneState.create()` to initialize both
+- Added Pydantic models: `RegisterParticipantRequest`, `ScopedVerdictItem`, `RespondToApprovalRequest`
+- Added endpoints:
+  - `POST /control/participants` — register session + roles (upsert)
+  - `DELETE /control/participants/{session_id}` — unregister
+  - `GET /control/participants` — list all
+  - `PATCH /control/approvals/{id}/respond` — submit scoped verdicts; notifies originator on first allow
+- Kept `POST /control/approvals/{id}/resolve` unchanged (backwards compat)
+- Added `_has_allow_verdict()` internal helper
+
+### mcp_server.py
+
+- After mounting control plane router, calls `control_plane.broadcaster.set_sse_store(sse_store)`
+  to wire the broadcaster to the SSE queue registry
+- In `_handle_tools_call()` for `decision.asked`:
+  - Pre-check `has_explicit_allow()` — if True, skip approval workflow and proceed to dispatch
+  - If False, create approval, broadcast to all registered participants (`broadcast_approval_requested()`),
+    return `pending_approval` to caller
+  - Broadcaster failures are caught and swallowed (fail-open)
+
+---
+
+## Current Test Count
+
+```
+pytest tests/control_plane/test_control_plane.py  →  57 passed
+pytest tests/control_plane/test_api.py            →  44 passed
+pytest tests/control_plane/test_phase8.py         →  52 passed
+pytest tests/hypervisor/test_gateway_wiring.py    →  23 passed
+Total: 176 passed, 0 failed
+```
+
+Note: `tests/hypervisor/test_mcp_gateway.py` still has 21 pre-existing failures
+(missing pytest-asyncio). Not caused by Phase 8 changes.
+
+---
+
+## Architecture (Final State — Phase 8)
+
+```
+HTTP Client (participant / operator)
+        ↓
+POST /control/participants  ←  register session_id + roles
+PATCH /control/approvals/{id}/respond  ←  submit scoped verdicts
+
+Approval Request Flow:
+  MCP tool call → verdict=ask → ApprovalService.request_approval()
+        ↓ broadcast_approval_requested()
+  ApprovalBroadcaster → SSE queues of all registered participants
+        ↓ (participants respond via PATCH /respond)
+  ApprovalService.respond()
+    one_off allow → has_explicit_allow() returns True on retry
+    session allow → SessionOverlay created (reveal_tool)
+    world allow   → stub no-op
+        ↓ notify_originator()
+  ApprovalBroadcaster → SSE queue of originating session
+        ↓ (originator retries tool call)
+  _handle_tools_call() → has_explicit_allow() → True → dispatch
+```
+
+---
+
+## Key Invariants Preserved
+
+1. No LLM in enforcement path ✅
+2. Base manifest never mutated at runtime ✅
+3. All runtime world changes are session-scoped overlays ✅
+4. One-off approvals do not widen the world (one_off allow ≠ overlay) ✅
+5. Operator augmentation is explicit and auditable ✅
+6. Unknown capabilities still fail closed ✅
+7. Control plane ≠ data plane ✅
+8. "ask" without control plane still fails closed ✅
+9. Broadcaster failures never crash the enforcement path (fail-open) ✅
+10. Expired approvals always deny, even if scoped_verdicts contain allow ✅
+
+---
+
+## What Remains
+
+1. **Persistent storage** — all stores are in-memory.
+2. **Auth layer** — control plane endpoints have no auth.
+3. **RBAC enforcement** — roles in ParticipantRegistration are informational; the
+   endpoint does not verify that the participant actually holds the role they claim.
+4. **World-scope allow implementation** — currently a stub no-op.
+5. **WebSocket live updates** — operators must poll for overlay changes.
+
+---
+
 # Handoff Note — Session 10
 
 **Date**: 2026-04-09  

--- a/src/agent_hypervisor/control_plane/api.py
+++ b/src/agent_hypervisor/control_plane/api.py
@@ -61,6 +61,7 @@ from fastapi import APIRouter, FastAPI, HTTPException
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 
+from .approval_broadcaster import ApprovalBroadcaster
 from .approval_service import ApprovalService
 from .domain import (
     APPROVAL_STATUS_ALLOWED,
@@ -68,9 +69,11 @@ from .domain import (
     SESSION_MODE_BACKGROUND,
     SESSION_MODE_INTERACTIVE,
     OverlayChanges,
+    ScopedVerdict,
 )
 from .event_store import EventStore, make_session_created, make_session_closed, make_mode_changed
 from .overlay_service import OverlayService
+from .participant_registry import ParticipantRegistry
 from .session_store import SessionStore
 from .world_state_resolver import WorldStateResolver
 
@@ -89,14 +92,16 @@ class ControlPlaneState:
     get_base_manifest to bridge to the gateway's manifest layer.
 
     Attributes:
-        session_store:      Session lifecycle store.
-        event_store:        Append-only audit log.
-        approval_service:   One-off action approval service.
-        overlay_service:    Session overlay service.
-        resolver:           WorldStateResolver (stateless; reads from stores above).
-        get_base_manifest:  Optional callable: (session_id) → (list[str], dict).
-                            Returns (base_tools, base_constraints) for a session.
-                            If None, world state endpoints return an empty base.
+        session_store:       Session lifecycle store.
+        event_store:         Append-only audit log.
+        approval_service:    One-off action approval service.
+        overlay_service:     Session overlay service.
+        resolver:            WorldStateResolver (stateless; reads from stores above).
+        participant_registry: Registry of participants eligible to vote on approvals.
+        broadcaster:         Fans out approval events to participant SSE queues.
+        get_base_manifest:   Optional callable: (session_id) → (list[str], dict).
+                             Returns (base_tools, base_constraints) for a session.
+                             If None, world state endpoints return an empty base.
     """
 
     session_store: SessionStore
@@ -104,6 +109,8 @@ class ControlPlaneState:
     approval_service: ApprovalService
     overlay_service: OverlayService
     resolver: WorldStateResolver
+    participant_registry: ParticipantRegistry = field(default_factory=ParticipantRegistry)
+    broadcaster: ApprovalBroadcaster = field(default_factory=ApprovalBroadcaster)
     get_base_manifest: Optional[Callable[[str], tuple[list[str], dict]]] = None
 
     @classmethod
@@ -124,12 +131,16 @@ class ControlPlaneState:
         approval_service = ApprovalService(default_ttl_seconds=default_ttl_seconds)
         overlay_service = OverlayService()
         resolver = WorldStateResolver(session_store, overlay_service)
+        participant_registry = ParticipantRegistry()
+        broadcaster = ApprovalBroadcaster()
         return cls(
             session_store=session_store,
             event_store=event_store,
             approval_service=approval_service,
             overlay_service=overlay_service,
             resolver=resolver,
+            participant_registry=participant_registry,
+            broadcaster=broadcaster,
             get_base_manifest=get_base_manifest,
         )
 
@@ -162,6 +173,21 @@ class AttachOverlayRequest(BaseModel):
     widen_scope: dict[str, Any] = {}
     narrow_scope: dict[str, Any] = {}
     additional_constraints: dict[str, Any] = {}
+
+
+class RegisterParticipantRequest(BaseModel):
+    session_id: str
+    roles: list[str]   # e.g. ["user", "operator"]
+
+
+class ScopedVerdictItem(BaseModel):
+    scope: str     # "one_off" | "session" | "world"
+    verdict: str   # "allow" | "deny"
+    participant_id: str = ""
+
+
+class RespondToApprovalRequest(BaseModel):
+    verdicts: list[ScopedVerdictItem]
 
 
 # ---------------------------------------------------------------------------
@@ -505,7 +531,152 @@ def create_control_plane_router(state: ControlPlaneState) -> APIRouter:
             "session_id": session_id,
         })
 
+    # ------------------------------------------------------------------
+    # Participants (multi-scope approval system)
+    # ------------------------------------------------------------------
+
+    @router.post("/participants", status_code=201)
+    def register_participant(body: RegisterParticipantRequest) -> JSONResponse:
+        """
+        Register a participant that can respond to approval requests.
+
+        A participant is an operator/user session identified by its SSE
+        session_id. It holds one or more roles that determine which approval
+        scopes it can vote on:
+          user     → one_off scope
+          operator → session scope
+          admin    → world scope
+
+        Registering the same session_id again updates the roles (upsert).
+        Participants receive "approval_requested" SSE events when approvals
+        are created.
+        """
+        reg = state.participant_registry.register(
+            session_id=body.session_id,
+            roles=set(body.roles),
+        )
+        return JSONResponse(reg.to_dict(), status_code=201)
+
+    @router.delete("/participants/{session_id}")
+    def unregister_participant(session_id: str) -> JSONResponse:
+        """
+        Unregister a participant.
+
+        Safe to call even if the session is not currently registered.
+        """
+        removed = state.participant_registry.unregister(session_id)
+        return JSONResponse({
+            "status": "unregistered" if removed else "not_registered",
+            "session_id": session_id,
+        })
+
+    @router.get("/participants")
+    def list_participants() -> JSONResponse:
+        """List all registered participants."""
+        regs = state.participant_registry.list_all()
+        return JSONResponse({
+            "participants": [r.to_dict() for r in regs],
+            "count": len(regs),
+        })
+
+    # ------------------------------------------------------------------
+    # Multi-scope approval response (new in Phase 8)
+    # ------------------------------------------------------------------
+
+    @router.patch("/approvals/{approval_id}/respond")
+    def respond_to_approval(
+        approval_id: str,
+        body: RespondToApprovalRequest,
+    ) -> JSONResponse:
+        """
+        Submit scoped verdicts for a pending approval.
+
+        Body::
+
+            {
+              "verdicts": [
+                {"scope": "one_off",  "verdict": "allow", "participant_id": "..."},
+                {"scope": "session",  "verdict": "allow", "participant_id": "..."},
+                {"scope": "world",    "verdict": "deny",  "participant_id": "..."}
+              ]
+            }
+
+        Each verdict fires its side effect immediately:
+          one_off allow  → marks the fingerprint approved (tool call can be retried)
+          session allow  → creates a SessionOverlay revealing the tool
+          world   allow  → stub (no-op)
+
+        Verdicts are idempotent per scope: duplicate scope submissions are ignored.
+
+        The tool call UNBLOCKS as soon as any scope provides "allow".
+        The originator receives an "approval_resolved" SSE event so the client
+        knows to retry.
+
+        An expired approval always results in denial regardless of verdict content.
+
+        Returns 404 if approval not found; 409 if already in a terminal state.
+        """
+        approval = state.approval_service.get(approval_id)
+        if approval is None:
+            raise HTTPException(
+                status_code=404,
+                detail=f"Approval not found: {approval_id!r}",
+            )
+
+        # Snapshot pre-respond state to detect first allow.
+        was_allowed_before = _has_allow_verdict(approval)
+
+        # Build ScopedVerdict objects from the request body.
+        verdicts = [
+            ScopedVerdict(
+                scope=v.scope,
+                verdict=v.verdict,
+                participant_id=v.participant_id,
+            )
+            for v in body.verdicts
+        ]
+
+        try:
+            updated = state.approval_service.respond(
+                approval_id=approval_id,
+                verdicts=verdicts,
+                overlay_service=state.overlay_service,
+                session_store=state.session_store,
+                event_store=state.event_store,
+            )
+        except KeyError:
+            raise HTTPException(
+                status_code=404,
+                detail=f"Approval not found: {approval_id!r}",
+            )
+        except RuntimeError as exc:
+            raise HTTPException(status_code=409, detail=str(exc))
+
+        # Notify the originator via SSE if an allow verdict was just received.
+        is_allowed_now = _has_allow_verdict(updated)
+        if is_allowed_now and not was_allowed_before:
+            effective_verdict = "allow"
+            state.broadcaster.notify_originator(
+                originator_session_id=updated.session_id,
+                approval=updated,
+                effective_verdict=effective_verdict,
+            )
+
+        return JSONResponse(updated.to_dict())
+
     return router
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+def _has_allow_verdict(approval: Any) -> bool:
+    """Return True if any scoped_verdict on the approval is an allow."""
+    for sv in approval.scoped_verdicts:
+        if sv.verdict == "allow":
+            return True
+    return False
 
 
 # ---------------------------------------------------------------------------
@@ -553,6 +724,7 @@ def create_control_plane_app(
             "sessions": cp_state.session_store.count(),
             "approvals": cp_state.approval_service.count(),
             "overlays": cp_state.overlay_service.count(),
+            "participants": cp_state.participant_registry.count(),
         })
 
     return app

--- a/src/agent_hypervisor/control_plane/approval_broadcaster.py
+++ b/src/agent_hypervisor/control_plane/approval_broadcaster.py
@@ -1,0 +1,176 @@
+"""
+approval_broadcaster.py — Fan-out of approval events to SSE participants.
+
+Two distinct event types are broadcast:
+
+1. "approval_requested" — sent to ALL registered participants when an approval
+   is created. Participants use this to know there is a pending decision waiting.
+
+2. "approval_resolved" — sent to the ORIGINATOR (the session that triggered the
+   tool call) when any approval scope returns "allow". This unblocks the client
+   so it can retry the tool call.
+
+Architecture:
+- ApprovalBroadcaster holds an optional reference to the SSESessionStore.
+- The SSESessionStore is wired in by create_mcp_app() after the sse_store is
+  created, via set_sse_store(). Without it, broadcasts are silent no-ops.
+- All queue writes use put_nowait() so they work from synchronous API handlers.
+- Failures (full queue, missing session) are logged and swallowed — the
+  enforcement path must never crash due to a notification failure.
+
+Design notes:
+- Fail-closed on enforcement; fail-open on notification (log + continue).
+- The broadcaster is stateless except for the sse_store reference.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import datetime, timezone
+from typing import Any, Optional
+
+log = logging.getLogger(__name__)
+
+_ALL_SCOPES = ["one_off", "session", "world"]
+
+
+class ApprovalBroadcaster:
+    """
+    Routes approval events to SSE queues.
+
+    Broadcast is fire-and-forget: failures are logged but never propagate.
+    The broadcaster can be used before the SSE store is wired (it becomes
+    a no-op) so that tests and standalone control-plane deployments work
+    without the full gateway.
+    """
+
+    def __init__(self) -> None:
+        self._sse_store: Optional[Any] = None  # SSESessionStore | None
+
+    def set_sse_store(self, sse_store: Any) -> None:
+        """
+        Wire the broadcaster to the gateway's SSE session store.
+
+        Called by create_mcp_app() after the SSESessionStore is created.
+        Without this, all broadcasts are silent no-ops.
+
+        Args:
+            sse_store: An SSESessionStore instance.
+        """
+        self._sse_store = sse_store
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def broadcast_approval_requested(
+        self,
+        approval: Any,
+        participant_registry: Any,
+    ) -> int:
+        """
+        Fan out an "approval_requested" event to all registered participants.
+
+        Each participant registered in the ParticipantRegistry receives the
+        event on their SSE queue (if their queue is still alive). Participants
+        that have disconnected (queue not found) are silently skipped.
+
+        Args:
+            approval:             The ActionApproval that was just created.
+            participant_registry: The ParticipantRegistry holding registered
+                                  participants and their session_ids.
+
+        Returns:
+            Number of participants successfully notified.
+        """
+        if self._sse_store is None:
+            return 0
+
+        ttl_remaining = _compute_ttl_remaining(approval.expires_at)
+        payload = json.dumps({
+            "type": "approval_requested",
+            "approval_id": approval.approval_id,
+            "tool_name": approval.tool_name,
+            "arguments": approval.arguments_summary,
+            "fingerprint": approval.action_fingerprint,
+            "ttl_seconds": ttl_remaining,
+            "scopes_available": _ALL_SCOPES,
+        })
+
+        count = 0
+        for reg in participant_registry.list_all():
+            if self._push_to_session(reg.session_id, payload):
+                count += 1
+        return count
+
+    def notify_originator(
+        self,
+        originator_session_id: str,
+        approval: Any,
+        effective_verdict: str,
+    ) -> bool:
+        """
+        Push an "approval_resolved" event to the originating session's SSE queue.
+
+        Called when any approval scope returns "allow" so the client knows it can
+        retry the tool call. If the originator has disconnected, this is a no-op.
+
+        Args:
+            originator_session_id: The session_id of the session that triggered
+                                   the original tool call (approval.session_id).
+            approval:              The ActionApproval with scoped_verdicts populated.
+            effective_verdict:     "allow" or "deny" — the aggregate outcome.
+
+        Returns:
+            True if the event was successfully queued, False otherwise.
+        """
+        if self._sse_store is None or not originator_session_id:
+            return False
+
+        payload = json.dumps({
+            "type": "approval_resolved",
+            "approval_id": approval.approval_id,
+            "effective_verdict": effective_verdict,
+            "scoped_verdicts": [sv.to_dict() for sv in approval.scoped_verdicts],
+        })
+        return self._push_to_session(originator_session_id, payload)
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _push_to_session(self, session_id: str, payload: str) -> bool:
+        """
+        Push a raw JSON string to a session's SSE queue.
+
+        Uses put_nowait() so it is safe to call from synchronous handlers.
+        Returns False and logs a warning on any failure.
+        """
+        if self._sse_store is None:
+            return False
+        queue = self._sse_store.get_queue(session_id)
+        if queue is None:
+            return False
+        try:
+            queue.put_nowait(payload)
+            return True
+        except Exception as exc:
+            log.warning(
+                "ApprovalBroadcaster: failed to push to session %r: %s",
+                session_id,
+                exc,
+            )
+            return False
+
+
+def _compute_ttl_remaining(expires_at: str) -> Optional[int]:
+    """Return seconds until expires_at, or None if no expiry."""
+    if not expires_at:
+        return None
+    try:
+        expiry = datetime.fromisoformat(expires_at)
+        remaining = (expiry - datetime.now(timezone.utc)).total_seconds()
+        return max(0, int(remaining))
+    except ValueError:
+        return 0

--- a/src/agent_hypervisor/control_plane/approval_service.py
+++ b/src/agent_hypervisor/control_plane/approval_service.py
@@ -24,11 +24,18 @@ from datetime import datetime, timedelta, timezone
 from typing import Any, Optional
 
 from .domain import (
+    APPROVAL_SCOPE_ONE_OFF,
+    APPROVAL_SCOPE_SESSION,
+    APPROVAL_SCOPE_WORLD,
     APPROVAL_STATUS_ALLOWED,
     APPROVAL_STATUS_DENIED,
     APPROVAL_STATUS_EXPIRED,
+    APPROVAL_STATUS_PARTIALLY_RESOLVED,
     APPROVAL_STATUS_PENDING,
+    APPROVAL_STATUS_RESOLVED,
     ActionApproval,
+    OverlayChanges,
+    ScopedVerdict,
     compute_action_fingerprint,
 )
 from .event_store import EventStore, make_approval_requested, make_approval_resolved
@@ -198,8 +205,9 @@ class ApprovalService:
         """
         now = datetime.now(timezone.utc)
         expired = []
+        _sweepable = {APPROVAL_STATUS_PENDING, APPROVAL_STATUS_PARTIALLY_RESOLVED}
         for approval in self._approvals.values():
-            if approval.status != APPROVAL_STATUS_PENDING:
+            if approval.status not in _sweepable:
                 continue
             if not approval.expires_at:
                 continue
@@ -250,6 +258,117 @@ class ApprovalService:
             approvals = [a for a in approvals if a.status == status]
         return sorted(approvals, key=lambda a: a.created_at)
 
+    def respond(
+        self,
+        approval_id: str,
+        verdicts: list,
+        overlay_service: Optional[Any] = None,
+        session_store: Optional[Any] = None,
+        event_store: Optional[EventStore] = None,
+    ) -> ActionApproval:
+        """
+        Submit one or more scoped verdicts for a pending approval.
+
+        Each entry in ``verdicts`` must be a ScopedVerdict. Verdicts are
+        idempotent per scope: if a verdict for a scope is already recorded,
+        the new verdict for that scope is ignored (no double side-effect).
+
+        Side effects fired immediately on receipt (if not already fired):
+          one_off allow  → marks the approval as fingerprint-approved so the
+                           originating tool call can be retried.
+          session allow  → creates a SessionOverlay (reveal_tool) for the session.
+          world   allow  → no-op stub.
+          any     deny   → recorded; no structural side effect.
+
+        Status progression:
+          pending            → partially_resolved (after first new verdict)
+          partially_resolved → resolved (after all three scopes have verdicts)
+          any status         → expired   (if TTL already passed when called)
+
+        Fail-closed: expired approvals always result in the approval being
+        marked expired and no side effects are applied.
+
+        Args:
+            approval_id:    The approval to respond to.
+            verdicts:       List of ScopedVerdict objects.
+            overlay_service: Required for session-scope allow side effect.
+            session_store:  Required for session-scope allow side effect.
+            event_store:    Optional; forwarded to overlay_service for audit.
+
+        Returns:
+            The updated ActionApproval.
+
+        Raises:
+            KeyError:    If approval_id is not found.
+            RuntimeError: If the approval is already in a terminal state
+                          (allowed/denied/expired/resolved) and not partially_resolved.
+        """
+        approval = self._require(approval_id)
+
+        # Fail closed: expired approval → mark expired, apply no verdicts.
+        if approval.is_expired():
+            if approval.status not in (APPROVAL_STATUS_EXPIRED,):
+                approval.status = APPROVAL_STATUS_EXPIRED
+            return approval
+
+        # Only pending and partially_resolved approvals can accept new verdicts.
+        _active_statuses = {APPROVAL_STATUS_PENDING, APPROVAL_STATUS_PARTIALLY_RESOLVED}
+        if approval.status not in _active_statuses:
+            raise RuntimeError(
+                f"Approval {approval_id!r} is already in terminal state "
+                f"(status={approval.status!r})."
+            )
+
+        existing_scopes = {sv.scope for sv in approval.scoped_verdicts}
+
+        for verdict in verdicts:
+            # Idempotent: skip if this scope already has a recorded verdict.
+            if verdict.scope in existing_scopes:
+                continue
+
+            # Record the verdict first.
+            approval.scoped_verdicts.append(verdict)
+            existing_scopes.add(verdict.scope)
+
+            # Fire scope-specific side effects.
+            if verdict.verdict == "allow":
+                if verdict.scope == APPROVAL_SCOPE_ONE_OFF:
+                    # Fingerprint approval: the tool call can be retried and will
+                    # succeed. We rely on is_action_approved() checking scoped_verdicts.
+                    pass  # side effect is is_action_approved() returning True
+
+                elif verdict.scope == APPROVAL_SCOPE_SESSION:
+                    # Create a SessionOverlay that reveals the tool for this session.
+                    if overlay_service is not None and session_store is not None:
+                        session = session_store.get(approval.session_id)
+                        manifest_id = (
+                            session.manifest_id if session is not None else "unknown"
+                        )
+                        changes = OverlayChanges(reveal_tools=[approval.tool_name])
+                        overlay_service.attach(
+                            session_id=approval.session_id,
+                            parent_manifest_id=manifest_id,
+                            created_by=verdict.participant_id or "approval_service",
+                            changes=changes,
+                            session_store=session_store,
+                            event_store=event_store,
+                        )
+
+                elif verdict.scope == APPROVAL_SCOPE_WORLD:
+                    # Stub: global approval is not yet implemented.
+                    pass
+
+        # Update status based on how many scopes now have verdicts.
+        _all_scopes = {APPROVAL_SCOPE_ONE_OFF, APPROVAL_SCOPE_SESSION, APPROVAL_SCOPE_WORLD}
+        recorded_scopes = {sv.scope for sv in approval.scoped_verdicts}
+        if recorded_scopes:
+            if _all_scopes <= recorded_scopes:
+                approval.status = APPROVAL_STATUS_RESOLVED
+            else:
+                approval.status = APPROVAL_STATUS_PARTIALLY_RESOLVED
+
+        return approval
+
     def is_action_approved(
         self,
         session_id: str,
@@ -257,14 +376,47 @@ class ApprovalService:
         arguments: dict[str, Any],
     ) -> bool:
         """
-        Check whether a concrete action has a valid pending approval.
+        Check whether a concrete action has a valid (pending or allowed) approval.
 
-        This does NOT consume the approval. The approval remains pending
-        until explicitly resolved. One approval = one authorization for
-        the fingerprint, not unlimited reuse.
+        Returns True if there is a non-expired approval in either pending or
+        allowed state for the exact fingerprint in the given session. This is
+        the backward-compatible check used by callers that treat "a pending
+        approval exists" as "this action is queued for authorization".
 
-        Returns True only if there is a non-expired pending approval
-        for the exact fingerprint in the given session.
+        Note: This is a point-in-time check. Callers must resolve the
+        approval immediately after using it to prevent double-use.
+
+        See also: has_explicit_allow() for the stricter check used by the
+        gateway pre-check to determine if execution can actually proceed.
+        """
+        fingerprint = compute_action_fingerprint(tool_name, arguments)
+        for approval in self._approvals.values():
+            if (
+                approval.session_id == session_id
+                and approval.action_fingerprint == fingerprint
+                and approval.status in (APPROVAL_STATUS_PENDING, APPROVAL_STATUS_ALLOWED)
+                and not approval.is_expired()
+            ):
+                return True
+        return False
+
+    def has_explicit_allow(
+        self,
+        session_id: str,
+        tool_name: str,
+        arguments: dict[str, Any],
+    ) -> bool:
+        """
+        Check whether a concrete action has been explicitly allowed.
+
+        Stricter than is_action_approved(): returns True only if an operator
+        has affirmatively allowed the action via either:
+          1. Old mechanism: resolve() setting status=allowed.
+          2. New multi-scope mechanism: respond() with a one_off "allow" scoped
+             verdict.
+
+        Used by the gateway pre-check to determine if a tool call that would
+        normally route to the approval workflow can instead proceed directly.
 
         Note: This is a point-in-time check. Callers must resolve the
         approval immediately after using it to prevent double-use.
@@ -272,12 +424,18 @@ class ApprovalService:
         fingerprint = compute_action_fingerprint(tool_name, arguments)
         for approval in self._approvals.values():
             if (
-                approval.session_id == session_id
-                and approval.action_fingerprint == fingerprint
-                and approval.status == APPROVAL_STATUS_PENDING
-                and not approval.is_expired()
+                approval.session_id != session_id
+                or approval.action_fingerprint != fingerprint
+                or approval.is_expired()
             ):
+                continue
+            # Old mechanism: explicit allow via resolve()
+            if approval.status == APPROVAL_STATUS_ALLOWED:
                 return True
+            # New mechanism: one_off allow scoped verdict via respond()
+            for sv in approval.scoped_verdicts:
+                if sv.scope == APPROVAL_SCOPE_ONE_OFF and sv.verdict == "allow":
+                    return True
         return False
 
     def count(self) -> int:

--- a/src/agent_hypervisor/control_plane/domain.py
+++ b/src/agent_hypervisor/control_plane/domain.py
@@ -52,6 +52,87 @@ APPROVAL_STATUS_PENDING = "pending"
 APPROVAL_STATUS_ALLOWED = "allowed"
 APPROVAL_STATUS_DENIED = "denied"
 APPROVAL_STATUS_EXPIRED = "expired"
+APPROVAL_STATUS_PARTIALLY_RESOLVED = "partially_resolved"
+APPROVAL_STATUS_RESOLVED = "resolved"
+
+# Approval scopes (multi-scope approval system)
+APPROVAL_SCOPE_ONE_OFF = "one_off"    # user role: allow/deny this fingerprint once (TTL-bound)
+APPROVAL_SCOPE_SESSION = "session"    # operator role: allow/deny for this session (SessionOverlay)
+APPROVAL_SCOPE_WORLD = "world"        # admin role: allow/deny globally (stub)
+
+
+# ---------------------------------------------------------------------------
+# ScopedVerdict
+# ---------------------------------------------------------------------------
+
+@dataclass
+class ScopedVerdict:
+    """
+    A single verdict for one approval scope from one participant.
+
+    Scopes:
+    - one_off:  User role — allow/deny this exact fingerprint once (TTL-bound).
+                Side effect: marks the ActionApproval as fingerprint-approved.
+    - session:  Operator role — allow/deny for the lifetime of this session.
+                Side effect: creates a SessionOverlay (reveal_tool) on allow.
+    - world:    Admin role — allow/deny globally.
+                Side effect: stub (no-op) for now.
+
+    Invariants:
+    - scope must be one of APPROVAL_SCOPE_*.
+    - verdict must be "allow" or "deny".
+    - timestamp is set at creation time (immutable after creation).
+    """
+
+    scope: str                   # one_off | session | world
+    verdict: str                 # allow | deny
+    participant_id: str = ""     # identity of the participant making this decision
+    timestamp: str = field(default_factory=lambda: _now())
+
+    def to_dict(self) -> dict:
+        return {
+            "scope": self.scope,
+            "verdict": self.verdict,
+            "participant_id": self.participant_id,
+            "timestamp": self.timestamp,
+        }
+
+
+# ---------------------------------------------------------------------------
+# ParticipantRegistration
+# ---------------------------------------------------------------------------
+
+@dataclass
+class ParticipantRegistration:
+    """
+    A registered participant that can respond to approval requests.
+
+    A participant holds a set of roles which map to approval scopes:
+      user     → one_off scope
+      operator → session scope
+      admin    → world scope
+
+    A single participant may hold multiple roles simultaneously and can
+    respond with verdicts for all applicable scopes in one PATCH request.
+
+    Invariants:
+    - participant_id is the session_id of the participant's SSE connection.
+    - roles is a set; duplicates are ignored.
+    - Registered participants receive "approval_requested" SSE events.
+    """
+
+    participant_id: str          # SSE session_id used to route events
+    session_id: str              # same as participant_id (SSE session)
+    roles: set                   # {"user", "operator", "admin"} — any subset
+    registered_at: str = field(default_factory=lambda: _now())
+
+    def to_dict(self) -> dict:
+        return {
+            "participant_id": self.participant_id,
+            "session_id": self.session_id,
+            "roles": sorted(self.roles),
+            "registered_at": self.registered_at,
+        }
 
 
 # ---------------------------------------------------------------------------
@@ -174,6 +255,7 @@ class ActionApproval:
     created_at: str = field(default_factory=lambda: _now())
     resolved_at: Optional[str] = None
     resolved_by: Optional[str] = None
+    scoped_verdicts: list = field(default_factory=list)  # list[ScopedVerdict]
 
     def is_expired(self) -> bool:
         """Return True if this approval has passed its expiry time."""
@@ -203,6 +285,7 @@ class ActionApproval:
             "created_at": self.created_at,
             "resolved_at": self.resolved_at,
             "resolved_by": self.resolved_by,
+            "scoped_verdicts": [sv.to_dict() for sv in self.scoped_verdicts],
         }
 
 

--- a/src/agent_hypervisor/control_plane/participant_registry.py
+++ b/src/agent_hypervisor/control_plane/participant_registry.py
@@ -1,0 +1,97 @@
+"""
+participant_registry.py — Registry of participants eligible to respond to approval requests.
+
+A participant is a connected session (identified by its SSE session_id) that holds
+one or more roles. Roles map to approval scopes:
+  user     → one_off scope
+  operator → session scope
+  admin    → world scope
+
+Participants receive "approval_requested" SSE events when an approval is created
+and can respond via PATCH /control/approvals/{id}/respond with verdicts for any
+of their applicable scopes.
+
+Design notes:
+- Keyed by session_id (one registration per SSE session).
+- Re-registering the same session_id updates the roles (upsert semantics).
+- In-memory; no persistence required — participants re-register on reconnect.
+- Thread-safety: single-threaded asyncio event loop context; no locking needed.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from .domain import ParticipantRegistration, _now
+
+
+class ParticipantRegistry:
+    """
+    In-memory registry of participants eligible to respond to approval requests.
+
+    Participants are identified by their SSE session_id. Each participant holds
+    a set of roles that determine which approval scopes they can vote on.
+
+    Invariants:
+    - At most one registration per session_id.
+    - Re-registering a session_id replaces the previous registration (upsert).
+    - Unregistering is idempotent — calling unregister() for an unknown session
+      is a no-op and returns False.
+    """
+
+    def __init__(self) -> None:
+        self._participants: dict[str, ParticipantRegistration] = {}  # session_id → reg
+
+    def register(self, session_id: str, roles: set) -> ParticipantRegistration:
+        """
+        Register (or update) a participant with the given roles.
+
+        Args:
+            session_id: The SSE session_id of the participant. Used to route
+                        approval events and to look up the SSE queue.
+            roles:      Set of role strings, e.g. {"user", "operator"}.
+                        Empty set is valid (participant receives events but has
+                        no applicable scopes).
+
+        Returns:
+            The ParticipantRegistration record (new or updated).
+        """
+        reg = ParticipantRegistration(
+            participant_id=session_id,
+            session_id=session_id,
+            roles=set(roles),
+        )
+        self._participants[session_id] = reg
+        return reg
+
+    def unregister(self, session_id: str) -> bool:
+        """
+        Remove a participant registration.
+
+        Args:
+            session_id: The session to remove.
+
+        Returns:
+            True if the session was found and removed, False if not registered.
+        """
+        if session_id in self._participants:
+            del self._participants[session_id]
+            return True
+        return False
+
+    def get(self, session_id: str) -> Optional[ParticipantRegistration]:
+        """Return the registration for a session, or None."""
+        return self._participants.get(session_id)
+
+    def list_all(self) -> list[ParticipantRegistration]:
+        """
+        Return all registered participants.
+
+        Returns:
+            Participants sorted by registered_at ascending.
+        """
+        return sorted(self._participants.values(), key=lambda r: r.registered_at)
+
+    def count(self) -> int:
+        """Return the number of registered participants."""
+        return len(self._participants)

--- a/src/agent_hypervisor/hypervisor/mcp_gateway/mcp_server.py
+++ b/src/agent_hypervisor/hypervisor/mcp_gateway/mcp_server.py
@@ -271,6 +271,8 @@ def create_mcp_app(
         from agent_hypervisor.control_plane.api import create_control_plane_router
         app.state.control_plane = control_plane
         app.include_router(create_control_plane_router(control_plane))
+        # Wire the broadcaster to the SSE store so it can push events to queues.
+        control_plane.broadcaster.set_sse_store(sse_store)
 
     # ------------------------------------------------------------------
     # JSON-RPC 2.0 dispatcher
@@ -664,22 +666,40 @@ def _handle_tools_call(
         # Policy engine returned "ask": route to approval workflow if control plane
         # is present; otherwise fail closed (treat as deny).
         if state.control_plane is not None and provenance.session_id:
-            approval = state.control_plane.approval_service.request_approval(
+            # Pre-check: if the action was explicitly allowed (operator said
+            # "allow" via resolve() or one_off scoped verdict via respond()),
+            # skip the approval workflow and proceed to adapter dispatch.
+            if state.control_plane.approval_service.has_explicit_allow(
                 session_id=provenance.session_id,
                 tool_name=tool_name,
                 arguments=arguments,
-                requested_by=provenance.source,
-                event_store=state.control_plane.event_store,
-            )
-            return make_result(request_id, {
-                "status": "pending_approval",
-                "approval_id": approval.approval_id,
-                "tool_name": tool_name,
-                "message": (
-                    f"Tool call '{tool_name}' requires operator approval. "
-                    f"Resolve via POST /control/approvals/{approval.approval_id}/resolve"
-                ),
-            })
+            ):
+                pass  # fall through to adapter dispatch below
+            else:
+                approval = state.control_plane.approval_service.request_approval(
+                    session_id=provenance.session_id,
+                    tool_name=tool_name,
+                    arguments=arguments,
+                    requested_by=provenance.source,
+                    event_store=state.control_plane.event_store,
+                )
+                # Broadcast to all registered participants.
+                try:
+                    state.control_plane.broadcaster.broadcast_approval_requested(
+                        approval=approval,
+                        participant_registry=state.control_plane.participant_registry,
+                    )
+                except Exception:
+                    pass  # fail-open: never crash the enforcement path
+                return make_result(request_id, {
+                    "status": "pending_approval",
+                    "approval_id": approval.approval_id,
+                    "tool_name": tool_name,
+                    "message": (
+                        f"Tool call '{tool_name}' requires operator approval. "
+                        f"Resolve via PATCH /control/approvals/{approval.approval_id}/respond"
+                    ),
+                })
         else:
             # No control plane or no session → fail closed
             return make_error(

--- a/tests/control_plane/test_phase8.py
+++ b/tests/control_plane/test_phase8.py
@@ -1,0 +1,744 @@
+"""
+test_phase8.py — Multi-scope approval system tests (Phase 8).
+
+Covers:
+  - Domain: ApprovalScope constants, ScopedVerdict, ParticipantRegistration
+  - Domain: ActionApproval.scoped_verdicts field
+  - ParticipantRegistry: register, unregister, list, upsert
+  - ApprovalService.respond(): one_off allow creates fingerprint entry
+  - ApprovalService.respond(): session allow creates overlay via overlay_service
+  - ApprovalService.respond(): idempotent (same scope twice → no double effect)
+  - ApprovalService.respond(): expired approval → deny even if verdicts arrive
+  - Mixed verdicts: one_off allow + session deny → proceeds, no overlay
+  - Status transitions: pending → partially_resolved → resolved
+  - API: POST /control/participants
+  - API: DELETE /control/participants/{session_id}
+  - API: GET /control/participants
+  - API: PATCH /control/approvals/{id}/respond with scoped verdicts
+  - API: full round-trip — ask → broadcast → respond → unblocked
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi.testclient import TestClient
+
+from agent_hypervisor.control_plane.api import ControlPlaneState, create_control_plane_app
+from agent_hypervisor.control_plane.approval_broadcaster import ApprovalBroadcaster
+from agent_hypervisor.control_plane.approval_service import ApprovalService
+from agent_hypervisor.control_plane.domain import (
+    APPROVAL_SCOPE_ONE_OFF,
+    APPROVAL_SCOPE_SESSION,
+    APPROVAL_SCOPE_WORLD,
+    APPROVAL_STATUS_EXPIRED,
+    APPROVAL_STATUS_PARTIALLY_RESOLVED,
+    APPROVAL_STATUS_PENDING,
+    APPROVAL_STATUS_RESOLVED,
+    ActionApproval,
+    ParticipantRegistration,
+    ScopedVerdict,
+)
+from agent_hypervisor.control_plane.overlay_service import OverlayService
+from agent_hypervisor.control_plane.participant_registry import ParticipantRegistry
+from agent_hypervisor.control_plane.session_store import SessionStore
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_expired_approval(svc: ApprovalService) -> ActionApproval:
+    """Create a pending approval that has already expired."""
+    approval = svc.request_approval(
+        session_id="sess-x",
+        tool_name="do_thing",
+        arguments={"x": 1},
+        requested_by="agent",
+        ttl_seconds=1,
+    )
+    # Backdate the expiry.
+    approval.expires_at = (
+        datetime.now(timezone.utc) - timedelta(seconds=10)
+    ).isoformat()
+    return approval
+
+
+def _sv(scope: str, verdict: str, pid: str = "p1") -> ScopedVerdict:
+    return ScopedVerdict(scope=scope, verdict=verdict, participant_id=pid)
+
+
+# ---------------------------------------------------------------------------
+# 1. Domain: constants and dataclasses
+# ---------------------------------------------------------------------------
+
+class TestApprovalScopeConstants:
+    def test_scope_values(self):
+        assert APPROVAL_SCOPE_ONE_OFF == "one_off"
+        assert APPROVAL_SCOPE_SESSION == "session"
+        assert APPROVAL_SCOPE_WORLD == "world"
+
+    def test_partial_resolved_constant(self):
+        assert APPROVAL_STATUS_PARTIALLY_RESOLVED == "partially_resolved"
+
+    def test_resolved_constant(self):
+        assert APPROVAL_STATUS_RESOLVED == "resolved"
+
+
+class TestScopedVerdict:
+    def test_creation(self):
+        sv = ScopedVerdict(scope="one_off", verdict="allow", participant_id="p1")
+        assert sv.scope == "one_off"
+        assert sv.verdict == "allow"
+        assert sv.participant_id == "p1"
+        assert sv.timestamp  # non-empty
+
+    def test_to_dict(self):
+        sv = ScopedVerdict(scope="session", verdict="deny", participant_id="op1")
+        d = sv.to_dict()
+        assert d["scope"] == "session"
+        assert d["verdict"] == "deny"
+        assert d["participant_id"] == "op1"
+        assert "timestamp" in d
+
+    def test_default_participant_id(self):
+        sv = ScopedVerdict(scope="world", verdict="allow")
+        assert sv.participant_id == ""
+
+
+class TestParticipantRegistration:
+    def test_creation(self):
+        reg = ParticipantRegistration(
+            participant_id="sess-1",
+            session_id="sess-1",
+            roles={"user", "operator"},
+        )
+        assert reg.participant_id == "sess-1"
+        assert reg.session_id == "sess-1"
+        assert reg.roles == {"user", "operator"}
+        assert reg.registered_at
+
+    def test_to_dict(self):
+        reg = ParticipantRegistration(
+            participant_id="sess-2",
+            session_id="sess-2",
+            roles={"admin"},
+        )
+        d = reg.to_dict()
+        assert d["participant_id"] == "sess-2"
+        assert d["roles"] == ["admin"]  # sorted list
+        assert "registered_at" in d
+
+
+class TestActionApprovalScopedVerdicts:
+    def test_new_approval_has_empty_scoped_verdicts(self):
+        svc = ApprovalService()
+        approval = svc.request_approval(
+            session_id="s1", tool_name="t1", arguments={}, requested_by="agent"
+        )
+        assert approval.scoped_verdicts == []
+
+    def test_scoped_verdicts_in_to_dict(self):
+        svc = ApprovalService()
+        approval = svc.request_approval(
+            session_id="s1", tool_name="t1", arguments={}, requested_by="agent"
+        )
+        sv = _sv(APPROVAL_SCOPE_ONE_OFF, "allow")
+        svc.respond(approval.approval_id, [sv])
+        d = approval.to_dict()
+        assert len(d["scoped_verdicts"]) == 1
+        assert d["scoped_verdicts"][0]["scope"] == "one_off"
+        assert d["scoped_verdicts"][0]["verdict"] == "allow"
+
+
+# ---------------------------------------------------------------------------
+# 2. ParticipantRegistry
+# ---------------------------------------------------------------------------
+
+class TestParticipantRegistry:
+    def setup_method(self):
+        self.reg = ParticipantRegistry()
+
+    def test_register_creates_entry(self):
+        result = self.reg.register("sess-1", {"user"})
+        assert result.session_id == "sess-1"
+        assert result.roles == {"user"}
+        assert self.reg.count() == 1
+
+    def test_register_upserts_roles(self):
+        self.reg.register("sess-1", {"user"})
+        updated = self.reg.register("sess-1", {"user", "operator"})
+        assert updated.roles == {"user", "operator"}
+        assert self.reg.count() == 1  # still one participant
+
+    def test_unregister_known_session(self):
+        self.reg.register("sess-1", {"user"})
+        removed = self.reg.unregister("sess-1")
+        assert removed is True
+        assert self.reg.count() == 0
+
+    def test_unregister_unknown_session(self):
+        removed = self.reg.unregister("does-not-exist")
+        assert removed is False
+
+    def test_list_all_empty(self):
+        assert self.reg.list_all() == []
+
+    def test_list_all_multiple(self):
+        self.reg.register("sess-a", {"user"})
+        self.reg.register("sess-b", {"operator"})
+        participants = self.reg.list_all()
+        assert len(participants) == 2
+        ids = {p.session_id for p in participants}
+        assert ids == {"sess-a", "sess-b"}
+
+    def test_get_existing(self):
+        self.reg.register("sess-1", {"user"})
+        result = self.reg.get("sess-1")
+        assert result is not None
+        assert result.session_id == "sess-1"
+
+    def test_get_missing_returns_none(self):
+        assert self.reg.get("missing") is None
+
+
+# ---------------------------------------------------------------------------
+# 3. ApprovalService.respond()
+# ---------------------------------------------------------------------------
+
+class TestApprovalServiceRespond:
+
+    def _setup(self):
+        svc = ApprovalService(default_ttl_seconds=300)
+        overlay_svc = OverlayService()
+        session_store = SessionStore()
+        session_store.create(manifest_id="manifest-1", session_id="sess-1")
+        approval = svc.request_approval(
+            session_id="sess-1",
+            tool_name="send_email",
+            arguments={"to": "alice@example.com"},
+            requested_by="agent",
+        )
+        return svc, overlay_svc, session_store, approval
+
+    # --- one_off allow ---
+
+    def test_one_off_allow_marks_fingerprint_approved(self):
+        svc, overlay_svc, ss, approval = self._setup()
+        sv = _sv(APPROVAL_SCOPE_ONE_OFF, "allow")
+        svc.respond(approval.approval_id, [sv], overlay_svc, ss)
+        assert svc.has_explicit_allow(
+            session_id="sess-1",
+            tool_name="send_email",
+            arguments={"to": "alice@example.com"},
+        )
+
+    def test_one_off_allow_does_not_create_overlay(self):
+        svc, overlay_svc, ss, approval = self._setup()
+        svc.respond(approval.approval_id, [_sv(APPROVAL_SCOPE_ONE_OFF, "allow")], overlay_svc, ss)
+        assert overlay_svc.count() == 0
+
+    # --- session allow ---
+
+    def test_session_allow_creates_overlay(self):
+        svc, overlay_svc, ss, approval = self._setup()
+        sv = _sv(APPROVAL_SCOPE_SESSION, "allow")
+        svc.respond(approval.approval_id, [sv], overlay_svc, ss)
+        overlays = overlay_svc.get_active_overlays("sess-1")
+        assert len(overlays) == 1
+        assert "send_email" in overlays[0].changes.reveal_tools
+
+    def test_session_deny_does_not_create_overlay(self):
+        svc, overlay_svc, ss, approval = self._setup()
+        sv = _sv(APPROVAL_SCOPE_SESSION, "deny")
+        svc.respond(approval.approval_id, [sv], overlay_svc, ss)
+        assert overlay_svc.count() == 0
+
+    # --- world allow (stub) ---
+
+    def test_world_allow_is_accepted_no_crash(self):
+        svc, overlay_svc, ss, approval = self._setup()
+        sv = _sv(APPROVAL_SCOPE_WORLD, "allow")
+        updated = svc.respond(approval.approval_id, [sv], overlay_svc, ss)
+        assert any(v.scope == APPROVAL_SCOPE_WORLD for v in updated.scoped_verdicts)
+
+    # --- idempotency ---
+
+    def test_idempotent_same_scope_twice_no_double_effect(self):
+        svc, overlay_svc, ss, approval = self._setup()
+        sv1 = _sv(APPROVAL_SCOPE_SESSION, "allow")
+        sv2 = _sv(APPROVAL_SCOPE_SESSION, "allow")
+        # First call: session allow → overlay is created.
+        svc.respond(approval.approval_id, [sv1], overlay_svc, ss)
+        # Second call with same scope: idempotent → no second overlay.
+        svc.respond(approval.approval_id, [sv2], overlay_svc, ss)
+        assert overlay_svc.count() == 1
+
+    def test_idempotent_same_scope_in_single_call(self):
+        svc, overlay_svc, ss, approval = self._setup()
+        sv1 = _sv(APPROVAL_SCOPE_SESSION, "allow")
+        sv2 = _sv(APPROVAL_SCOPE_SESSION, "deny")
+        svc.respond(approval.approval_id, [sv1, sv2], overlay_svc, ss)
+        # Only first verdict for session scope counts.
+        assert overlay_svc.count() == 1
+
+    # --- expired approval ---
+
+    def test_expired_approval_returns_expired_status(self):
+        svc = ApprovalService()
+        approval = _make_expired_approval(svc)
+        updated = svc.respond(
+            approval.approval_id,
+            [_sv(APPROVAL_SCOPE_ONE_OFF, "allow")],
+        )
+        assert updated.status == APPROVAL_STATUS_EXPIRED
+
+    def test_expired_approval_does_not_create_overlay(self):
+        svc = ApprovalService()
+        overlay_svc = OverlayService()
+        ss = SessionStore()
+        ss.create(manifest_id="m1", session_id="sess-x")
+        approval = _make_expired_approval(svc)
+        svc.respond(
+            approval.approval_id,
+            [_sv(APPROVAL_SCOPE_SESSION, "allow")],
+            overlay_svc,
+            ss,
+        )
+        assert overlay_svc.count() == 0
+
+    def test_expired_approval_does_not_mark_fingerprint_approved(self):
+        svc = ApprovalService()
+        approval = _make_expired_approval(svc)
+        svc.respond(
+            approval.approval_id,
+            [_sv(APPROVAL_SCOPE_ONE_OFF, "allow")],
+        )
+        assert not svc.has_explicit_allow("sess-x", "do_thing", {"x": 1})
+
+    # --- terminal state rejection ---
+
+    def test_respond_to_terminal_state_raises(self):
+        svc, overlay_svc, ss, approval = self._setup()
+        # Fully resolve (all scopes).
+        svc.respond(
+            approval.approval_id,
+            [
+                _sv(APPROVAL_SCOPE_ONE_OFF, "allow"),
+                _sv(APPROVAL_SCOPE_SESSION, "allow"),
+                _sv(APPROVAL_SCOPE_WORLD, "allow"),
+            ],
+            overlay_svc,
+            ss,
+        )
+        assert approval.status == APPROVAL_STATUS_RESOLVED
+        with pytest.raises(RuntimeError):
+            svc.respond(approval.approval_id, [_sv(APPROVAL_SCOPE_ONE_OFF, "allow")])
+
+    # --- mixed verdicts ---
+
+    def test_mixed_verdicts_one_off_allow_session_deny(self):
+        svc, overlay_svc, ss, approval = self._setup()
+        svc.respond(
+            approval.approval_id,
+            [
+                _sv(APPROVAL_SCOPE_ONE_OFF, "allow"),
+                _sv(APPROVAL_SCOPE_SESSION, "deny"),
+            ],
+            overlay_svc,
+            ss,
+        )
+        # one_off allow → tool call explicitly allowed.
+        assert svc.has_explicit_allow("sess-1", "send_email", {"to": "alice@example.com"})
+        # session deny → no overlay.
+        assert overlay_svc.count() == 0
+
+    # --- status transitions ---
+
+    def test_status_pending_to_partially_resolved(self):
+        svc, overlay_svc, ss, approval = self._setup()
+        assert approval.status == APPROVAL_STATUS_PENDING
+        svc.respond(approval.approval_id, [_sv(APPROVAL_SCOPE_ONE_OFF, "allow")])
+        assert approval.status == APPROVAL_STATUS_PARTIALLY_RESOLVED
+
+    def test_status_partially_resolved_to_resolved(self):
+        svc, overlay_svc, ss, approval = self._setup()
+        svc.respond(approval.approval_id, [_sv(APPROVAL_SCOPE_ONE_OFF, "allow")])
+        assert approval.status == APPROVAL_STATUS_PARTIALLY_RESOLVED
+        svc.respond(approval.approval_id, [_sv(APPROVAL_SCOPE_SESSION, "deny")])
+        assert approval.status == APPROVAL_STATUS_PARTIALLY_RESOLVED
+        svc.respond(
+            approval.approval_id,
+            [_sv(APPROVAL_SCOPE_WORLD, "deny")],
+            overlay_svc,
+            ss,
+        )
+        assert approval.status == APPROVAL_STATUS_RESOLVED
+
+    def test_status_transitions_all_at_once(self):
+        svc, overlay_svc, ss, approval = self._setup()
+        svc.respond(
+            approval.approval_id,
+            [
+                _sv(APPROVAL_SCOPE_ONE_OFF, "allow"),
+                _sv(APPROVAL_SCOPE_SESSION, "deny"),
+                _sv(APPROVAL_SCOPE_WORLD, "deny"),
+            ],
+            overlay_svc,
+            ss,
+        )
+        assert approval.status == APPROVAL_STATUS_RESOLVED
+
+
+# ---------------------------------------------------------------------------
+# 4. ApprovalBroadcaster
+# ---------------------------------------------------------------------------
+
+class TestApprovalBroadcaster:
+    def test_broadcast_without_sse_store_is_noop(self):
+        bc = ApprovalBroadcaster()
+        reg = ParticipantRegistry()
+        reg.register("sess-1", {"user"})
+        svc = ApprovalService()
+        approval = svc.request_approval("sess-1", "tool", {}, "agent")
+        count = bc.broadcast_approval_requested(approval, reg)
+        assert count == 0
+
+    def test_broadcast_with_sse_store_pushes_to_queues(self):
+        bc = ApprovalBroadcaster()
+        reg = ParticipantRegistry()
+        reg.register("sess-p", {"user"})
+
+        # Mock SSE store with a real asyncio.Queue.
+        loop = asyncio.new_event_loop()
+        try:
+            queue = asyncio.Queue(loop=loop) if hasattr(asyncio, 'Queue') else asyncio.Queue()
+        except TypeError:
+            queue = asyncio.Queue()
+
+        mock_store = MagicMock()
+        mock_store.get_queue.return_value = queue
+        bc.set_sse_store(mock_store)
+
+        svc = ApprovalService()
+        approval = svc.request_approval("sess-p", "tool", {}, "agent")
+        count = bc.broadcast_approval_requested(approval, reg)
+        assert count == 1
+        assert not queue.empty()
+        payload = json.loads(queue.get_nowait())
+        assert payload["type"] == "approval_requested"
+        assert payload["approval_id"] == approval.approval_id
+        assert payload["tool_name"] == "tool"
+        assert "one_off" in payload["scopes_available"]
+
+    def test_notify_originator_without_sse_store(self):
+        bc = ApprovalBroadcaster()
+        svc = ApprovalService()
+        approval = svc.request_approval("sess-o", "tool", {}, "agent")
+        result = bc.notify_originator("sess-o", approval, "allow")
+        assert result is False
+
+    def test_notify_originator_pushes_resolved_event(self):
+        bc = ApprovalBroadcaster()
+        queue = asyncio.Queue()
+        mock_store = MagicMock()
+        mock_store.get_queue.return_value = queue
+        bc.set_sse_store(mock_store)
+
+        svc = ApprovalService()
+        approval = svc.request_approval("sess-o", "tool", {}, "agent")
+        sv = _sv(APPROVAL_SCOPE_ONE_OFF, "allow", "p1")
+        approval.scoped_verdicts.append(sv)
+
+        result = bc.notify_originator("sess-o", approval, "allow")
+        assert result is True
+        payload = json.loads(queue.get_nowait())
+        assert payload["type"] == "approval_resolved"
+        assert payload["approval_id"] == approval.approval_id
+        assert payload["effective_verdict"] == "allow"
+
+
+# ---------------------------------------------------------------------------
+# 5. API endpoints
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def cp_state():
+    return ControlPlaneState.create()
+
+
+@pytest.fixture
+def api_client():
+    """
+    Returns (TestClient, ControlPlaneState) sharing the same in-memory services.
+
+    create_control_plane_app() creates its own internal ControlPlaneState and
+    wires the router to it via closure. We can't replace it after the fact via
+    app.state.control_plane. So we build the router directly with our state.
+    """
+    from fastapi import FastAPI
+    from agent_hypervisor.control_plane.api import create_control_plane_router
+
+    state = ControlPlaneState.create()
+    router = create_control_plane_router(state)
+    app = FastAPI()
+    app.include_router(router)
+    return TestClient(app), state
+
+
+class TestParticipantEndpoints:
+    def test_post_participants_creates_registration(self, api_client):
+        client, state = api_client
+        resp = client.post("/control/participants", json={
+            "session_id": "sess-1",
+            "roles": ["user", "operator"],
+        })
+        assert resp.status_code == 201
+        body = resp.json()
+        assert body["session_id"] == "sess-1"
+        assert set(body["roles"]) == {"user", "operator"}
+
+    def test_post_participants_upserts_roles(self, api_client):
+        client, state = api_client
+        client.post("/control/participants", json={"session_id": "sess-1", "roles": ["user"]})
+        resp = client.post("/control/participants", json={"session_id": "sess-1", "roles": ["user", "operator"]})
+        assert resp.status_code == 201
+        assert state.participant_registry.count() == 1
+
+    def test_delete_participants_removes_registration(self, api_client):
+        client, state = api_client
+        client.post("/control/participants", json={"session_id": "sess-1", "roles": ["user"]})
+        resp = client.delete("/control/participants/sess-1")
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "unregistered"
+        assert state.participant_registry.count() == 0
+
+    def test_delete_participants_unknown_returns_not_registered(self, api_client):
+        client, state = api_client
+        resp = client.delete("/control/participants/ghost")
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "not_registered"
+
+    def test_get_participants_returns_list(self, api_client):
+        client, state = api_client
+        client.post("/control/participants", json={"session_id": "s1", "roles": ["user"]})
+        client.post("/control/participants", json={"session_id": "s2", "roles": ["operator"]})
+        resp = client.get("/control/participants")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["count"] == 2
+
+    def test_get_participants_empty(self, api_client):
+        client, _ = api_client
+        resp = client.get("/control/participants")
+        assert resp.status_code == 200
+        assert resp.json()["count"] == 0
+
+
+class TestRespondEndpoint:
+    def _create_session_and_approval(self, client, state):
+        """Create a session and pending approval via the service layer."""
+        state.session_store.create(manifest_id="m1", session_id="sess-a")
+        approval = state.approval_service.request_approval(
+            session_id="sess-a",
+            tool_name="read_file",
+            arguments={"path": "/tmp/x"},
+            requested_by="agent",
+        )
+        return approval
+
+    def test_patch_respond_one_off_allow(self, api_client):
+        client, state = api_client
+        approval = self._create_session_and_approval(client, state)
+        resp = client.patch(f"/control/approvals/{approval.approval_id}/respond", json={
+            "verdicts": [{"scope": "one_off", "verdict": "allow", "participant_id": "p1"}],
+        })
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["status"] == APPROVAL_STATUS_PARTIALLY_RESOLVED
+        assert len(body["scoped_verdicts"]) == 1
+        assert body["scoped_verdicts"][0]["scope"] == "one_off"
+        assert body["scoped_verdicts"][0]["verdict"] == "allow"
+
+    def test_patch_respond_marks_fingerprint_approved(self, api_client):
+        client, state = api_client
+        approval = self._create_session_and_approval(client, state)
+        client.patch(f"/control/approvals/{approval.approval_id}/respond", json={
+            "verdicts": [{"scope": "one_off", "verdict": "allow"}],
+        })
+        assert state.approval_service.has_explicit_allow(
+            session_id="sess-a",
+            tool_name="read_file",
+            arguments={"path": "/tmp/x"},
+        )
+
+    def test_patch_respond_session_allow_creates_overlay(self, api_client):
+        client, state = api_client
+        approval = self._create_session_and_approval(client, state)
+        client.patch(f"/control/approvals/{approval.approval_id}/respond", json={
+            "verdicts": [{"scope": "session", "verdict": "allow", "participant_id": "op1"}],
+        })
+        overlays = state.overlay_service.get_active_overlays("sess-a")
+        assert len(overlays) == 1
+        assert "read_file" in overlays[0].changes.reveal_tools
+
+    def test_patch_respond_full_all_scopes_resolves(self, api_client):
+        client, state = api_client
+        approval = self._create_session_and_approval(client, state)
+        resp = client.patch(f"/control/approvals/{approval.approval_id}/respond", json={
+            "verdicts": [
+                {"scope": "one_off", "verdict": "allow"},
+                {"scope": "session", "verdict": "deny"},
+                {"scope": "world", "verdict": "deny"},
+            ],
+        })
+        assert resp.status_code == 200
+        assert resp.json()["status"] == APPROVAL_STATUS_RESOLVED
+
+    def test_patch_respond_unknown_approval_returns_404(self, api_client):
+        client, _ = api_client
+        resp = client.patch("/control/approvals/does-not-exist/respond", json={
+            "verdicts": [{"scope": "one_off", "verdict": "allow"}],
+        })
+        assert resp.status_code == 404
+
+    def test_patch_respond_terminal_state_returns_409(self, api_client):
+        client, state = api_client
+        approval = self._create_session_and_approval(client, state)
+        # Exhaust all scopes.
+        client.patch(f"/control/approvals/{approval.approval_id}/respond", json={
+            "verdicts": [
+                {"scope": "one_off", "verdict": "deny"},
+                {"scope": "session", "verdict": "deny"},
+                {"scope": "world", "verdict": "deny"},
+            ],
+        })
+        # Now try again.
+        resp = client.patch(f"/control/approvals/{approval.approval_id}/respond", json={
+            "verdicts": [{"scope": "one_off", "verdict": "allow"}],
+        })
+        assert resp.status_code == 409
+
+    def test_patch_respond_idempotent_duplicate_scope(self, api_client):
+        client, state = api_client
+        approval = self._create_session_and_approval(client, state)
+        # First call: one_off allow.
+        client.patch(f"/control/approvals/{approval.approval_id}/respond", json={
+            "verdicts": [{"scope": "one_off", "verdict": "allow"}],
+        })
+        # Second call with same scope: should be ignored.
+        resp = client.patch(f"/control/approvals/{approval.approval_id}/respond", json={
+            "verdicts": [{"scope": "one_off", "verdict": "deny"}],
+        })
+        assert resp.status_code == 200
+        # Still only one scoped verdict.
+        body = resp.json()
+        assert len(body["scoped_verdicts"]) == 1
+        assert body["scoped_verdicts"][0]["verdict"] == "allow"  # first wins
+
+    def test_old_resolve_endpoint_still_works(self, api_client):
+        """Backwards compatibility: POST /control/approvals/{id}/resolve still works."""
+        client, state = api_client
+        approval = self._create_session_and_approval(client, state)
+        resp = client.post(f"/control/approvals/{approval.approval_id}/resolve", json={
+            "decision": "allowed",
+            "resolved_by": "human",
+        })
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "allowed"
+
+
+# ---------------------------------------------------------------------------
+# 6. Full round-trip test
+# ---------------------------------------------------------------------------
+
+class TestFullRoundTrip:
+    """
+    Simulates the complete Phase 8 approval flow:
+      1. Register a participant.
+      2. Create an approval (simulating ask verdict from gateway).
+      3. Broadcast to participants (simulate – check queue contents).
+      4. Participant responds with scoped verdicts.
+      5. Verify tool is now approved (is_action_approved = True).
+      6. Verify overlay created for session scope.
+    """
+
+    def test_full_round_trip(self):
+        from fastapi import FastAPI
+        from agent_hypervisor.control_plane.api import create_control_plane_router
+
+        state = ControlPlaneState.create()
+        app = FastAPI()
+        app.include_router(create_control_plane_router(state))
+
+        # Wire a mock SSE store for broadcasting.
+        participant_queue = asyncio.Queue()
+        originator_queue = asyncio.Queue()
+
+        mock_sse = MagicMock()
+
+        def _get_queue(sid):
+            if sid == "participant-sess":
+                return participant_queue
+            if sid == "agent-sess":
+                return originator_queue
+            return None
+
+        mock_sse.get_queue.side_effect = _get_queue
+        state.broadcaster.set_sse_store(mock_sse)
+
+        # Step 1: Create control plane session for agent.
+        state.session_store.create(manifest_id="m1", session_id="agent-sess")
+
+        # Step 2: Register participant.
+        state.participant_registry.register("participant-sess", {"user", "operator"})
+
+        # Step 3: Create approval (as gateway would on verdict=ask).
+        approval = state.approval_service.request_approval(
+            session_id="agent-sess",
+            tool_name="write_file",
+            arguments={"path": "/tmp/out.txt", "content": "hello"},
+            requested_by="agent",
+        )
+
+        # Step 4: Broadcast to participants.
+        n = state.broadcaster.broadcast_approval_requested(approval, state.participant_registry)
+        assert n == 1
+        payload = json.loads(participant_queue.get_nowait())
+        assert payload["type"] == "approval_requested"
+        assert payload["approval_id"] == approval.approval_id
+        assert payload["tool_name"] == "write_file"
+
+        # Step 5: Participant responds with one_off allow + session allow.
+        verdicts = [
+            ScopedVerdict(scope=APPROVAL_SCOPE_ONE_OFF, verdict="allow", participant_id="participant-sess"),
+            ScopedVerdict(scope=APPROVAL_SCOPE_SESSION, verdict="allow", participant_id="participant-sess"),
+        ]
+        state.approval_service.respond(
+            approval_id=approval.approval_id,
+            verdicts=verdicts,
+            overlay_service=state.overlay_service,
+            session_store=state.session_store,
+        )
+
+        # Step 6: Originator is notified.
+        state.broadcaster.notify_originator("agent-sess", approval, "allow")
+        notification = json.loads(originator_queue.get_nowait())
+        assert notification["type"] == "approval_resolved"
+        assert notification["effective_verdict"] == "allow"
+
+        # Step 7: Tool call is now explicitly allowed (one_off path).
+        assert state.approval_service.has_explicit_allow(
+            session_id="agent-sess",
+            tool_name="write_file",
+            arguments={"path": "/tmp/out.txt", "content": "hello"},
+        )
+
+        # Step 8: Session overlay was created.
+        overlays = state.overlay_service.get_active_overlays("agent-sess")
+        assert len(overlays) == 1
+        assert "write_file" in overlays[0].changes.reveal_tools


### PR DESCRIPTION
Adds the complete Phase 8 multi-scope approval system. A single approval
request can now receive verdicts at three scopes simultaneously:
  - one_off (user): marks the fingerprint explicitly allowed for retry
  - session (operator): creates a SessionOverlay revealing the tool
  - world (admin): stub/no-op, wired for future implementation

New components:
  - ScopedVerdict + ParticipantRegistration domain types
  - ParticipantRegistry: registers SSE sessions with role sets
  - ApprovalBroadcaster: fans out approval_requested events to participants;
    notifies originator on first allow verdict (fail-open; never crashes enforcement)
  - ApprovalService.respond(): scoped verdict processing, idempotent per scope,
    status transitions pending → partially_resolved → resolved
  - ApprovalService.has_explicit_allow(): strict check for gateway pre-check
  - API: POST/DELETE/GET /control/participants; PATCH /control/approvals/{id}/respond
  - Gateway wires broadcaster to SSE store; pre-checks has_explicit_allow() before
    routing ask-verdict tool calls to the approval workflow

All 176 tests pass (57 domain/service + 44 API + 52 Phase 8 + 23 gateway wiring).

https://claude.ai/code/session_01Cub9Why84sAFDdn5DebxnZ