### PR TITLE
docs(wiki): reflect control plane, gateway wiring, and multi-scope approvals

### DIFF
--- a/wiki/code/README.md
+++ b/wiki/code/README.md
@@ -14,6 +14,7 @@ This section maps the Python codebase to the [Four-Layer Architecture](../concep
 | `src/agent_hypervisor/compiler` | [compiler.md](compiler.md) | Layer 1 — Base Ontology | YAML → deterministic policy artifacts; `awc`/`ahc` CLI; semantic compiler pipeline |
 | `src/agent_hypervisor/authoring` | [authoring.md](authoring.md) | Layer 2 — Dynamic Ontology | Capability DSL, named policy presets, MCP integration; design-time only |
 | `src/agent_hypervisor/hypervisor` | [hypervisor.md](hypervisor.md) | PoC Gateway | FastAPI gateway, PolicyEngine, ProvenanceFirewall, approval workflow, policy tuner |
+| `src/agent_hypervisor/control_plane` | [control_plane.md](control_plane.md) | World Authoring Control Plane | Session governance, action approvals, SessionOverlay, multi-scope approval system; sits beside the data plane |
 | `src/agent_hypervisor/economic` | [economic.md](economic.md) | Economic Constraints | Budget enforcement at IR construction time; conservative cost estimation without LLM |
 | `src/agent_hypervisor/program_layer` | [program_layer.md](program_layer.md) | Optional Execution Abstraction | Sandboxed program execution after all policy checks have passed |
 
@@ -30,7 +31,7 @@ The [`modules/`](modules/README.md) subdirectory contains individual pages for e
 | `runtime/proxy.py` | [modules/proxy.md](modules/proxy.md) | Single MCP enforcement point; typed denial kinds |
 | `runtime/executor.py` | [modules/executor.md](modules/executor.md) | Process boundary; main process never calls handlers |
 | `hypervisor/firewall.py` | [modules/firewall.md](modules/firewall.md) | Structural provenance rules; sticky derivation (RULE-03) |
-| `hypervisor/mcp_gateway/` | [modules/mcp_gateway.md](modules/mcp_gateway.md) | JSON-RPC 2.0 MCP gateway; manifest-driven tool visibility; 4-stage enforcement |
+| `hypervisor/mcp_gateway/` | [modules/mcp_gateway.md](modules/mcp_gateway.md) | JSON-RPC 2.0 MCP gateway; manifest-driven tool visibility; 4-stage enforcement; control-plane bridge |
 | `core/hypervisor.py` | [modules/core_hypervisor.md](modules/core_hypervisor.md) | Deterministic resolution; physics laws override all rules |
 
 ## Architectural Patterns

--- a/wiki/code/control_plane.md
+++ b/wiki/code/control_plane.md
@@ -1,0 +1,314 @@
+# Package: `control_plane`
+
+**Source:** [`src/agent_hypervisor/control_plane/`](../../src/agent_hypervisor/control_plane/)
+
+The `control_plane` package is the **World Authoring Console** backend — the operator-facing control layer that sits beside the MCP gateway data plane. It provides session lifecycle governance, action authorization, world augmentation, and a multi-scope approval system. Crucially, it never touches the enforcement pipeline: the data plane's deterministic checks remain unmodified.
+
+Status: **Supported** (working and maintained; in-memory only — no disk persistence in current implementation).
+
+---
+
+## Purpose
+
+The control plane separates two concerns that are often conflated:
+
+| Concept | Actor | Effect |
+|---------|-------|--------|
+| **Act Authorization** (`ActionApproval`) | End user | Allow or deny one concrete action instance; no world mutation |
+| **World Augmentation** (`SessionOverlay`) | Operator | Temporarily expand/restrict a session's visible world; base manifest is never mutated |
+
+Neither mechanism weakens the enforcement pipeline. An approval that the data plane's policy engine would deny still requires the overlay or explicit allowance to succeed; the control plane surfaces these decisions to humans, it does not override them silently.
+
+---
+
+## Architecture
+
+```
+               ┌──────────────────────────────────────────────┐
+               │           Control Plane (/control/*)          │
+               │                                              │
+               │  ControlPlaneState                           │
+               │  ┌──────────────┐  ┌────────────────────┐   │
+               │  │ SessionStore │  │    EventStore       │   │
+               │  └──────────────┘  │  (append-only log)  │   │
+               │  ┌──────────────┐  └────────────────────┘   │
+               │  │ Approval     │  ┌────────────────────┐   │
+               │  │ Service      │  │ ParticipantRegistry │   │
+               │  └──────┬───────┘  └────────────────────┘   │
+               │         │          ┌────────────────────┐   │
+               │  ┌──────┴───────┐  │ ApprovalBroadcaster│   │
+               │  │ OverlayServ. │  └────────────────────┘   │
+               │  └──────────────┘  ┌────────────────────┐   │
+               │  ┌──────────────┐  │ WorldStateResolver  │   │
+               │  │              │  └────────────────────┘   │
+               └──────────────────────────────────────────────┘
+                          │  optional bridge
+               ┌──────────▼───────────────────────────────────┐
+               │         MCP Gateway (data plane)             │
+               │  tools/call → ToolCallEnforcer               │
+               │  ask verdict → ApprovalService               │
+               │  active overlays → tools/list rendering       │
+               └──────────────────────────────────────────────┘
+```
+
+---
+
+## Public API
+
+```python
+from agent_hypervisor.control_plane import (
+    # Domain types
+    Session, SessionEvent, ActionApproval,
+    SessionOverlay, OverlayChanges, WorldStateView,
+    ScopedVerdict, ParticipantRegistration,
+    # Domain functions
+    compute_action_fingerprint,
+    # Session state constants
+    SESSION_MODE_BACKGROUND, SESSION_MODE_INTERACTIVE,
+    SESSION_STATE_ACTIVE, SESSION_STATE_WAITING_APPROVAL,
+    SESSION_STATE_BLOCKED, SESSION_STATE_CLOSED,
+    # Approval status constants
+    APPROVAL_STATUS_PENDING, APPROVAL_STATUS_ALLOWED,
+    APPROVAL_STATUS_DENIED, APPROVAL_STATUS_EXPIRED,
+    # Event type constants
+    EVENT_TYPE_SESSION_CREATED, EVENT_TYPE_TOOL_CALL,
+    EVENT_TYPE_APPROVAL_REQUESTED, EVENT_TYPE_APPROVAL_RESOLVED,
+    EVENT_TYPE_OVERLAY_ATTACHED, EVENT_TYPE_OVERLAY_DETACHED,
+    # Services
+    SessionStore, EventStore, ApprovalService,
+    OverlayService, WorldStateResolver,
+    ParticipantRegistry,
+    # Event factories
+    make_session_created, make_tool_call,
+    make_approval_requested, make_approval_resolved,
+    make_overlay_attached, make_overlay_detached,
+    # World state bridge
+    world_state_to_manifest_dict,
+    # API
+    ControlPlaneState, create_control_plane_router,
+    create_control_plane_app,
+)
+```
+
+---
+
+## Key Modules
+
+| Module | Key Symbols | Description |
+|--------|-------------|-------------|
+| [`domain.py`](../../src/agent_hypervisor/control_plane/domain.py) | `Session`, `ActionApproval`, `SessionOverlay`, `OverlayChanges`, `WorldStateView`, `ScopedVerdict`, `ParticipantRegistration`, `compute_action_fingerprint` | All domain types and string-literal constants |
+| [`session_store.py`](../../src/agent_hypervisor/control_plane/session_store.py) | `SessionStore` | In-memory session lifecycle store (create/transition/close) |
+| [`event_store.py`](../../src/agent_hypervisor/control_plane/event_store.py) | `EventStore`, `make_*` factories | Append-only structured audit log |
+| [`approval_service.py`](../../src/agent_hypervisor/control_plane/approval_service.py) | `ApprovalService` | Fingerprint-bound, TTL-governed action approval with multi-scope verdict processing |
+| [`overlay_service.py`](../../src/agent_hypervisor/control_plane/overlay_service.py) | `OverlayService` | Session-scoped world augmentation overlays (attach/detach/expire) |
+| [`world_state_resolver.py`](../../src/agent_hypervisor/control_plane/world_state_resolver.py) | `WorldStateResolver`, `world_state_to_manifest_dict` | Deterministic WorldStateView: base manifest + active overlays |
+| [`participant_registry.py`](../../src/agent_hypervisor/control_plane/participant_registry.py) | `ParticipantRegistry` | Registry of SSE sessions eligible to vote on approval requests |
+| [`approval_broadcaster.py`](../../src/agent_hypervisor/control_plane/approval_broadcaster.py) | `ApprovalBroadcaster` | Fan-out of approval events to participant SSE queues |
+| [`api.py`](../../src/agent_hypervisor/control_plane/api.py) | `ControlPlaneState`, `create_control_plane_router`, `create_control_plane_app` | FastAPI router with 16 endpoints; injectable into the MCP gateway |
+
+---
+
+## Domain Model
+
+### `Session`
+
+A governed runtime session tracking one agent from creation through closure.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `session_id` | `str` | Immutable unique identifier |
+| `manifest_id` | `str` | WorldManifest this session operates under |
+| `mode` | `str` | `"background"` or `"interactive"` |
+| `state` | `str` | `"active"` / `"waiting_approval"` / `"blocked"` / `"closed"` |
+| `overlay_ids` | `list[str]` | Ordered list of attached overlay IDs |
+| `principal` | `Optional[str]` | User/agent identity if known |
+
+### `ActionApproval`
+
+A one-off authorization request bound to a specific `(tool_name, arguments)` fingerprint. An approval does **not** reveal hidden tools or widen the session's capability world — it authorizes exactly one concrete action instance.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `approval_id` | `str` | UUID |
+| `action_fingerprint` | `str` | SHA-256 (truncated 16 chars) of `tool + args` |
+| `status` | `str` | `pending` / `partially_resolved` / `resolved` / `allowed` / `denied` / `expired` |
+| `expires_at` | `str` | ISO-8601; empty = no expiry |
+| `scoped_verdicts` | `list[ScopedVerdict]` | Multi-scope verdict records (Phase 8) |
+
+### `ScopedVerdict` (Phase 8)
+
+A single verdict for one approval scope from one participant. Three scopes:
+
+| Scope | Actor Role | Effect |
+|-------|-----------|--------|
+| `one_off` | user | Marks the fingerprint explicitly allowed; call can be retried |
+| `session` | operator | Creates a `SessionOverlay` (reveal_tool) for the session |
+| `world` | admin | Global allow/deny (stub — not yet implemented) |
+
+### `SessionOverlay`
+
+An operator-authored temporary world augmentation for one session. The base manifest is never mutated.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `overlay_id` | `str` | UUID |
+| `changes` | `OverlayChanges` | `reveal_tools`, `hide_tools`, `widen_scope`, `narrow_scope` |
+| `ttl_seconds` | `Optional[int]` | `None` = no expiry |
+| `detached_at` | `Optional[str]` | Set when explicitly detached |
+
+### `WorldStateView`
+
+A computed, point-in-time view of a session's executable world: base manifest + all active overlays. Always deterministic: same inputs → same view.
+
+### `ParticipantRegistration`
+
+A registered SSE session that can vote on approval requests. Role set maps to approval scopes (`user → one_off`, `operator → session`, `admin → world`).
+
+---
+
+## Services
+
+### `SessionStore`
+
+In-memory session lifecycle store. Operations: `create()`, `get()`, `transition_state()`, `set_mode()`, `close()`, `list_active()`.
+
+### `EventStore`
+
+Append-only structured audit log. Events are never deleted or mutated. Factory helpers (`make_session_created()`, `make_tool_call()`, `make_approval_requested()`, etc.) construct well-typed `SessionEvent` records.
+
+### `ApprovalService`
+
+Core service for one-off action authorization.
+
+Key methods:
+
+| Method | Description |
+|--------|-------------|
+| `request_approval(session_id, tool_name, arguments, ...)` | Create a pending approval (emits `approval_requested` event if `event_store` provided) |
+| `respond(approval_id, verdicts, ...)` | Submit `ScopedVerdict` list; fires scope-specific side effects; idempotent per scope |
+| `resolve(approval_id, decision, resolved_by, ...)` | Legacy single-decision resolution; fail-closed on expiry |
+| `has_explicit_allow(session_id, tool_name, arguments)` | Strict check: `one_off` allow verdict or `status=allowed` — used by gateway pre-check |
+| `is_action_approved(session_id, tool_name, arguments)` | Broader check: pending or allowed, non-expired |
+| `check_expired()` | Sweep pending approvals past TTL → mark `expired` |
+
+**Invariants:**
+- Resolved approvals are retained for audit; never deleted.
+- Expired approvals fail closed even if the operator's decision arrives late.
+- `respond()` is idempotent per scope: a scope already recorded is skipped.
+
+### `OverlayService`
+
+Session-scoped world augmentation. `attach()` creates a `SessionOverlay` and records the overlay ID on the session. `detach()` marks it inactive. Expired overlays are silently skipped by the resolver.
+
+### `WorldStateResolver`
+
+Stateless resolver. `resolve(session_id, base_tools, base_constraints)` computes the `WorldStateView` by applying all active overlays in creation order (last-applied wins for conflicts). The `world_state_to_manifest_dict()` bridge converts a view to a dict suitable for loading as a `WorldManifest`.
+
+### `ParticipantRegistry`
+
+In-memory registry of SSE sessions eligible to vote. Keyed by `session_id`; re-registration replaces roles (upsert semantics).
+
+### `ApprovalBroadcaster`
+
+Fire-and-forget SSE fan-out.
+
+- **`approval_requested`** → sent to ALL registered participants when an approval is created.
+- **`approval_resolved`** → sent to the ORIGINATOR session when any scope returns `allow`.
+
+Broadcasts are non-blocking (`put_nowait()`). Failures are logged and swallowed — the enforcement path must never crash due to a notification failure.
+
+---
+
+## HTTP API
+
+Mounted at `/control/*` when `create_mcp_app()` receives a `ControlPlaneState`.
+
+### Sessions
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| `POST` | `/control/sessions` | Create session |
+| `GET` | `/control/sessions` | List sessions (filter by `state`, `mode`) |
+| `GET` | `/control/sessions/{id}` | Get session detail |
+| `PATCH` | `/control/sessions/{id}/mode` | Set mode (`background`/`interactive`) |
+| `DELETE` | `/control/sessions/{id}` | Close session |
+
+### World State & Audit
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| `GET` | `/control/sessions/{id}/world` | Get `WorldStateView` (live overlay composite) |
+| `GET` | `/control/sessions/{id}/events` | Get session event log |
+
+### Approvals
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| `GET` | `/control/approvals` | List pending approvals (sweeps expired before return) |
+| `GET` | `/control/approvals/{id}` | Get approval detail |
+| `POST` | `/control/approvals/{id}/resolve` | Resolve (legacy single-decision) |
+| `PATCH` | `/control/approvals/{id}/respond` | Submit `ScopedVerdict` list (Phase 8 multi-scope) |
+
+### Overlays
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| `GET` | `/control/sessions/{id}/overlays` | List session overlays |
+| `POST` | `/control/sessions/{id}/overlays` | Attach overlay |
+| `DELETE` | `/control/sessions/{id}/overlays/{ov_id}` | Detach overlay |
+
+### Participants (Phase 8)
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| `POST` | `/control/participants` | Register participant with roles |
+| `DELETE` | `/control/participants/{id}` | Unregister participant |
+| `GET` | `/control/participants` | List registered participants |
+
+---
+
+## Gateway Integration
+
+To attach the control plane to the MCP gateway:
+
+```python
+from agent_hypervisor.hypervisor.mcp_gateway import create_mcp_app
+from agent_hypervisor.control_plane import ControlPlaneState
+
+cp = ControlPlaneState.create()
+app = create_mcp_app("manifests/example_world.yaml", control_plane=cp)
+```
+
+When a `control_plane` is provided to `create_mcp_app()`:
+
+1. The `/control/*` router is mounted on the FastAPI app.
+2. The `get_base_manifest` bridge is auto-configured to read from the gateway's `SessionWorldResolver`.
+3. SSE connections opened via `GET /mcp/sse` are automatically registered with `SessionStore`.
+4. `tools/call` responses with verdict `ask` from the policy engine are routed to `ApprovalService.request_approval()` (instead of failing closed).
+5. `tools/list` uses `WorldStateResolver` when any active overlay exists for the session, so the visible tool surface reflects the current overlay state.
+6. A pre-check `has_explicit_allow()` before routing `ask` verdicts means that an already-approved action (via `one_off` scope) bypasses the approval workflow and executes directly.
+
+---
+
+## Security Invariants
+
+| Invariant | Where enforced |
+|-----------|----------------|
+| An approval does not reveal hidden tools | `ApprovalService`; only `SessionOverlay` with `reveal_tools` changes visibility |
+| An approval applies only to the exact fingerprint | `compute_action_fingerprint(tool_name, args)` → deterministic SHA-256 hash |
+| Expired approvals fail closed | `ApprovalService.respond()`, `resolve()`, `has_explicit_allow()` |
+| Base manifest is never mutated | `OverlayService.attach()` creates new overlay; `WorldStateResolver` composites non-destructively |
+| `respond()` is idempotent per scope | `existing_scopes` set check skips already-recorded scopes |
+| Broadcast failures do not affect enforcement | `put_nowait()` + logged swallow in `ApprovalBroadcaster` |
+| Overlay detachment is permanent | `detached_at` is set; `is_active()` returns False; never reversed |
+
+---
+
+## See Also
+
+- [Package: hypervisor](hypervisor.md) — parent package; the data plane this control plane sits beside
+- [AH MCP Gateway](modules/mcp_gateway.md) — gateway integration details; enforcement pipeline with `ask` routing
+- [World Manifest](../concepts/world-manifest.md) — the manifest that base world state comes from
+- [Trust, Taint, and Provenance](../concepts/trust-and-taint.md) — conceptual overview of the trust model
+- [`WORLD_AUTHORING.md`](../../WORLD_AUTHORING.md) — architecture overview for the World Authoring Console
+- [`docs/implementation/CONTROL_PLANE_PLAN.md`](../../docs/implementation/CONTROL_PLANE_PLAN.md) — phase-by-phase implementation plan

--- a/wiki/code/index.md
+++ b/wiki/code/index.md
@@ -14,6 +14,7 @@ This section maps the Python codebase to the [Four-Layer Architecture](../concep
 | `src/agent_hypervisor/compiler` | [compiler](compiler.md) | Layer 1 — Base Ontology | Canonical |
 | `src/agent_hypervisor/authoring` | [authoring](authoring.md) | Layer 2 — Dynamic Ontology | Supported |
 | `src/agent_hypervisor/hypervisor` | [hypervisor](hypervisor.md) | PoC Gateway | Supported |
+| `src/agent_hypervisor/control_plane` | [control_plane](control_plane.md) | World Authoring Control Plane | Supported |
 | `src/agent_hypervisor/economic` | [economic](economic.md) | Economic Constraints | Supported |
 | `src/agent_hypervisor/program_layer` | [program_layer](program_layer.md) | Optional Execution Abstraction | Supported |
 
@@ -30,7 +31,7 @@ These modules own critical security invariants and warrant individual pages.
 | `runtime/proxy.py` | [SafeMCPProxy](modules/proxy.md) | In-path MCP enforcement |
 | `runtime/executor.py` | [Executor](modules/executor.md) | Subprocess transport & boundary |
 | `hypervisor/firewall.py` | [ProvenanceFirewall](modules/firewall.md) | Provenance-aware tool firewall |
-| `hypervisor/mcp_gateway/` | [AH MCP Gateway](modules/mcp_gateway.md) | JSON-RPC 2.0 MCP gateway; manifest-driven tool visibility; 4-stage enforcement |
+| `hypervisor/mcp_gateway/` | [AH MCP Gateway](modules/mcp_gateway.md) | JSON-RPC 2.0 MCP gateway; manifest-driven tool visibility; 4-stage enforcement; control-plane bridge |
 | `core/hypervisor.py` | [Core Hypervisor](modules/core_hypervisor.md) | Reference manifest resolver |
 
 ## Architectural Patterns

--- a/wiki/code/modules/mcp_gateway.md
+++ b/wiki/code/modules/mcp_gateway.md
@@ -58,9 +58,9 @@ MCP Client (Claude / Cursor / any agent)
 | `__init__.py` | `create_mcp_app` | Public API; re-exports all key symbols |
 | `protocol.py` | `JSONRPCRequest`, `JSONRPCResponse`, `MCPTool`, `MCPToolResult`, error codes | JSON-RPC 2.0 wire types and MCP-specific error codes |
 | `tool_surface_renderer.py` | `ToolSurfaceRenderer` | Renders the visible tool surface for `tools/list` |
-| `tool_call_enforcer.py` | `ToolCallEnforcer`, `EnforcementDecision`, `InvocationProvenance` | 4-stage deterministic enforcement pipeline |
+| `tool_call_enforcer.py` | `ToolCallEnforcer`, `EnforcementDecision`, `InvocationProvenance` | 4-stage deterministic enforcement pipeline; `asked` property for control-plane routing |
 | `session_world_resolver.py` | `SessionWorldResolver` | Maps session IDs to WorldManifest instances |
-| `mcp_server.py` | `create_mcp_app`, `MCPGatewayState` | FastAPI app factory; all HTTP and SSE endpoints |
+| `mcp_server.py` | `create_mcp_app`, `MCPGatewayState` | FastAPI app factory; all HTTP and SSE endpoints; optional control-plane bridge |
 | `sse_transport.py` | `SSESessionStore` | Registry of active SSE sessions and stream helpers |
 
 ---
@@ -82,9 +82,13 @@ tools/call {name, arguments}
     │  No → deny, rule=registry:no_adapter
     │
     ▼  Stage 3: Policy engine check (optional)
-    │  PolicyEngine.evaluate() returns deny or ask?
-    │  Yes → deny, rule=policy:<matched_rule>
-    │         (ask is treated as deny — fail closed)
+    │  PolicyEngine.evaluate() returns deny → deny, rule=policy:<matched_rule>
+    │  PolicyEngine.evaluate() returns ask →
+    │    ├─ control plane present:
+    │    │    pre-check has_explicit_allow()
+    │    │      True  → continue to Stage 4 (execute directly)
+    │    │      False → route to ApprovalService (return approval_pending response)
+    │    └─ no control plane → deny, fail closed
     │
     ▼  Stage 4: Manifest constraint check
     │  cap.allows(tool_name, arguments)?
@@ -94,12 +98,15 @@ tools/call {name, arguments}
        allow, rule=manifest:allowed
 ```
 
+`EnforcementDecision` now exposes three boolean properties: `allowed`, `denied`, and `asked`. The `asked` verdict is only meaningful when the gateway has a control plane attached; callers without a control plane must treat `asked` as `denied` (fail closed).
+
 **Invariants:**
 - No LLM in this path.
 - Same input → same output (deterministic).
 - Unknown tool → deny, never allow.
 - If `manifest is None` (startup failure) → deny all.
 - Policy engine errors → deny (fail closed, not fail open).
+- `ask` without a control plane → deny (fail closed, not fail open).
 
 ---
 
@@ -205,6 +212,8 @@ A keep-alive comment is sent every ~25 s to prevent proxy timeouts.
 
 ## HTTP API Reference
 
+### MCP Data Plane
+
 | Method | Endpoint | Description |
 |--------|----------|-------------|
 | `POST` | `/mcp` | JSON-RPC 2.0 dispatcher (HTTP transport) |
@@ -215,6 +224,19 @@ A keep-alive comment is sent every ~25 s to prevent proxy timeouts.
 | `POST` | `/mcp/sessions/{session_id}/bind` | Bind session to a specific manifest |
 | `DELETE` | `/mcp/sessions/{session_id}` | Unbind session; revert to default |
 | `GET` | `/mcp/sessions` | List all active per-session bindings |
+
+### Control Plane (mounted when `control_plane` is provided)
+
+See [Package: control_plane](../control_plane.md) for the full control plane API reference. Summary:
+
+| Prefix | Routes | Description |
+|--------|--------|-------------|
+| `/control/sessions` | CRUD + mode | Session lifecycle management |
+| `/control/sessions/{id}/world` | GET | Live WorldStateView (base + overlays) |
+| `/control/sessions/{id}/events` | GET | Append-only audit log |
+| `/control/approvals` | GET, resolve, respond | Approval listing and multi-scope verdict submission |
+| `/control/sessions/{id}/overlays` | CRUD | Session overlay management |
+| `/control/participants` | CRUD | Participant registration for approval voting |
 
 ### Per-session manifest binding
 
@@ -260,6 +282,26 @@ Any other method returns JSON-RPC error `-32601` (Method not found).
 
 ---
 
+## Control Plane Integration
+
+When `create_mcp_app()` receives a `ControlPlaneState`, the gateway and control plane are bridged automatically:
+
+1. **Router mount** — the `/control/*` router is mounted on the FastAPI app.
+2. **Manifest bridge** — `get_base_manifest` callback is configured to read from `SessionWorldResolver`, so world-state endpoints reflect the live manifest.
+3. **Auto-registration** — sessions opened via `GET /mcp/sse` are automatically registered in `SessionStore`.
+4. **`ask` routing** — instead of failing closed on `ask` verdicts, the gateway calls `ApprovalService.request_approval()`. A pre-check via `has_explicit_allow()` lets already-approved actions skip the approval queue and execute directly.
+5. **Overlay-aware rendering** — `tools/list` uses `WorldStateResolver` when the session has active overlays, so revealed or hidden tools are reflected immediately in the visible surface.
+
+```python
+from agent_hypervisor.hypervisor.mcp_gateway import create_mcp_app
+from agent_hypervisor.control_plane import ControlPlaneState
+
+cp = ControlPlaneState.create()
+app = create_mcp_app("manifests/example_world.yaml", control_plane=cp)
+```
+
+---
+
 ## Usage
 
 ```python
@@ -277,6 +319,11 @@ app = create_mcp_app("manifests/example_world.yaml", use_default_policy=True)
 from agent_hypervisor.hypervisor.policy_engine import PolicyEngine
 engine = PolicyEngine.from_yaml("configs/my_policy.yaml")
 app = create_mcp_app("manifests/example_world.yaml", policy_engine=engine)
+
+# With full control plane (approval workflow + overlays)
+from agent_hypervisor.control_plane import ControlPlaneState
+cp = ControlPlaneState.create()
+app = create_mcp_app("manifests/example_world.yaml", control_plane=cp)
 ```
 
 **Quick test:**
@@ -308,18 +355,22 @@ curl -s -X POST http://127.0.0.1:8090/mcp \
 | Undeclared tool call always fails with `-32001` | `ToolCallEnforcer` Stage 1 |
 | Missing adapter always fails with `-32001` | `ToolCallEnforcer` Stage 2 |
 | Policy engine error → deny, not allow | `ToolCallEnforcer._evaluate_policy()` |
+| `ask` without a control plane → deny (fail closed) | `mcp_server._handle_tools_call()` |
 | Manifest load failure → gateway does not start | `SessionWorldResolver.__init__()` |
 | Per-session bind failure → session not registered | `SessionWorldResolver.register_session()` |
 | Reload failure → existing manifest retained | `SessionWorldResolver.reload()` |
 | Taint context always set on `EnforcementDecision` | `ToolCallEnforcer.enforce()` |
 | `trust_level` defaults to `"untrusted"` (TAINTED) | `InvocationProvenance` dataclass default |
 | Tool results always wrapped in `TaintedValue` | `mcp_server._handle_tools_call()` |
+| Overlay-revealed tools still pass enforcement pipeline | `ToolCallEnforcer` runs regardless of overlay source |
+| `has_explicit_allow()` required before bypassing approval queue | `mcp_server._handle_tools_call()` pre-check |
 
 ---
 
 ## See Also
 
 - [Package: hypervisor](../hypervisor.md) — parent package; PoC gateway, PolicyEngine, ProvenanceFirewall
+- [Package: control_plane](../control_plane.md) — control plane package; approval workflow, overlays, participant registry
 - [Taint Engine](taint.md) — monotonic taint lattice that `taint_context` plugs into
 - [ProvenanceFirewall](firewall.md) — structural provenance rules (the optional Stage 3 policy)
 - [World Manifest](../../concepts/world-manifest.md) — the manifest that defines the agent's world

--- a/wiki/index.md
+++ b/wiki/index.md
@@ -24,6 +24,7 @@ This is the curated, content-oriented catalog of the Agent Hypervisor knowledge 
 - [compiler](code/compiler.md) - Layer 1 Base Ontology: manifest → deterministic policy artifacts; awc/ahc CLI
 - [authoring](code/authoring.md) - Layer 2 Dynamic Ontology: Capability DSL, World presets, MCP integration
 - [hypervisor](code/hypervisor.md) - PoC Gateway: HTTP server, ProvenanceFirewall, PolicyEngine, provenance graph
+- [control_plane](code/control_plane.md) - World Authoring Control Plane: session governance, action approvals, overlays, multi-scope approval system
 - [economic](code/economic.md) - Economic constraints: budget enforcement, cost estimation, pricing registry
 - [program_layer](code/program_layer.md) - Optional execution abstraction: sandbox runtime, program executor
 - [core](code/core.md) - Portable reference implementation: ManifestResolver, WorldManifest, invariants

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -1,5 +1,38 @@
 # Wiki Log
 
+## [2026-04-10] ingest | Control plane, gateway wiring, and multi-scope approval system
+
+Reflected PRs #88 and #89 into the wiki. Three major features landed:
+
+**1. World Authoring Control Plane (`src/agent_hypervisor/control_plane/`)** — new package introducing:
+- `domain.py`: `Session`, `ActionApproval`, `SessionOverlay`, `OverlayChanges`, `WorldStateView`, `ScopedVerdict`, `ParticipantRegistration`, `compute_action_fingerprint`
+- `session_store.py`, `event_store.py`: session lifecycle and append-only audit log
+- `approval_service.py`: fingerprint-bound, TTL-governed action approvals
+- `overlay_service.py`, `world_state_resolver.py`: session-scoped world augmentation
+- `api.py` (`ControlPlaneState`, `create_control_plane_router`): 16-endpoint FastAPI router
+
+**2. Gateway Wiring (PR #88)** — `mcp_server.py` + `tool_call_enforcer.py`:
+- `MCPGatewayState.control_plane` field
+- `EnforcementDecision.asked` property; `ask` verdicts route to `ApprovalService` (fail-closed without CP)
+- SSE sessions auto-register with `SessionStore`
+- `tools/list` uses `WorldStateResolver` when overlays are active
+- `create_mcp_app()` auto-mounts `/control/*` router when CP provided
+
+**3. Multi-scope Approval System (PR #89)** — Phase 8:
+- `ScopedVerdict`, `ParticipantRegistration` domain types
+- `ParticipantRegistry`: registered SSE sessions eligible to vote
+- `ApprovalBroadcaster`: fan-out of `approval_requested` / `approval_resolved` events to SSE queues
+- `ApprovalService.respond()`: idempotent per-scope verdict processing; status `pending → partially_resolved → resolved`
+- `ApprovalService.has_explicit_allow()`: strict gateway pre-check
+- New API endpoints: POST/DELETE/GET `/control/participants`; PATCH `/control/approvals/{id}/respond`
+
+Updated:
+- `wiki/code/control_plane.md` — **created** (package-level article)
+- `wiki/code/modules/mcp_gateway.md` — updated enforcement pipeline diagram (ask routing), Control Plane Integration section, updated HTTP API reference, updated security invariants
+- `wiki/code/index.md` — added `control_plane` row to Package Map
+- `wiki/code/README.md` — added `control_plane` row to Packages table
+- `wiki/index.md` — added `control_plane` link under Code Documentation → Packages
+
 ## [2026-04-09] ingest | Ingested Python source code under src/
 
 Read all Python modules in `src/core/` and `src/agent_hypervisor/` (7 sub-packages, ~60 modules). Synthesized package-level and module-level wiki articles, and updated `PROMPT.txt` to include a formal Python code integration schema.


### PR DESCRIPTION
Add wiki/code/control_plane.md covering the new control_plane package
(SessionStore, EventStore, ApprovalService, OverlayService, WorldStateResolver,
ParticipantRegistry, ApprovalBroadcaster, ControlPlaneState HTTP API).

Update wiki/code/modules/mcp_gateway.md to document the gateway wiring
changes: EnforcementDecision.asked, ask-verdict routing to ApprovalService,
overlay-aware tools/list, SSE auto-registration, and the Control Plane
Integration section.

Update index pages (wiki/index.md, wiki/code/index.md, wiki/code/README.md)
to include the control_plane package entry.

Append log entry for PRs #88 and #89.

https://claude.ai/code/session_01DVdeC1GyNgYyEq2K4S92ph