### PR TITLE
feat(ui): add Web UI dashboard for manifests, decisions, traces, provenance, and benchmarks

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,15 +3,41 @@ version: "3.9"
 # Agent Hypervisor — local demo stack
 #
 # Services:
+#   gateway    : MCP gateway + Web UI dashboard  →  http://localhost:8090/ui
 #   demo       : runs the interactive demo (02_hypervisor_demo.py) and exits
 #   benchmarks : runs the full benchmark suite and emits a metrics report
 #
 # Usage:
+#   docker compose up gateway       # start the MCP gateway and open http://localhost:8090/ui
 #   docker compose up demo          # run the three-scenario demo
 #   docker compose up benchmarks    # run benchmark + metrics report
 #   docker compose run demo bash    # interactive shell for exploration
 
 services:
+  gateway:
+    build: .
+    command: >
+      python -c "
+      import uvicorn
+      from agent_hypervisor.hypervisor.mcp_gateway.mcp_server import create_mcp_app
+      from agent_hypervisor.control_plane.api import ControlPlaneState
+      cp = ControlPlaneState.create()
+      app = create_mcp_app(
+          manifest_path='manifests/example_world.yaml',
+          use_default_policy=True,
+          control_plane=cp,
+      )
+      uvicorn.run(app, host='0.0.0.0', port=8090)
+      "
+    ports:
+      - "8090:8090"
+    volumes:
+      - ./manifests:/app/manifests:ro
+      - ./_research/benchmarks/reports:/app/_research/benchmarks/reports:ro
+    environment:
+      - PYTHONPATH=/app/src
+
+
   demo:
     build: .
     command: python examples/basic/02_hypervisor_demo.py

--- a/src/agent_hypervisor/hypervisor/mcp_gateway/mcp_server.py
+++ b/src/agent_hypervisor/hypervisor/mcp_gateway/mcp_server.py
@@ -274,6 +274,16 @@ def create_mcp_app(
         # Wire the broadcaster to the SSE store so it can push events to queues.
         control_plane.broadcaster.set_sse_store(sse_store)
 
+    # Mount Web UI dashboard (always available; enriched when control plane is wired)
+    from agent_hypervisor.ui.router import create_ui_router
+    app.include_router(
+        create_ui_router(
+            gw_state=state,
+            cp_state=control_plane,
+            policy_path=_DEFAULT_POLICY_PATH if use_default_policy else None,
+        )
+    )
+
     # ------------------------------------------------------------------
     # JSON-RPC 2.0 dispatcher
     # ------------------------------------------------------------------

--- a/src/agent_hypervisor/ui/__init__.py
+++ b/src/agent_hypervisor/ui/__init__.py
@@ -1,0 +1,1 @@
+# ui — Web dashboard for manifests, decisions, traces, provenance, and benchmarks.

--- a/src/agent_hypervisor/ui/router.py
+++ b/src/agent_hypervisor/ui/router.py
@@ -1,0 +1,162 @@
+"""
+router.py — Web UI FastAPI router for Agent Hypervisor.
+
+Serves a dashboard at /ui with five tabs:
+  - Manifests:  Loaded world manifest and visible tool surface.
+  - Decisions:  Approval queue and resolved action authorizations (policy reasoning).
+  - Traces:     Session event logs — tool calls, mode changes, approvals.
+  - Provenance: Active provenance firewall policy rules.
+  - Benchmarks: AgentDojo benchmark run results.
+
+Mount via create_ui_router() and app.include_router() in create_mcp_app().
+
+Data API (all GET, JSON):
+  /ui/api/status      — gateway status + manifest summary
+  /ui/api/decisions   — all approvals (pending + history)
+  /ui/api/traces      — sessions with their event logs
+  /ui/api/provenance  — provenance policy rule list
+  /ui/api/benchmarks  — benchmark report files
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Optional
+
+import yaml
+from fastapi import APIRouter
+from fastapi.responses import HTMLResponse, JSONResponse, Response
+
+_STATIC = Path(__file__).parent / "static"
+# Reports live in _research/ at the repo root.
+_BENCHMARK_DIR = Path(__file__).parent.parent.parent.parent / "_research" / "benchmarks" / "reports"
+
+
+def create_ui_router(
+    gw_state: Any,
+    cp_state: Optional[Any] = None,
+    policy_path: Optional[Path] = None,
+) -> APIRouter:
+    """
+    Build and return the FastAPI router for the Web UI.
+
+    Args:
+        gw_state:    MCPGatewayState — provides manifest and session info.
+        cp_state:    Optional ControlPlaneState — approvals and event log.
+        policy_path: Path to the provenance policy YAML. When provided the
+                     Provenance tab renders the full rule table.
+
+    Returns:
+        APIRouter with /ui/* routes (no prefix set; caller includes directly).
+    """
+    router = APIRouter()
+
+    # ── Static files ─────────────────────────────────────────────────────────
+
+    @router.get("/ui", response_class=HTMLResponse, include_in_schema=False)
+    @router.get("/ui/", response_class=HTMLResponse, include_in_schema=False)
+    def ui_index() -> HTMLResponse:
+        return HTMLResponse((_STATIC / "index.html").read_text(encoding="utf-8"))
+
+    @router.get("/ui/style.css", include_in_schema=False)
+    def ui_css() -> Response:
+        return Response(
+            (_STATIC / "style.css").read_text(encoding="utf-8"),
+            media_type="text/css",
+        )
+
+    @router.get("/ui/app.js", include_in_schema=False)
+    def ui_js() -> Response:
+        return Response(
+            (_STATIC / "app.js").read_text(encoding="utf-8"),
+            media_type="application/javascript",
+        )
+
+    # ── Data API ─────────────────────────────────────────────────────────────
+
+    @router.get("/ui/api/status")
+    def api_status() -> JSONResponse:
+        """Gateway status and loaded manifest summary."""
+        manifest = gw_state.resolver.manifest
+        visible = [t.name for t in gw_state.renderer.render()]
+        caps = []
+        if manifest:
+            for cap in manifest.capabilities:
+                caps.append({
+                    "tool": cap.tool,
+                    "allow": getattr(cap, "allow", True),
+                    "constraints": cap.constraints or {},
+                })
+        return JSONResponse({
+            "status": "running",
+            "started_at": gw_state.started_at,
+            "manifest": {
+                "path": str(gw_state.manifest_path),
+                "workflow_id": manifest.workflow_id if manifest else None,
+                "version": getattr(manifest, "version", None) if manifest else None,
+                "capabilities": caps,
+                "visible_tools": visible,
+            },
+            "session_count": cp_state.session_store.count() if cp_state else 0,
+            "control_plane": cp_state is not None,
+        })
+
+    @router.get("/ui/api/decisions")
+    def api_decisions() -> JSONResponse:
+        """All approval records — pending and resolved."""
+        if cp_state is None:
+            return JSONResponse({"approvals": [], "pending_count": 0, "total": 0})
+        cp_state.approval_service.check_expired()
+        approvals = sorted(
+            cp_state.approval_service._approvals.values(),
+            key=lambda a: a.created_at,
+            reverse=True,
+        )
+        pending = sum(1 for a in approvals if a.status == "pending")
+        return JSONResponse({
+            "approvals": [a.to_dict() for a in approvals],
+            "pending_count": pending,
+            "total": len(approvals),
+        })
+
+    @router.get("/ui/api/traces")
+    def api_traces() -> JSONResponse:
+        """All sessions with their event logs."""
+        if cp_state is None:
+            return JSONResponse({"sessions": [], "total_events": 0})
+        sessions = cp_state.session_store.list()
+        total_events = 0
+        result = []
+        for s in sessions:
+            events = cp_state.event_store.get_session_events(s.session_id, limit=200)
+            total_events += len(events)
+            d = s.to_dict()
+            d["events"] = [e.to_dict() for e in events]
+            result.append(d)
+        return JSONResponse({"sessions": result, "total_events": total_events})
+
+    @router.get("/ui/api/provenance")
+    def api_provenance() -> JSONResponse:
+        """Provenance firewall policy rules."""
+        if policy_path is None or not Path(policy_path).exists():
+            return JSONResponse({"rules": [], "source": None, "count": 0})
+        try:
+            policy = yaml.safe_load(Path(policy_path).read_text())
+            rules = policy.get("rules", [])
+        except Exception as exc:
+            return JSONResponse({"rules": [], "error": str(exc), "source": str(policy_path), "count": 0})
+        return JSONResponse({"rules": rules, "source": str(policy_path), "count": len(rules)})
+
+    @router.get("/ui/api/benchmarks")
+    def api_benchmarks() -> JSONResponse:
+        """Benchmark report files from _research/benchmarks/reports/."""
+        reports = []
+        if _BENCHMARK_DIR.exists():
+            for f in sorted(_BENCHMARK_DIR.glob("*.md"), reverse=True):
+                try:
+                    reports.append({"filename": f.name, "content": f.read_text(encoding="utf-8")})
+                except Exception:
+                    pass
+        return JSONResponse({"reports": reports, "count": len(reports)})
+
+    return router

--- a/src/agent_hypervisor/ui/static/app.js
+++ b/src/agent_hypervisor/ui/static/app.js
@@ -1,0 +1,589 @@
+/* Agent Hypervisor — Governance Dashboard */
+
+'use strict';
+
+const REFRESH_MS = 5000;
+
+let activeTab = 'manifests';
+let refreshTimer = null;
+let lastRefresh = null;
+
+// Decisions tab state
+let decisionFilter = 'all';
+let expandedDecisionId = null;
+
+// Traces tab state
+let selectedSessionId = null;
+
+// ── Boot ──────────────────────────────────────────────────────────────────
+
+document.addEventListener('DOMContentLoaded', () => {
+  document.querySelectorAll('.tab-btn').forEach(btn => {
+    btn.addEventListener('click', () => switchTab(btn.dataset.tab));
+  });
+  switchTab('manifests');
+  // Poll pending count for header badge regardless of active tab
+  pollPendingCount();
+  setInterval(pollPendingCount, REFRESH_MS);
+});
+
+// ── Tab switching ─────────────────────────────────────────────────────────
+
+function switchTab(tab) {
+  activeTab = tab;
+  document.querySelectorAll('.tab-btn').forEach(b => b.classList.toggle('active', b.dataset.tab === tab));
+  document.querySelectorAll('.tab-panel').forEach(p => p.classList.toggle('active', p.id === `tab-${tab}`));
+  clearInterval(refreshTimer);
+  loadTab(tab);
+  refreshTimer = setInterval(() => loadTab(tab), REFRESH_MS);
+}
+
+async function loadTab(tab) {
+  try {
+    if (tab === 'manifests')  await loadManifests();
+    if (tab === 'decisions')  await loadDecisions();
+    if (tab === 'traces')     await loadTraces();
+    if (tab === 'provenance') await loadProvenance();
+    if (tab === 'benchmarks') await loadBenchmarks();
+    lastRefresh = Date.now();
+    setRefreshLabel();
+  } catch (err) {
+    console.error(`[ui] tab=${tab} error:`, err);
+  }
+}
+
+function setRefreshLabel() {
+  const el = document.getElementById('refresh-label');
+  if (el) el.textContent = `updated ${fmtTime(new Date().toISOString())}`;
+}
+
+// ── Header: pending badge + status dot ───────────────────────────────────
+
+async function pollPendingCount() {
+  try {
+    const d = await apiFetch('/ui/api/decisions');
+    const badge = document.getElementById('pending-badge');
+    const dot = document.getElementById('status-dot');
+    const label = document.getElementById('status-label');
+    if (dot) { dot.className = 'status-dot running'; }
+    if (label) label.textContent = 'running';
+    if (badge) {
+      if (d.pending_count > 0) {
+        badge.textContent = `${d.pending_count} pending`;
+        badge.style.display = '';
+      } else {
+        badge.style.display = 'none';
+      }
+    }
+  } catch {
+    const dot = document.getElementById('status-dot');
+    const label = document.getElementById('status-label');
+    if (dot) dot.className = 'status-dot error';
+    if (label) label.textContent = 'unreachable';
+  }
+}
+
+// ── Manifests tab ─────────────────────────────────────────────────────────
+
+async function loadManifests() {
+  const data = await apiFetch('/ui/api/status');
+  const panel = document.getElementById('tab-manifests');
+  const m = data.manifest;
+  panel.innerHTML = `
+    <div class="info-grid">
+      <div class="info-card">
+        <div class="info-card-header">Gateway</div>
+        <div class="kv-list">
+          <div class="kv"><span class="k">status</span><span class="v"><span class="tag tag-allow">running</span></span></div>
+          <div class="kv"><span class="k">started</span><span class="v">${relTime(data.started_at)}</span></div>
+          <div class="kv"><span class="k">sessions</span><span class="v">${data.session_count}</span></div>
+          <div class="kv"><span class="k">control plane</span><span class="v">${data.control_plane
+            ? '<span class="tag tag-allow">wired</span>'
+            : '<span class="tag tag-muted">not wired</span>'}</span></div>
+        </div>
+      </div>
+      <div class="info-card">
+        <div class="info-card-header">Manifest</div>
+        <div class="kv-list">
+          <div class="kv"><span class="k">workflow_id</span><span class="v mono">${esc(m.workflow_id || '—')}</span></div>
+          <div class="kv"><span class="k">version</span><span class="v mono">${esc(String(m.version || '—'))}</span></div>
+          <div class="kv"><span class="k">path</span><span class="v mono small">${esc(m.path || '—')}</span></div>
+          <div class="kv"><span class="k">visible tools</span><span class="v">${m.visible_tools.length}</span></div>
+          <div class="kv"><span class="k">capabilities</span><span class="v">${m.capabilities.length}</span></div>
+        </div>
+        <button class="btn btn-sm" onclick="reloadManifest()">Reload manifest</button>
+      </div>
+    </div>
+
+    <div class="section-title">Capability surface</div>
+    <table class="data-table">
+      <thead><tr><th>Tool</th><th>Allow</th><th>Constraints</th></tr></thead>
+      <tbody>
+        ${m.capabilities.length === 0
+          ? `<tr><td colspan="3" class="muted" style="padding:16px;text-align:center">No capabilities declared</td></tr>`
+          : m.capabilities.map(cap => `
+            <tr>
+              <td class="mono">${esc(cap.tool)}</td>
+              <td>${cap.allow !== false
+                ? '<span class="tag tag-allow">allow</span>'
+                : '<span class="tag tag-deny">deny</span>'}</td>
+              <td class="mono small">${
+                cap.constraints && Object.keys(cap.constraints).length
+                  ? esc(JSON.stringify(cap.constraints))
+                  : '<span class="muted">—</span>'
+              }</td>
+            </tr>`).join('')
+        }
+      </tbody>
+    </table>
+
+    ${m.visible_tools.length ? `
+      <div class="section-title">Rendered tool surface</div>
+      <div class="pill-group">
+        ${m.visible_tools.map(t => `<span class="tool-pill">${esc(t)}</span>`).join('')}
+      </div>` : ''}
+  `;
+}
+
+async function reloadManifest() {
+  try {
+    await fetch('/mcp/reload', { method: 'POST' });
+    await loadManifests();
+  } catch (e) {
+    console.error('[ui] reload failed', e);
+  }
+}
+
+// ── Decisions tab ─────────────────────────────────────────────────────────
+
+async function loadDecisions() {
+  const data = await apiFetch('/ui/api/decisions');
+  renderDecisions(data);
+}
+
+function renderDecisions(data) {
+  const panel = document.getElementById('tab-decisions');
+  const list = data.approvals.filter(a =>
+    decisionFilter === 'all' || a.status === decisionFilter
+  );
+
+  panel.innerHTML = `
+    <div class="stats-row">
+      <div class="stat">
+        <div class="stat-val${data.pending_count > 0 ? ' stat-pending' : ''}">${data.pending_count}</div>
+        <div class="stat-label">pending</div>
+      </div>
+      <div class="stat">
+        <div class="stat-val">${data.total}</div>
+        <div class="stat-label">total</div>
+      </div>
+      <div class="stat">
+        <div class="stat-val">${data.approvals.filter(a=>a.status==='allowed').length}</div>
+        <div class="stat-label">allowed</div>
+      </div>
+      <div class="stat">
+        <div class="stat-val">${data.approvals.filter(a=>a.status==='denied').length}</div>
+        <div class="stat-label">denied</div>
+      </div>
+    </div>
+
+    <div class="filter-row">
+      ${['all','pending','allowed','denied','expired','partially_resolved','resolved'].map(f =>
+        `<button class="filter-btn${decisionFilter===f?' active':''}" onclick="setDecisionFilter('${f}')">${f}</button>`
+      ).join('')}
+    </div>
+
+    ${list.length === 0
+      ? emptyState('No decisions', decisionFilter === 'all'
+          ? 'Tool calls that trigger the approval workflow will appear here.'
+          : `No approvals with status "${decisionFilter}".`)
+      : `<div class="decision-list">${list.map(renderDecisionRow).join('')}</div>`
+    }
+  `;
+}
+
+function renderDecisionRow(a) {
+  const expanded = expandedDecisionId === a.approval_id;
+  const statusCls = statusTagClass(a.status);
+  return `
+    <div class="decision-row${expanded ? ' expanded' : ''}" onclick="toggleDecision('${a.approval_id}')">
+      <div class="decision-summary">
+        <span class="tag ${statusCls}">${a.status}</span>
+        <span class="mono">${esc(a.tool_name)}</span>
+        <span class="muted">${esc(a.session_id.slice(0, 8))}…</span>
+        <span class="muted">${relTime(a.created_at)}</span>
+        ${a.status === 'pending' ? `
+          <div class="decision-actions" onclick="event.stopPropagation()">
+            <button class="btn btn-allow btn-sm" onclick="resolveApproval('${a.approval_id}','allowed')">Allow</button>
+            <button class="btn btn-deny btn-sm"  onclick="resolveApproval('${a.approval_id}','denied')">Deny</button>
+          </div>` : ''}
+      </div>
+      ${expanded ? `
+        <div class="decision-detail">
+          <div class="kv-list">
+            <div class="kv"><span class="k">approval_id</span> <span class="v mono small">${esc(a.approval_id)}</span></div>
+            <div class="kv"><span class="k">session_id</span>  <span class="v mono small">${esc(a.session_id)}</span></div>
+            <div class="kv"><span class="k">requested_by</span><span class="v mono">${esc(a.requested_by)}</span></div>
+            <div class="kv"><span class="k">fingerprint</span> <span class="v mono small">${esc(a.action_fingerprint)}</span></div>
+            <div class="kv"><span class="k">expires</span>     <span class="v">${a.expires_at ? relTime(a.expires_at) : '—'}</span></div>
+            ${a.resolved_by ? `<div class="kv"><span class="k">resolved_by</span><span class="v mono">${esc(a.resolved_by)}</span></div>` : ''}
+            ${a.resolved_at ? `<div class="kv"><span class="k">resolved_at</span><span class="v">${relTime(a.resolved_at)}</span></div>` : ''}
+            ${a.rationale   ? `<div class="kv"><span class="k">rationale</span>  <span class="v">${esc(a.rationale)}</span></div>` : ''}
+          </div>
+          <div class="detail-section">
+            <div class="detail-label">Arguments</div>
+            <pre class="code-block">${esc(JSON.stringify(a.arguments_summary, null, 2))}</pre>
+          </div>
+          ${a.scoped_verdicts && a.scoped_verdicts.length ? `
+            <div class="detail-section">
+              <div class="detail-label">Scoped verdicts</div>
+              ${a.scoped_verdicts.map(sv => `
+                <div class="verdict-row">
+                  <span class="tag tag-muted">${esc(sv.scope)}</span>
+                  <span class="tag ${sv.verdict === 'allow' ? 'tag-allow' : 'tag-deny'}">${esc(sv.verdict)}</span>
+                  ${sv.participant_id ? `<span class="muted small mono">${esc(sv.participant_id)}</span>` : ''}
+                </div>`).join('')}
+            </div>` : ''}
+        </div>` : ''}
+    </div>
+  `;
+}
+
+function toggleDecision(id) {
+  expandedDecisionId = expandedDecisionId === id ? null : id;
+  loadDecisions();
+}
+
+function setDecisionFilter(f) {
+  decisionFilter = f;
+  loadDecisions();
+}
+
+async function resolveApproval(id, decision) {
+  try {
+    await fetch(`/control/approvals/${id}/resolve`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ decision, resolved_by: 'ui_operator' }),
+    });
+    expandedDecisionId = null;
+    await loadDecisions();
+  } catch (e) {
+    console.error('[ui] resolve failed', e);
+  }
+}
+
+function statusTagClass(s) {
+  return {
+    pending:            'tag-pending',
+    allowed:            'tag-allow',
+    denied:             'tag-deny',
+    expired:            'tag-muted',
+    partially_resolved: 'tag-ask',
+    resolved:           'tag-ask',
+  }[s] || 'tag-muted';
+}
+
+// ── Traces tab ────────────────────────────────────────────────────────────
+
+async function loadTraces() {
+  const data = await apiFetch('/ui/api/traces');
+  renderTraces(data);
+}
+
+function renderTraces(data) {
+  const panel = document.getElementById('tab-traces');
+
+  if (data.sessions.length === 0) {
+    panel.innerHTML = emptyState('No sessions', 'Sessions appear here when agents connect.');
+    return;
+  }
+
+  // Auto-select first session if none selected (or selection gone)
+  const ids = data.sessions.map(s => s.session_id);
+  if (!selectedSessionId || !ids.includes(selectedSessionId)) {
+    selectedSessionId = ids[0];
+  }
+  const selected = data.sessions.find(s => s.session_id === selectedSessionId);
+
+  panel.innerHTML = `
+    <div class="traces-layout">
+      <div class="session-list">
+        ${data.sessions.map(s => renderSessionItem(s, s.session_id === selectedSessionId)).join('')}
+      </div>
+      <div class="event-timeline">
+        ${selected ? renderEventTimeline(selected) : emptyState('Select a session', '')}
+      </div>
+    </div>
+  `;
+}
+
+function renderSessionItem(s, active) {
+  const stCls = { active: 'tag-allow', closed: 'tag-muted', waiting_approval: 'tag-pending', blocked: 'tag-deny' }[s.state] || 'tag-muted';
+  return `
+    <div class="session-item${active ? ' active' : ''}" onclick="selectSession('${s.session_id}')">
+      <div class="session-item-header">
+        <span class="mono small">${esc(s.session_id.slice(0, 14))}…</span>
+        <span class="tag ${stCls}">${s.state}</span>
+      </div>
+      <div class="session-item-meta">
+        <span class="muted">${esc(s.manifest_id)}</span>
+        <span class="muted">${s.events.length} events</span>
+      </div>
+      <div class="muted small">${relTime(s.created_at)}</div>
+    </div>
+  `;
+}
+
+function renderEventTimeline(s) {
+  if (s.events.length === 0) {
+    return emptyState('No events', 'Events will appear when the agent acts.');
+  }
+  const rows = s.events.slice().reverse().map(renderEventRow).join('');
+  return `<div class="timeline">${rows}</div>`;
+}
+
+function renderEventRow(e) {
+  const typeCls = evtClass(e.type);
+  const decTag = e.decision
+    ? `<span class="tag ${decisionTagCls(e.decision)}">${esc(e.decision)}</span>`
+    : '';
+  const ruleTag = e.rule_hit
+    ? `<span class="rule-hit mono small">${esc(e.rule_hit)}</span>`
+    : '';
+  return `
+    <div class="event-row">
+      <div class="event-time muted small">${fmtTime(e.timestamp)}</div>
+      <div class="event-dot ${typeCls}"></div>
+      <div class="event-body">
+        <div class="event-header">
+          <span class="event-type ${typeCls}">${esc(e.type)}</span>
+          ${decTag}
+          ${ruleTag}
+        </div>
+        ${e.payload && Object.keys(e.payload).length
+          ? `<div class="event-payload mono small">${esc(fmtPayload(e.payload))}</div>`
+          : ''}
+      </div>
+    </div>
+  `;
+}
+
+function selectSession(id) {
+  selectedSessionId = id;
+  loadTraces();
+}
+
+function evtClass(type) {
+  return {
+    tool_call:           'evt-tool',
+    approval_requested:  'evt-ask',
+    approval_resolved:   'evt-resolved',
+    session_created:     'evt-session',
+    session_closed:      'evt-session',
+    mode_changed:        'evt-session',
+    overlay_attached:    'evt-overlay',
+    overlay_detached:    'evt-overlay',
+  }[type] || 'evt-default';
+}
+
+function decisionTagCls(d) {
+  return { allow: 'tag-allow', allowed: 'tag-allow', deny: 'tag-deny', denied: 'tag-deny', pending: 'tag-pending' }[d] || 'tag-muted';
+}
+
+function fmtPayload(p) {
+  const parts = [];
+  if (p.tool_name)             parts.push(p.tool_name);
+  if (p.approval_id)           parts.push(`approval:${p.approval_id.slice(0, 8)}…`);
+  if (p.resolved_by)           parts.push(`by:${p.resolved_by}`);
+  if (p.old_mode && p.new_mode) parts.push(`${p.old_mode}→${p.new_mode}`);
+  if (p.manifest_id)           parts.push(`manifest:${p.manifest_id}`);
+  if (p.overlay_id)            parts.push(`overlay:${p.overlay_id.slice(0, 8)}…`);
+  return parts.join('  ') || JSON.stringify(p);
+}
+
+// ── Provenance tab ────────────────────────────────────────────────────────
+
+async function loadProvenance() {
+  const data = await apiFetch('/ui/api/provenance');
+  renderProvenance(data);
+}
+
+function renderProvenance(data) {
+  const panel = document.getElementById('tab-provenance');
+
+  if (!data.rules || data.rules.length === 0) {
+    panel.innerHTML = emptyState(
+      'No policy loaded',
+      'Policy rules appear here when a provenance firewall is configured.'
+    );
+    return;
+  }
+
+  const denyCount  = data.rules.filter(r => r.verdict === 'deny').length;
+  const askCount   = data.rules.filter(r => r.verdict === 'ask').length;
+  const allowCount = data.rules.filter(r => r.verdict === 'allow').length;
+
+  panel.innerHTML = `
+    <div class="stats-row">
+      <div class="stat"><div class="stat-val">${data.count}</div><div class="stat-label">rules</div></div>
+      <div class="stat"><div class="stat-val" style="color:var(--deny)">${denyCount}</div><div class="stat-label">deny</div></div>
+      <div class="stat"><div class="stat-val" style="color:var(--ask)">${askCount}</div><div class="stat-label">ask</div></div>
+      <div class="stat"><div class="stat-val" style="color:var(--allow)">${allowCount}</div><div class="stat-label">allow</div></div>
+    </div>
+
+    <div class="provenance-note">
+      Rules evaluated in order. Verdict precedence: <strong>deny &gt; ask &gt; allow</strong>.
+      Default on no match: <strong>deny</strong>.<br>
+      Source: <span class="mono small">${esc(data.source || '—')}</span>
+    </div>
+
+    <table class="data-table">
+      <thead>
+        <tr>
+          <th>#</th>
+          <th>Rule ID</th>
+          <th>Tool</th>
+          <th>Argument</th>
+          <th>Provenance</th>
+          <th>Verdict</th>
+        </tr>
+      </thead>
+      <tbody>
+        ${data.rules.map((r, i) => `
+          <tr>
+            <td class="muted small">${i + 1}</td>
+            <td class="mono small">${esc(r.id || '—')}</td>
+            <td class="mono">${esc(r.tool || '—')}</td>
+            <td class="mono">${esc(r.argument || '—')}</td>
+            <td class="mono">${esc(r.provenance || '—')}</td>
+            <td><span class="tag ${verdictTagCls(r.verdict)}">${esc(r.verdict || '—')}</span></td>
+          </tr>`).join('')}
+      </tbody>
+    </table>
+  `;
+}
+
+function verdictTagCls(v) {
+  return { allow: 'tag-allow', ask: 'tag-ask', deny: 'tag-deny' }[v] || 'tag-muted';
+}
+
+// ── Benchmarks tab ────────────────────────────────────────────────────────
+
+async function loadBenchmarks() {
+  const data = await apiFetch('/ui/api/benchmarks');
+  renderBenchmarks(data);
+}
+
+function renderBenchmarks(data) {
+  const panel = document.getElementById('tab-benchmarks');
+  if (!data.reports || data.reports.length === 0) {
+    panel.innerHTML = emptyState(
+      'No benchmark reports',
+      'Run the benchmark suite to generate reports: python benchmarks/runner.py'
+    );
+    return;
+  }
+  panel.innerHTML = data.reports.map(r => `
+    <div class="report-card">
+      <div class="report-filename">${esc(r.filename)}</div>
+      ${mdToHtml(r.content)}
+    </div>
+  `).join('');
+}
+
+// Minimal markdown → HTML for benchmark reports (handles headers, tables, lists)
+function mdToHtml(md) {
+  let html = '';
+  const lines = md.split('\n');
+  let tableLines = [];
+  let inTable = false;
+
+  const flushTable = () => {
+    if (tableLines.length) html += renderMdTable(tableLines);
+    tableLines = [];
+    inTable = false;
+  };
+
+  for (const raw of lines) {
+    const line = raw.trimEnd();
+
+    if (line.startsWith('|')) {
+      inTable = true;
+      tableLines.push(line);
+      continue;
+    }
+
+    if (inTable) flushTable();
+
+    if (line.startsWith('# '))       html += `<h1 class="md-h1">${mdInline(line.slice(2))}</h1>`;
+    else if (line.startsWith('## ')) html += `<h2 class="md-h2">${mdInline(line.slice(3))}</h2>`;
+    else if (line.startsWith('### '))html += `<h3 class="md-h3">${mdInline(line.slice(4))}</h3>`;
+    else if (line.startsWith('- '))  html += `<div class="md-li">${mdInline(line.slice(2))}</div>`;
+    else if (line.trim())            html += `<p class="md-p">${mdInline(line)}</p>`;
+  }
+  if (inTable) flushTable();
+  return html;
+}
+
+function mdInline(s) {
+  return esc(s)
+    .replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>')
+    .replace(/`(.+?)`/g, '<span class="mono small">$1</span>');
+}
+
+function renderMdTable(rows) {
+  const cells = rows.map(r =>
+    r.split('|').slice(1, -1).map(c => c.trim())
+  );
+  // rows[1] is the separator row (---)
+  const [header, , ...body] = cells;
+  if (!header) return '';
+  return `
+    <table class="data-table md-table">
+      <thead><tr>${header.map(h => `<th>${mdInline(h)}</th>`).join('')}</tr></thead>
+      <tbody>${body.map(row =>
+        `<tr>${row.map(c => `<td>${mdInline(c)}</td>`).join('')}</tr>`
+      ).join('')}</tbody>
+    </table>`;
+}
+
+// ── Shared helpers ────────────────────────────────────────────────────────
+
+async function apiFetch(path) {
+  const resp = await fetch(path);
+  if (!resp.ok) throw new Error(`${resp.status} ${resp.statusText}`);
+  return resp.json();
+}
+
+function relTime(iso) {
+  if (!iso) return '—';
+  const d = Date.now() - new Date(iso).getTime();
+  if (d < 0)        return 'just now';
+  if (d < 60000)    return `${Math.round(d / 1000)}s ago`;
+  if (d < 3600000)  return `${Math.round(d / 60000)}m ago`;
+  if (d < 86400000) return `${Math.round(d / 3600000)}h ago`;
+  return new Date(iso).toLocaleDateString();
+}
+
+function fmtTime(iso) {
+  if (!iso) return '—';
+  return new Date(iso).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' });
+}
+
+function emptyState(title, msg) {
+  return `
+    <div class="empty-state">
+      <div class="empty-icon">◯</div>
+      <div class="empty-title">${esc(title)}</div>
+      <div class="empty-msg">${esc(msg)}</div>
+    </div>`;
+}
+
+function esc(s) {
+  return String(s)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}

--- a/src/agent_hypervisor/ui/static/index.html
+++ b/src/agent_hypervisor/ui/static/index.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Agent Hypervisor</title>
+  <link rel="stylesheet" href="/ui/style.css">
+</head>
+<body>
+  <div class="app">
+    <header>
+      <div class="header-brand">
+        <span class="brand-icon">⬡</span>
+        <div>
+          <div class="brand-title">Agent Hypervisor</div>
+          <div class="brand-sub">Execution Governance Dashboard</div>
+        </div>
+      </div>
+      <div class="header-status">
+        <span class="status-dot" id="status-dot"></span>
+        <span class="status-label" id="status-label">connecting…</span>
+        <span class="badge" id="pending-badge" style="display:none"></span>
+      </div>
+    </header>
+
+    <nav class="tab-bar">
+      <button class="tab-btn active" data-tab="manifests">Manifests</button>
+      <button class="tab-btn" data-tab="decisions">Decisions</button>
+      <button class="tab-btn" data-tab="traces">Traces</button>
+      <button class="tab-btn" data-tab="provenance">Provenance</button>
+      <button class="tab-btn" data-tab="benchmarks">Benchmarks</button>
+      <div class="tab-refresh">
+        <span class="refresh-label" id="refresh-label">—</span>
+      </div>
+    </nav>
+
+    <main>
+      <div id="tab-manifests"  class="tab-panel active"><div class="loading"><div class="spinner"></div>Loading…</div></div>
+      <div id="tab-decisions"  class="tab-panel"><div class="loading"><div class="spinner"></div>Loading…</div></div>
+      <div id="tab-traces"     class="tab-panel"><div class="loading"><div class="spinner"></div>Loading…</div></div>
+      <div id="tab-provenance" class="tab-panel"><div class="loading"><div class="spinner"></div>Loading…</div></div>
+      <div id="tab-benchmarks" class="tab-panel"><div class="loading"><div class="spinner"></div>Loading…</div></div>
+    </main>
+  </div>
+  <script src="/ui/app.js"></script>
+</body>
+</html>

--- a/src/agent_hypervisor/ui/static/style.css
+++ b/src/agent_hypervisor/ui/static/style.css
@@ -1,0 +1,675 @@
+/* Agent Hypervisor — Governance Dashboard */
+
+:root {
+  --bg:          #0f1117;
+  --surface:     #1a1d27;
+  --surface2:    #22263a;
+  --border:      #2e3250;
+  --text:        #e2e8f0;
+  --text-muted:  #6b7280;
+  --text-dim:    #9ca3af;
+
+  --allow:   #22c55e;
+  --ask:     #f59e0b;
+  --deny:    #ef4444;
+  --pending: #818cf8;
+  --muted:   #374151;
+
+  --allow-bg:   rgba(34,197,94,0.1);
+  --ask-bg:     rgba(245,158,11,0.1);
+  --deny-bg:    rgba(239,68,68,0.1);
+  --pending-bg: rgba(129,140,248,0.12);
+
+  --accent: #4f6ef7;
+
+  --font: 'Inter', system-ui, -apple-system, sans-serif;
+  --mono: 'JetBrains Mono', 'Fira Code', monospace;
+
+  --header-h: 60px;
+  --tabbar-h: 44px;
+}
+
+* { box-sizing: border-box; margin: 0; padding: 0; }
+
+body {
+  background: var(--bg);
+  color: var(--text);
+  font-family: var(--font);
+  font-size: 14px;
+  line-height: 1.6;
+  height: 100vh;
+  overflow: hidden;
+}
+
+/* ── App shell ── */
+
+.app {
+  display: grid;
+  grid-template-rows: var(--header-h) var(--tabbar-h) 1fr;
+  height: 100vh;
+}
+
+/* ── Header ── */
+
+header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 28px;
+  border-bottom: 1px solid var(--border);
+  background: var(--surface);
+}
+
+.header-brand {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.brand-icon {
+  font-size: 22px;
+  color: var(--accent);
+}
+
+.brand-title {
+  font-size: 15px;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+}
+
+.brand-sub {
+  font-size: 11px;
+  color: var(--text-muted);
+}
+
+.header-status {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.status-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--text-muted);
+  transition: background 0.3s;
+}
+
+.status-dot.running  { background: var(--allow); box-shadow: 0 0 6px var(--allow); }
+.status-dot.error    { background: var(--deny); }
+
+.status-label {
+  font-size: 13px;
+  color: var(--text-dim);
+}
+
+.badge {
+  font-size: 11px;
+  font-weight: 700;
+  padding: 2px 8px;
+  border-radius: 99px;
+  background: var(--pending-bg);
+  color: var(--pending);
+  border: 1px solid rgba(129,140,248,0.3);
+}
+
+/* ── Tab bar ── */
+
+.tab-bar {
+  display: flex;
+  align-items: center;
+  gap: 0;
+  border-bottom: 1px solid var(--border);
+  padding: 0 20px;
+  background: var(--surface);
+}
+
+.tab-btn {
+  background: none;
+  border: none;
+  color: var(--text-muted);
+  cursor: pointer;
+  font-family: var(--font);
+  font-size: 13px;
+  font-weight: 500;
+  padding: 0 16px;
+  height: var(--tabbar-h);
+  border-bottom: 2px solid transparent;
+  transition: color 0.15s, border-color 0.15s;
+  white-space: nowrap;
+}
+
+.tab-btn:hover { color: var(--text); }
+
+.tab-btn.active {
+  color: var(--text);
+  border-bottom-color: var(--accent);
+}
+
+.tab-refresh {
+  margin-left: auto;
+  padding-right: 4px;
+}
+
+.refresh-label {
+  font-size: 11px;
+  color: var(--text-muted);
+  font-family: var(--mono);
+}
+
+/* ── Tab panels ── */
+
+main {
+  overflow: hidden;
+  position: relative;
+}
+
+.tab-panel {
+  display: none;
+  height: 100%;
+  overflow-y: auto;
+  padding: 24px 28px;
+}
+
+.tab-panel.active { display: block; }
+
+/* ── Tags / badges ── */
+
+.tag {
+  display: inline-block;
+  padding: 1px 8px;
+  border-radius: 99px;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.03em;
+}
+
+.tag-allow   { background: var(--allow-bg);   color: var(--allow); }
+.tag-ask     { background: var(--ask-bg);     color: var(--ask); }
+.tag-deny    { background: var(--deny-bg);    color: var(--deny); }
+.tag-pending { background: var(--pending-bg); color: var(--pending); }
+.tag-muted   { background: var(--surface2);   color: var(--text-muted); border: 1px solid var(--border); }
+
+/* ── Utility classes ── */
+
+.mono  { font-family: var(--mono); }
+.small { font-size: 11px; }
+.muted { color: var(--text-muted); }
+
+/* ── Loading / empty ── */
+
+.loading {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  color: var(--text-muted);
+  padding: 40px 0;
+}
+
+.spinner {
+  width: 16px;
+  height: 16px;
+  border: 2px solid var(--border);
+  border-top-color: var(--accent);
+  border-radius: 50%;
+  animation: spin 0.7s linear infinite;
+  flex-shrink: 0;
+}
+
+@keyframes spin { to { transform: rotate(360deg); } }
+
+.empty-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 60px 40px;
+  color: var(--text-muted);
+  text-align: center;
+}
+
+.empty-icon  { font-size: 36px; opacity: 0.3; }
+.empty-title { font-size: 15px; font-weight: 600; color: var(--text-dim); }
+.empty-msg   { font-size: 13px; max-width: 280px; }
+
+/* ── Buttons ── */
+
+.btn {
+  background: var(--surface2);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  color: var(--text-dim);
+  cursor: pointer;
+  font-family: var(--font);
+  font-size: 13px;
+  padding: 6px 12px;
+  transition: all 0.15s;
+}
+
+.btn:hover { border-color: var(--accent); color: var(--text); }
+
+.btn-sm { font-size: 11px; padding: 3px 9px; }
+
+.btn-allow {
+  background: var(--allow-bg);
+  border-color: rgba(34,197,94,0.3);
+  color: var(--allow);
+}
+.btn-allow:hover { background: rgba(34,197,94,0.2); }
+
+.btn-deny {
+  background: var(--deny-bg);
+  border-color: rgba(239,68,68,0.3);
+  color: var(--deny);
+}
+.btn-deny:hover { background: rgba(239,68,68,0.2); }
+
+/* ── Tables ── */
+
+.data-table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: 12px;
+  font-size: 13px;
+}
+
+.data-table th {
+  text-align: left;
+  padding: 8px 12px;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+  border-bottom: 1px solid var(--border);
+}
+
+.data-table td {
+  padding: 9px 12px;
+  border-bottom: 1px solid rgba(46,50,80,0.6);
+  vertical-align: middle;
+}
+
+.data-table tr:last-child td { border-bottom: none; }
+
+.data-table tr:hover td { background: var(--surface2); }
+
+/* ── Stats row ── */
+
+.stats-row {
+  display: flex;
+  gap: 16px;
+  margin-bottom: 20px;
+}
+
+.stat {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 12px 20px;
+  min-width: 80px;
+  text-align: center;
+}
+
+.stat-val {
+  font-size: 26px;
+  font-weight: 700;
+  line-height: 1;
+  margin-bottom: 4px;
+}
+
+.stat-val.stat-pending { color: var(--pending); }
+
+.stat-label {
+  font-size: 11px;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+/* ── KV list ── */
+
+.kv-list {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin-bottom: 12px;
+}
+
+.kv {
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+}
+
+.kv .k {
+  font-size: 11px;
+  color: var(--text-muted);
+  min-width: 100px;
+  flex-shrink: 0;
+}
+
+.kv .v { font-size: 13px; }
+.kv .v.mono { font-family: var(--mono); }
+
+/* ── Info grid (Manifests tab) ── */
+
+.info-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+  gap: 16px;
+  margin-bottom: 28px;
+}
+
+.info-card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 16px 20px;
+}
+
+.info-card-header {
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+  margin-bottom: 12px;
+}
+
+.section-title {
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+  margin: 24px 0 8px;
+}
+
+.pill-group {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-top: 8px;
+}
+
+.tool-pill {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 3px 10px;
+  font-family: var(--mono);
+  font-size: 12px;
+  color: var(--text-dim);
+}
+
+/* ── Filter row ── */
+
+.filter-row {
+  display: flex;
+  gap: 6px;
+  margin-bottom: 16px;
+}
+
+.filter-btn {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 99px;
+  color: var(--text-muted);
+  cursor: pointer;
+  font-family: var(--font);
+  font-size: 12px;
+  padding: 4px 12px;
+  transition: all 0.15s;
+}
+
+.filter-btn:hover { border-color: var(--accent); color: var(--text); }
+.filter-btn.active { background: var(--accent); border-color: var(--accent); color: #fff; }
+
+/* ── Decisions ── */
+
+.decision-list {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.decision-row {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  overflow: hidden;
+  cursor: pointer;
+  transition: border-color 0.15s;
+}
+
+.decision-row:hover { border-color: rgba(79,110,247,0.4); }
+.decision-row.expanded { border-color: var(--accent); }
+
+.decision-summary {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 14px;
+  flex-wrap: wrap;
+}
+
+.decision-summary .mono { font-size: 13px; font-weight: 500; }
+.decision-summary .muted { font-size: 12px; }
+
+.decision-actions {
+  margin-left: auto;
+  display: flex;
+  gap: 6px;
+}
+
+.decision-detail {
+  padding: 12px 14px;
+  border-top: 1px solid var(--border);
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.detail-section {}
+
+.detail-label {
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+  margin-bottom: 6px;
+}
+
+.code-block {
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 10px 12px;
+  font-family: var(--mono);
+  font-size: 12px;
+  color: var(--text-dim);
+  overflow-x: auto;
+  white-space: pre;
+}
+
+.verdict-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 4px 0;
+}
+
+/* ── Traces ── */
+
+.traces-layout {
+  display: grid;
+  grid-template-columns: 280px 1fr;
+  gap: 16px;
+  height: calc(100vh - var(--header-h) - var(--tabbar-h) - 48px);
+}
+
+.session-list {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  overflow-y: auto;
+}
+
+.session-item {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 10px 12px;
+  cursor: pointer;
+  transition: border-color 0.15s;
+}
+
+.session-item:hover { border-color: rgba(79,110,247,0.4); }
+.session-item.active { border-color: var(--accent); background: var(--surface2); }
+
+.session-item-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 4px;
+}
+
+.session-item-meta {
+  display: flex;
+  justify-content: space-between;
+  font-size: 12px;
+  color: var(--text-muted);
+  margin-bottom: 2px;
+}
+
+.event-timeline {
+  overflow-y: auto;
+  padding: 4px 0;
+}
+
+.timeline {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.event-row {
+  display: grid;
+  grid-template-columns: 70px 12px 1fr;
+  gap: 10px;
+  align-items: start;
+  padding: 6px 8px;
+  border-radius: 6px;
+  transition: background 0.1s;
+}
+
+.event-row:hover { background: var(--surface); }
+
+.event-time {
+  text-align: right;
+  padding-top: 2px;
+  font-family: var(--mono);
+  line-height: 1.4;
+}
+
+.event-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  margin-top: 4px;
+  flex-shrink: 0;
+}
+
+.evt-tool     { background: var(--accent); }
+.evt-ask      { background: var(--ask); }
+.evt-resolved { background: var(--allow); }
+.evt-session  { background: var(--text-muted); }
+.evt-overlay  { background: var(--pending); }
+.evt-default  { background: var(--border); }
+
+.event-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.event-type {
+  font-size: 12px;
+  font-weight: 600;
+  font-family: var(--mono);
+}
+
+.evt-tool     .event-type,
+.event-type.evt-tool     { color: var(--accent); }
+.event-type.evt-ask      { color: var(--ask); }
+.event-type.evt-resolved { color: var(--allow); }
+.event-type.evt-session  { color: var(--text-muted); }
+.event-type.evt-overlay  { color: var(--pending); }
+
+.rule-hit {
+  color: var(--text-muted);
+  background: var(--surface2);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 0 5px;
+}
+
+.event-payload {
+  color: var(--text-muted);
+  margin-top: 2px;
+  line-height: 1.4;
+}
+
+/* ── Provenance ── */
+
+.provenance-note {
+  font-size: 13px;
+  color: var(--text-dim);
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 10px 14px;
+  margin-bottom: 16px;
+  line-height: 1.6;
+}
+
+/* ── Benchmarks ── */
+
+.report-card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 24px 28px;
+  margin-bottom: 20px;
+  max-width: 860px;
+}
+
+.report-filename {
+  font-family: var(--mono);
+  font-size: 12px;
+  color: var(--text-muted);
+  margin-bottom: 20px;
+  padding-bottom: 10px;
+  border-bottom: 1px solid var(--border);
+}
+
+.md-h1 { font-size: 20px; font-weight: 700; margin: 0 0 16px; }
+.md-h2 { font-size: 15px; font-weight: 700; margin: 20px 0 10px; color: var(--text-dim); }
+.md-h3 { font-size: 13px; font-weight: 700; margin: 16px 0 8px; color: var(--text-muted); text-transform: uppercase; letter-spacing: 0.05em; }
+.md-p  { font-size: 13px; color: var(--text-dim); margin-bottom: 8px; }
+.md-bold { font-size: 13px; font-weight: 600; color: var(--text); margin-bottom: 6px; }
+.md-li { font-size: 13px; color: var(--text-dim); padding-left: 14px; position: relative; margin-bottom: 4px; }
+.md-li::before { content: '–'; position: absolute; left: 0; color: var(--text-muted); }
+.md-table { margin-top: 8px; margin-bottom: 16px; }
+
+/* ── Scrollbar ── */
+
+::-webkit-scrollbar { width: 6px; height: 6px; }
+::-webkit-scrollbar-track { background: transparent; }
+::-webkit-scrollbar-thumb { background: var(--border); border-radius: 3px; }
+::-webkit-scrollbar-thumb:hover { background: #4a4f6b; }

--- a/tests/hypervisor/test_ui_router.py
+++ b/tests/hypervisor/test_ui_router.py
@@ -1,0 +1,401 @@
+"""
+test_ui_router.py — Tests for the Web UI FastAPI router.
+
+Verifies:
+  - Static files (index.html, style.css, app.js) are served correctly.
+  - /ui/api/status returns manifest and gateway metadata.
+  - /ui/api/decisions returns all approvals (pending + resolved).
+  - /ui/api/traces returns sessions with their event logs.
+  - /ui/api/provenance returns policy rules from YAML.
+  - /ui/api/benchmarks returns report files from disk.
+  - All data endpoints degrade gracefully when the control plane is absent.
+"""
+
+from __future__ import annotations
+
+import json
+import tempfile
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi.testclient import TestClient
+
+MANIFESTS_DIR = Path(__file__).parent.parent.parent / "manifests"
+_POLICY_PATH = (
+    Path(__file__).parent.parent.parent
+    / "src" / "agent_hypervisor" / "runtime" / "configs" / "default_policy.yaml"
+)
+
+
+# ---------------------------------------------------------------------------
+# Shared fixtures
+# ---------------------------------------------------------------------------
+
+def _make_manifest(tool_names: list[str]):
+    from agent_hypervisor.compiler.schema import WorldManifest, CapabilityConstraint
+    return WorldManifest(
+        workflow_id="test-world",
+        version="1.0",
+        capabilities=[CapabilityConstraint(tool=name) for name in tool_names],
+    )
+
+
+def _make_gw_state(tool_names: list[str] | None = None):
+    """Build a minimal MCPGatewayState-like mock for the UI router."""
+    tool_names = tool_names or ["read_file", "send_email"]
+    manifest = _make_manifest(tool_names)
+
+    renderer = MagicMock()
+    renderer.render.return_value = [MagicMock(name=t) for t in tool_names]
+    # Make each mock's .name property return the tool name
+    for i, mock_tool in enumerate(renderer.render.return_value):
+        type(mock_tool).name = property(lambda self, n=tool_names[i]: n)
+
+    resolver = MagicMock()
+    resolver.manifest = manifest
+
+    gw = MagicMock()
+    gw.resolver = resolver
+    gw.renderer = renderer
+    gw.manifest_path = Path("manifests/example_world.yaml")
+    gw.started_at = "2026-01-01T00:00:00+00:00"
+    return gw, manifest
+
+
+def _make_app(tool_names=None, with_control_plane=False, policy_path=None):
+    from fastapi import FastAPI
+    from agent_hypervisor.ui.router import create_ui_router
+
+    gw_state, _ = _make_gw_state(tool_names)
+    cp_state = None
+
+    if with_control_plane:
+        from agent_hypervisor.control_plane.api import ControlPlaneState
+        cp_state = ControlPlaneState.create()
+
+    app = FastAPI()
+    app.include_router(create_ui_router(gw_state, cp_state, policy_path))
+    return app, cp_state
+
+
+# ---------------------------------------------------------------------------
+# Static file serving
+# ---------------------------------------------------------------------------
+
+class TestStaticFiles:
+
+    def test_ui_root_returns_html(self):
+        app, _ = _make_app()
+        client = TestClient(app)
+        resp = client.get("/ui/")
+        assert resp.status_code == 200
+        assert "text/html" in resp.headers["content-type"]
+        assert "<title>" in resp.text
+
+    def test_ui_no_trailing_slash_also_works(self):
+        app, _ = _make_app()
+        client = TestClient(app)
+        resp = client.get("/ui")
+        assert resp.status_code == 200
+        assert "text/html" in resp.headers["content-type"]
+
+    def test_ui_html_references_css_and_js(self):
+        app, _ = _make_app()
+        client = TestClient(app)
+        html = client.get("/ui/").text
+        assert "/ui/style.css" in html
+        assert "/ui/app.js" in html
+
+    def test_css_served_with_correct_content_type(self):
+        app, _ = _make_app()
+        client = TestClient(app)
+        resp = client.get("/ui/style.css")
+        assert resp.status_code == 200
+        assert "text/css" in resp.headers["content-type"]
+        assert ":root" in resp.text  # sanity check on content
+
+    def test_js_served_with_correct_content_type(self):
+        app, _ = _make_app()
+        client = TestClient(app)
+        resp = client.get("/ui/app.js")
+        assert resp.status_code == 200
+        assert "javascript" in resp.headers["content-type"]
+        assert "switchTab" in resp.text  # sanity check on content
+
+
+# ---------------------------------------------------------------------------
+# /ui/api/status
+# ---------------------------------------------------------------------------
+
+class TestApiStatus:
+
+    def test_status_returns_200(self):
+        app, _ = _make_app()
+        client = TestClient(app)
+        resp = client.get("/ui/api/status")
+        assert resp.status_code == 200
+
+    def test_status_contains_manifest_fields(self):
+        app, _ = _make_app(["read_file", "send_email"])
+        client = TestClient(app)
+        data = client.get("/ui/api/status").json()
+        assert data["status"] == "running"
+        assert "manifest" in data
+        m = data["manifest"]
+        assert m["workflow_id"] == "test-world"
+        assert m["version"] == "1.0"
+        assert isinstance(m["capabilities"], list)
+        assert len(m["capabilities"]) == 2
+
+    def test_status_visible_tools_listed(self):
+        app, _ = _make_app(["read_file"])
+        client = TestClient(app)
+        data = client.get("/ui/api/status").json()
+        assert "read_file" in data["manifest"]["visible_tools"]
+
+    def test_status_control_plane_false_when_absent(self):
+        app, _ = _make_app(with_control_plane=False)
+        client = TestClient(app)
+        data = client.get("/ui/api/status").json()
+        assert data["control_plane"] is False
+        assert data["session_count"] == 0
+
+    def test_status_control_plane_true_when_wired(self):
+        app, _ = _make_app(with_control_plane=True)
+        client = TestClient(app)
+        data = client.get("/ui/api/status").json()
+        assert data["control_plane"] is True
+
+
+# ---------------------------------------------------------------------------
+# /ui/api/decisions
+# ---------------------------------------------------------------------------
+
+class TestApiDecisions:
+
+    def test_decisions_empty_without_control_plane(self):
+        app, _ = _make_app(with_control_plane=False)
+        client = TestClient(app)
+        data = client.get("/ui/api/decisions").json()
+        assert data["approvals"] == []
+        assert data["pending_count"] == 0
+        assert data["total"] == 0
+
+    def test_decisions_empty_when_no_approvals(self):
+        app, _ = _make_app(with_control_plane=True)
+        client = TestClient(app)
+        data = client.get("/ui/api/decisions").json()
+        assert data["total"] == 0
+        assert data["pending_count"] == 0
+
+    def test_decisions_includes_pending_approval(self):
+        app, cp = _make_app(with_control_plane=True)
+        client = TestClient(app)
+
+        # Create an approval via the service directly
+        cp.approval_service.request_approval(
+            session_id="sess-001",
+            tool_name="send_email",
+            arguments={"to": "attacker@evil.com", "body": "exfil"},
+            requested_by="agent",
+        )
+
+        data = client.get("/ui/api/decisions").json()
+        assert data["total"] == 1
+        assert data["pending_count"] == 1
+        approval = data["approvals"][0]
+        assert approval["tool_name"] == "send_email"
+        assert approval["status"] == "pending"
+        assert approval["session_id"] == "sess-001"
+
+    def test_decisions_includes_resolved_approval(self):
+        app, cp = _make_app(with_control_plane=True)
+        client = TestClient(app)
+
+        a = cp.approval_service.request_approval(
+            session_id="sess-002",
+            tool_name="write_file",
+            arguments={"path": "/tmp/x", "content": "data"},
+            requested_by="agent",
+        )
+        cp.approval_service.resolve(a.approval_id, "allowed", "operator")
+
+        data = client.get("/ui/api/decisions").json()
+        assert data["total"] == 1
+        assert data["pending_count"] == 0
+        assert data["approvals"][0]["status"] == "allowed"
+
+    def test_decisions_contains_required_fields(self):
+        app, cp = _make_app(with_control_plane=True)
+        client = TestClient(app)
+
+        cp.approval_service.request_approval(
+            session_id="sess-003",
+            tool_name="http_post",
+            arguments={"url": "http://evil.com", "body": "x"},
+            requested_by="agent",
+        )
+
+        approval = client.get("/ui/api/decisions").json()["approvals"][0]
+        for field in ("approval_id", "session_id", "tool_name", "status",
+                      "requested_by", "created_at", "action_fingerprint",
+                      "arguments_summary", "scoped_verdicts"):
+            assert field in approval, f"Missing field: {field}"
+
+
+# ---------------------------------------------------------------------------
+# /ui/api/traces
+# ---------------------------------------------------------------------------
+
+class TestApiTraces:
+
+    def test_traces_empty_without_control_plane(self):
+        app, _ = _make_app(with_control_plane=False)
+        client = TestClient(app)
+        data = client.get("/ui/api/traces").json()
+        assert data["sessions"] == []
+        assert data["total_events"] == 0
+
+    def test_traces_empty_when_no_sessions(self):
+        app, _ = _make_app(with_control_plane=True)
+        client = TestClient(app)
+        data = client.get("/ui/api/traces").json()
+        assert data["sessions"] == []
+
+    def test_traces_includes_sessions_and_events(self):
+        app, cp = _make_app(with_control_plane=True)
+        client = TestClient(app)
+
+        sess = cp.session_store.create(manifest_id="test-world", session_id="trace-sess-1")
+        from agent_hypervisor.control_plane.event_store import make_tool_call
+        cp.event_store.append(make_tool_call(
+            session_id=sess.session_id,
+            tool_name="read_file",
+            decision="allow",
+            rule_hit="allow-read-file",
+        ))
+
+        data = client.get("/ui/api/traces").json()
+        assert len(data["sessions"]) == 1
+        assert data["total_events"] == 1
+        s = data["sessions"][0]
+        assert s["session_id"] == "trace-sess-1"
+        assert len(s["events"]) == 1
+        e = s["events"][0]
+        assert e["type"] == "tool_call"
+        assert e["decision"] == "allow"
+        assert e["rule_hit"] == "allow-read-file"
+
+    def test_traces_session_contains_required_fields(self):
+        app, cp = _make_app(with_control_plane=True)
+        client = TestClient(app)
+        cp.session_store.create(manifest_id="test-world", session_id="trace-sess-2")
+
+        sess_data = client.get("/ui/api/traces").json()["sessions"][0]
+        for field in ("session_id", "state", "mode", "manifest_id", "created_at", "events"):
+            assert field in sess_data, f"Missing field: {field}"
+
+
+# ---------------------------------------------------------------------------
+# /ui/api/provenance
+# ---------------------------------------------------------------------------
+
+class TestApiProvenance:
+
+    def test_provenance_empty_when_no_policy_path(self):
+        app, _ = _make_app(policy_path=None)
+        client = TestClient(app)
+        data = client.get("/ui/api/provenance").json()
+        assert data["rules"] == []
+        assert data["source"] is None
+        assert data["count"] == 0
+
+    def test_provenance_empty_when_path_does_not_exist(self):
+        app, _ = _make_app(policy_path=Path("/nonexistent/policy.yaml"))
+        client = TestClient(app)
+        data = client.get("/ui/api/provenance").json()
+        assert data["rules"] == []
+
+    def test_provenance_loads_default_policy(self):
+        if not _POLICY_PATH.exists():
+            pytest.skip("default_policy.yaml not found")
+        app, _ = _make_app(policy_path=_POLICY_PATH)
+        client = TestClient(app)
+        data = client.get("/ui/api/provenance").json()
+        assert data["count"] > 0
+        assert data["rules"]
+        assert data["source"] is not None
+
+    def test_provenance_rule_has_required_fields(self):
+        if not _POLICY_PATH.exists():
+            pytest.skip("default_policy.yaml not found")
+        app, _ = _make_app(policy_path=_POLICY_PATH)
+        client = TestClient(app)
+        rules = client.get("/ui/api/provenance").json()["rules"]
+        for rule in rules:
+            assert "id" in rule
+            assert "tool" in rule
+            assert "verdict" in rule
+
+    def test_provenance_rules_from_custom_policy(self):
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".yaml", delete=False
+        ) as f:
+            f.write("rules:\n  - id: allow-test\n    tool: test_tool\n    verdict: allow\n")
+            fpath = Path(f.name)
+        try:
+            app, _ = _make_app(policy_path=fpath)
+            client = TestClient(app)
+            data = client.get("/ui/api/provenance").json()
+            assert data["count"] == 1
+            assert data["rules"][0]["id"] == "allow-test"
+            assert data["rules"][0]["verdict"] == "allow"
+        finally:
+            fpath.unlink(missing_ok=True)
+
+
+# ---------------------------------------------------------------------------
+# /ui/api/benchmarks
+# ---------------------------------------------------------------------------
+
+class TestApiBenchmarks:
+
+    def test_benchmarks_empty_when_no_reports(self, tmp_path, monkeypatch):
+        """Router returns empty list when the benchmark dir has no .md files."""
+        import agent_hypervisor.ui.router as ui_router_mod
+        monkeypatch.setattr(ui_router_mod, "_BENCHMARK_DIR", tmp_path)
+
+        app, _ = _make_app()
+        client = TestClient(app)
+        data = client.get("/ui/api/benchmarks").json()
+        assert data["reports"] == []
+        assert data["count"] == 0
+
+    def test_benchmarks_returns_report_content(self, tmp_path, monkeypatch):
+        """Router serves .md files from the benchmark reports directory."""
+        import agent_hypervisor.ui.router as ui_router_mod
+        monkeypatch.setattr(ui_router_mod, "_BENCHMARK_DIR", tmp_path)
+
+        (tmp_path / "report-test.md").write_text("# Test Report\n\nmetric: 100%\n")
+
+        app, _ = _make_app()
+        client = TestClient(app)
+        data = client.get("/ui/api/benchmarks").json()
+        assert data["count"] == 1
+        assert data["reports"][0]["filename"] == "report-test.md"
+        assert "Test Report" in data["reports"][0]["content"]
+
+    def test_benchmarks_returns_multiple_reports(self, tmp_path, monkeypatch):
+        import agent_hypervisor.ui.router as ui_router_mod
+        monkeypatch.setattr(ui_router_mod, "_BENCHMARK_DIR", tmp_path)
+
+        (tmp_path / "report-a.md").write_text("# A")
+        (tmp_path / "report-b.md").write_text("# B")
+
+        app, _ = _make_app()
+        client = TestClient(app)
+        data = client.get("/ui/api/benchmarks").json()
+        assert data["count"] == 2
+        names = {r["filename"] for r in data["reports"]}
+        assert names == {"report-a.md", "report-b.md"}


### PR DESCRIPTION
Closes #32. Implements the governance dashboard as a FastAPI router
mounted at /ui on the MCP gateway, with five tabs:

- Manifests: loaded world manifest, capability surface, visible tools, reload
- Decisions: approval queue + history with inline allow/deny controls and
  policy-reasoning detail (arguments, fingerprint, scoped verdicts)
- Traces: session event timeline grouped by session with type and decision badges
- Provenance: provenance firewall rule table from default_policy.yaml
- Benchmarks: renders AgentDojo report files from _research/benchmarks/reports/

Implementation:
- src/agent_hypervisor/ui/router.py: create_ui_router() factory; five /ui/api/*
  JSON endpoints backed by MCPGatewayState and ControlPlaneState
- src/agent_hypervisor/ui/static/{index.html,style.css,app.js}: vanilla JS SPA,
  5-second auto-refresh, inline approve/deny for pending decisions
- Wired into create_mcp_app() alongside the control plane router; active when
  use_default_policy=True passes the policy path to the provenance tab
- docker-compose.yml: new `gateway` service exposing port 8090 with the UI
- 27 tests in tests/hypervisor/test_ui_router.py covering all endpoints and
  static file serving

https://claude.ai/code/session_01Fho2gS77VGr1b4fWmwBncs