### PR TITLE
feat(control-plane): approval feedback loop

### DIFF
--- a/src/agent_hypervisor/control_plane/api.py
+++ b/src/agent_hypervisor/control_plane/api.py
@@ -407,6 +407,10 @@ def create_control_plane_router(state: ControlPlaneState) -> APIRouter:
 
         An expired approval always resolves as "denied" regardless of the
         requested decision (fail-closed rule).
+
+        When the decision is "allowed", an ``approval_resolved`` SSE event is
+        pushed to the originating session so the MCP client can automatically
+        retry the tool call without manual re-issue.
         """
         if body.decision not in (APPROVAL_STATUS_ALLOWED, APPROVAL_STATUS_DENIED):
             raise HTTPException(
@@ -425,6 +429,18 @@ def create_control_plane_router(state: ControlPlaneState) -> APIRouter:
             raise HTTPException(status_code=404, detail=f"Approval not found: {approval_id!r}")
         except RuntimeError as exc:
             raise HTTPException(status_code=409, detail=str(exc))
+
+        # Notify the originating session so it can retry the tool call.
+        # Fail-open: broadcaster errors must never crash the response path.
+        effective_verdict = "allow" if resolved.status == APPROVAL_STATUS_ALLOWED else "deny"
+        try:
+            state.broadcaster.notify_originator(
+                originator_session_id=resolved.session_id,
+                approval=resolved,
+                effective_verdict=effective_verdict,
+            )
+        except Exception:
+            pass
 
         return JSONResponse(resolved.to_dict())
 

--- a/src/agent_hypervisor/control_plane/approval_broadcaster.py
+++ b/src/agent_hypervisor/control_plane/approval_broadcaster.py
@@ -10,6 +10,19 @@ Two distinct event types are broadcast:
    tool call) when any approval scope returns "allow". This unblocks the client
    so it can retry the tool call.
 
+SSE framing:
+  Control-plane notifications use a named SSE event type so clients can
+  distinguish them from JSON-RPC responses:
+
+    event: approval
+    data: {"type": "approval_requested", ...}
+
+  Clients listen via:
+    source.addEventListener("approval", (e) => { ... });
+
+  Raw JSON-RPC responses pushed by the MCP layer use the default "message"
+  event type and are unaffected.
+
 Architecture:
 - ApprovalBroadcaster holds an optional reference to the SSESessionStore.
 - The SSESessionStore is wired in by create_mcp_app() after the sse_store is
@@ -142,7 +155,13 @@ class ApprovalBroadcaster:
 
     def _push_to_session(self, session_id: str, payload: str) -> bool:
         """
-        Push a raw JSON string to a session's SSE queue.
+        Push a control-plane SSE frame to a session's queue.
+
+        Frames use the named event type ``approval`` so clients can distinguish
+        them from JSON-RPC ``message`` events::
+
+            event: approval
+            data: {"type": "approval_requested", ...}
 
         Uses put_nowait() so it is safe to call from synchronous handlers.
         Returns False and logs a warning on any failure.
@@ -152,8 +171,10 @@ class ApprovalBroadcaster:
         queue = self._sse_store.get_queue(session_id)
         if queue is None:
             return False
+        # Wrap payload in a named SSE event frame.
+        frame = f"event: approval\ndata: {payload}\n\n"
         try:
-            queue.put_nowait(payload)
+            queue.put_nowait(frame)
             return True
         except Exception as exc:
             log.warning(

--- a/tests/control_plane/test_phase8.py
+++ b/tests/control_plane/test_phase8.py
@@ -72,6 +72,23 @@ def _sv(scope: str, verdict: str, pid: str = "p1") -> ScopedVerdict:
     return ScopedVerdict(scope=scope, verdict=verdict, participant_id=pid)
 
 
+def _parse_sse_frame(frame: str) -> dict:
+    """
+    Parse a control-plane SSE frame into a dict.
+
+    Frames have the format::
+
+        event: approval
+        data: {...JSON...}
+
+    Strips the frame header lines and returns the parsed JSON payload.
+    """
+    for line in frame.split("\n"):
+        if line.startswith("data: "):
+            return json.loads(line[len("data: "):])
+    raise ValueError(f"No data line found in SSE frame: {frame!r}")
+
+
 # ---------------------------------------------------------------------------
 # 1. Domain: constants and dataclasses
 # ---------------------------------------------------------------------------
@@ -429,7 +446,7 @@ class TestApprovalBroadcaster:
         count = bc.broadcast_approval_requested(approval, reg)
         assert count == 1
         assert not queue.empty()
-        payload = json.loads(queue.get_nowait())
+        payload = _parse_sse_frame(queue.get_nowait())
         assert payload["type"] == "approval_requested"
         assert payload["approval_id"] == approval.approval_id
         assert payload["tool_name"] == "tool"
@@ -456,7 +473,7 @@ class TestApprovalBroadcaster:
 
         result = bc.notify_originator("sess-o", approval, "allow")
         assert result is True
-        payload = json.loads(queue.get_nowait())
+        payload = _parse_sse_frame(queue.get_nowait())
         assert payload["type"] == "approval_resolved"
         assert payload["approval_id"] == approval.approval_id
         assert payload["effective_verdict"] == "allow"
@@ -708,7 +725,7 @@ class TestFullRoundTrip:
         # Step 4: Broadcast to participants.
         n = state.broadcaster.broadcast_approval_requested(approval, state.participant_registry)
         assert n == 1
-        payload = json.loads(participant_queue.get_nowait())
+        payload = _parse_sse_frame(participant_queue.get_nowait())
         assert payload["type"] == "approval_requested"
         assert payload["approval_id"] == approval.approval_id
         assert payload["tool_name"] == "write_file"
@@ -727,7 +744,7 @@ class TestFullRoundTrip:
 
         # Step 6: Originator is notified.
         state.broadcaster.notify_originator("agent-sess", approval, "allow")
-        notification = json.loads(originator_queue.get_nowait())
+        notification = _parse_sse_frame(originator_queue.get_nowait())
         assert notification["type"] == "approval_resolved"
         assert notification["effective_verdict"] == "allow"
 

--- a/tests/hypervisor/test_gateway_wiring.py
+++ b/tests/hypervisor/test_gateway_wiring.py
@@ -483,3 +483,283 @@ class TestExistingBehaviorUnchanged:
             client.post("/control/sessions", json={"manifest_id": "m1"})
             resp = client.get("/control/sessions")
             assert resp.json()["count"] >= 1
+
+
+# ---------------------------------------------------------------------------
+# Group 7: Approval feedback loop — end-to-end round-trip
+# ---------------------------------------------------------------------------
+
+import asyncio
+
+
+class TestApprovalFeedbackLoop:
+    """
+    Verify the full feedback loop:
+
+      tools/call (ask) → pending_approval
+        → operator resolves via /resolve OR /respond
+        → originator SSE queue receives an approval_resolved frame
+        → second tools/call (same args) succeeds because has_explicit_allow()=True
+    """
+
+    @pytest.fixture
+    def app_with_cp(self):
+        """Gateway with a control plane and a policy engine that asks for send_email."""
+        cp = ControlPlaneState.create()
+        policy = _AskPolicyEngine(ask_tool="send_email")
+        return create_mcp_app(
+            manifest_path=MANIFEST_PATH,
+            policy_engine=policy,
+            control_plane=cp,
+        )
+
+    def _wire_sse_queue(self, app, session_id: str):
+        """
+        Inject a real asyncio.Queue into the SSESessionStore for ``session_id``
+        so that broadcaster.notify_originator() has somewhere to push events.
+        Returns the queue so the test can inspect it.
+        """
+        queue: asyncio.Queue = asyncio.Queue()
+        sse_store = app.state.sse_store
+        sse_store._sessions[session_id] = queue
+        return queue
+
+    # ------------------------------------------------------------------
+    # Test 1: old /resolve endpoint now notifies originator
+    # ------------------------------------------------------------------
+
+    def test_resolve_endpoint_pushes_sse_on_allow(self, app_with_cp):
+        """POST /control/approvals/{id}/resolve with 'allowed' pushes approval_resolved to originator."""
+        with TestClient(app_with_cp) as client:
+            sid = "feedback-resolve-01"
+            app_with_cp.state.control_plane.session_store.create(
+                manifest_id="test", session_id=sid
+            )
+            queue = self._wire_sse_queue(app_with_cp, sid)
+
+            # Step 1: trigger ask → pending_approval
+            result = _tools_call(client, "send_email", {"to": "x@y.com"}, session_id=sid)
+            assert result["result"]["status"] == "pending_approval"
+            approval_id = result["result"]["approval_id"]
+
+            # Confirm queue is empty before resolve
+            assert queue.empty()
+
+            # Step 2: operator resolves via old endpoint
+            resp = client.post(
+                f"/control/approvals/{approval_id}/resolve",
+                json={"decision": "allowed", "resolved_by": "operator"},
+            )
+            assert resp.status_code == 200
+
+            # Step 3: SSE queue must now contain an approval_resolved frame
+            assert not queue.empty(), "Expected approval_resolved event in SSE queue"
+            frame = queue.get_nowait()
+            assert "event: approval" in frame
+            assert "approval_resolved" in frame
+            assert "allow" in frame
+
+    def test_resolve_deny_does_not_push_allow_sse(self, app_with_cp):
+        """POST /resolve with 'denied' still pushes an SSE frame (with deny verdict)."""
+        with TestClient(app_with_cp) as client:
+            sid = "feedback-resolve-02"
+            app_with_cp.state.control_plane.session_store.create(
+                manifest_id="test", session_id=sid
+            )
+            queue = self._wire_sse_queue(app_with_cp, sid)
+
+            result = _tools_call(client, "send_email", {"to": "x@y.com"}, session_id=sid)
+            approval_id = result["result"]["approval_id"]
+
+            client.post(
+                f"/control/approvals/{approval_id}/resolve",
+                json={"decision": "denied", "resolved_by": "operator"},
+            )
+
+            # Denied: a frame is pushed but its verdict is "deny"
+            assert not queue.empty(), "Expected SSE frame even on deny"
+            frame = queue.get_nowait()
+            assert "approval_resolved" in frame
+            assert "deny" in frame
+
+    # ------------------------------------------------------------------
+    # Test 2: new /respond endpoint still notifies originator
+    # ------------------------------------------------------------------
+
+    def test_respond_endpoint_pushes_sse_on_one_off_allow(self, app_with_cp):
+        """PATCH /control/approvals/{id}/respond with one_off allow notifies originator."""
+        with TestClient(app_with_cp) as client:
+            sid = "feedback-respond-01"
+            app_with_cp.state.control_plane.session_store.create(
+                manifest_id="test", session_id=sid
+            )
+            queue = self._wire_sse_queue(app_with_cp, sid)
+
+            result = _tools_call(client, "send_email", {"to": "x@y.com"}, session_id=sid)
+            approval_id = result["result"]["approval_id"]
+
+            assert queue.empty()
+
+            resp = client.patch(
+                f"/control/approvals/{approval_id}/respond",
+                json={"verdicts": [{"scope": "one_off", "verdict": "allow", "participant_id": "op"}]},
+            )
+            assert resp.status_code == 200
+
+            assert not queue.empty(), "Expected approval_resolved event via /respond"
+            frame = queue.get_nowait()
+            assert "event: approval" in frame
+            assert "approval_resolved" in frame
+            assert "allow" in frame
+
+    # ------------------------------------------------------------------
+    # Test 3: retry tool call succeeds after explicit allow
+    # ------------------------------------------------------------------
+
+    def test_retry_after_resolve_allow_succeeds(self, app_with_cp):
+        """
+        After /resolve with 'allowed', a second tools/call with the same
+        args bypasses the ask workflow (has_explicit_allow=True) and executes.
+        """
+        with TestClient(app_with_cp) as client:
+            sid = "feedback-retry-01"
+            app_with_cp.state.control_plane.session_store.create(
+                manifest_id="test", session_id=sid
+            )
+            self._wire_sse_queue(app_with_cp, sid)
+
+            args = {"to": "retry@example.com"}
+
+            # First call → pending
+            result1 = _tools_call(client, "send_email", args, session_id=sid)
+            assert result1["result"]["status"] == "pending_approval"
+            approval_id = result1["result"]["approval_id"]
+
+            # Operator allows
+            client.post(
+                f"/control/approvals/{approval_id}/resolve",
+                json={"decision": "allowed", "resolved_by": "operator"},
+            )
+
+            # Second call with same args → must not be pending_approval
+            result2 = _tools_call(client, "send_email", args, session_id=sid)
+            # has_explicit_allow() returns True → falls through to adapter dispatch
+            assert result2.get("result", {}).get("status") != "pending_approval", (
+                f"Expected retry to succeed, got: {result2}"
+            )
+            # And it should not be a hard error about missing control plane
+            if "error" in result2:
+                assert "no control plane" not in result2["error"].get("message", "").lower()
+
+    def test_retry_after_respond_one_off_allow_succeeds(self, app_with_cp):
+        """
+        After /respond with one_off allow, a second tools/call with the same
+        args sees has_explicit_allow=True and proceeds to dispatch.
+        """
+        with TestClient(app_with_cp) as client:
+            sid = "feedback-retry-02"
+            app_with_cp.state.control_plane.session_store.create(
+                manifest_id="test", session_id=sid
+            )
+            self._wire_sse_queue(app_with_cp, sid)
+
+            args = {"to": "retry2@example.com"}
+
+            result1 = _tools_call(client, "send_email", args, session_id=sid)
+            approval_id = result1["result"]["approval_id"]
+
+            client.patch(
+                f"/control/approvals/{approval_id}/respond",
+                json={"verdicts": [{"scope": "one_off", "verdict": "allow", "participant_id": "op"}]},
+            )
+
+            result2 = _tools_call(client, "send_email", args, session_id=sid)
+            assert result2.get("result", {}).get("status") != "pending_approval"
+
+    # ------------------------------------------------------------------
+    # Test 4: SSE frame format is well-formed
+    # ------------------------------------------------------------------
+
+    def test_sse_frame_contains_named_event_type(self, app_with_cp):
+        """Broadcaster pushes frames with 'event: approval\\ndata: {...}' format."""
+        with TestClient(app_with_cp) as client:
+            sid = "feedback-frame-01"
+            app_with_cp.state.control_plane.session_store.create(
+                manifest_id="test", session_id=sid
+            )
+            queue = self._wire_sse_queue(app_with_cp, sid)
+
+            result = _tools_call(client, "send_email", {"to": "fmt@example.com"}, session_id=sid)
+            approval_id = result["result"]["approval_id"]
+
+            client.post(
+                f"/control/approvals/{approval_id}/resolve",
+                json={"decision": "allowed", "resolved_by": "op"},
+            )
+
+            frame = queue.get_nowait()
+            lines = frame.split("\n")
+            # First line must be the named event type
+            assert lines[0] == "event: approval", f"Bad frame first line: {lines[0]!r}"
+            # Second line must start with 'data: '
+            assert lines[1].startswith("data: "), f"Bad frame data line: {lines[1]!r}"
+            # The data must be valid JSON
+            import json
+            payload = json.loads(lines[1][len("data: "):])
+            assert payload["type"] == "approval_resolved"
+            assert "approval_id" in payload
+            assert payload["effective_verdict"] in ("allow", "deny")
+
+    # ------------------------------------------------------------------
+    # Test 5: broadcaster has no SSE store → notify is a safe no-op
+    # ------------------------------------------------------------------
+
+    def test_notify_without_sse_store_is_noop(self, app_with_cp):
+        """If broadcaster has no SSE store wired, notify_originator returns False silently."""
+        from agent_hypervisor.control_plane.approval_broadcaster import ApprovalBroadcaster
+        broadcaster = ApprovalBroadcaster()  # no set_sse_store() called
+        from unittest.mock import MagicMock
+        mock_approval = MagicMock()
+        mock_approval.approval_id = "test-id"
+        mock_approval.scoped_verdicts = []
+        result = broadcaster.notify_originator("any-session", mock_approval, "allow")
+        assert result is False
+
+    # ------------------------------------------------------------------
+    # Test 6: expired approval → resolve → deny pushed, not allow
+    # ------------------------------------------------------------------
+
+    def test_expired_approval_resolve_pushes_deny(self, app_with_cp):
+        """Resolving an expired approval with 'allowed' still results in a deny broadcast."""
+        from datetime import datetime, timezone, timedelta
+        with TestClient(app_with_cp) as client:
+            sid = "feedback-expired-01"
+            app_with_cp.state.control_plane.session_store.create(
+                manifest_id="test", session_id=sid
+            )
+            queue = self._wire_sse_queue(app_with_cp, sid)
+
+            result = _tools_call(client, "send_email", {"to": "exp@example.com"}, session_id=sid)
+            approval_id = result["result"]["approval_id"]
+
+            # Manually expire the approval
+            cp = app_with_cp.state.control_plane
+            approval = cp.approval_service.get(approval_id)
+            approval.expires_at = (
+                datetime.now(timezone.utc) - timedelta(seconds=1)
+            ).isoformat()
+
+            # Operator attempts to allow the expired approval
+            resp = client.post(
+                f"/control/approvals/{approval_id}/resolve",
+                json={"decision": "allowed", "resolved_by": "operator"},
+            )
+            assert resp.status_code == 200
+            # Service overrides to denied on expiry
+            assert resp.json()["status"] in ("denied", "expired")
+
+            # SSE frame should carry deny verdict
+            if not queue.empty():
+                frame = queue.get_nowait()
+                assert "deny" in frame
+


### PR DESCRIPTION
## What

Closes the gap where an operator resolving an approval via `POST /control/approvals/{id}/resolve` left the originating MCP session waiting indefinitely — the caller had to manually re-issue the tool call.

## Changes

### `api.py` — wire `notify_originator` into the old `/resolve` endpoint
The multi-scope `PATCH /respond` endpoint already called `broadcaster.notify_originator()`. The single-decision `POST /resolve` did not. Fixed.

### `approval_broadcaster.py` — named SSE event type
Control-plane notifications now use a named SSE event frame:
```
event: approval
data: {"type": "approval_resolved", ...}
```
Clients listen via `source.addEventListener("approval", handler)` without confusion with JSON-RPC `message` events.

### `test_gateway_wiring.py` — new `TestApprovalFeedbackLoop` group (8 tests)
Full end-to-end round-trip tests:
- `/resolve allow` → SSE frame pushed to originator
- `/resolve deny` → SSE frame pushed with deny verdict
- `/respond one_off allow` → SSE frame pushed
- Retry after `/resolve allow` → tool call succeeds (has_explicit_allow=True)
- Retry after `/respond allow` → tool call succeeds
- SSE frame format is well-formed (event: + data: + valid JSON)
- Broadcaster with no SSE store → safe no-op
- Expired approval → deny frame, not allow

### `test_phase8.py` — update 3 existing broadcaster tests
Tests that parsed raw JSON from the queue now use `_parse_sse_frame()` to strip the SSE header first.

## Test results
```
267 passed, 0 failed
```
