### PR TITLE
docs: reconcile ROADMAP, NEXT_TASKS and wiki with current UI + registry status

### DIFF
--- a/NEXT_TASKS.md
+++ b/NEXT_TASKS.md
@@ -21,8 +21,9 @@
   - Add/extend tests for accepted + rejected payloads.
 
 - [-] **T3 — Harden approval/ASK runtime pathway**
-  - Resolve key gaps keeping approval gate in “experimental”.
+  - Resolve remaining gaps keeping approval gate in “experimental”.
   - Ensure deterministic state transitions and persistence/recovery behavior are covered by tests.
+  - 2026-04-12 audit note: approval persistence/recovery primitives are present (`ApprovalStore`, gateway recovery path); remaining work is to close any edge-case/runtime parity gaps before promoting maturity.
 
 - [ ] **T4 — Implement ProgramRegistry persistence interface**
   - Implement `store()` and `load()` with a concrete backend.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -108,7 +108,7 @@ Full results: `research/benchmarks/agentdojo/results.md`
 | Deliverable | Issue | What it enables |
 | --- | --- | --- |
 | Docker local stack | #31 | `docker compose up` starts a complete working demo |
-| Web UI | #32 | **Phase 1 delivered:** decisions + approvals + sessions ops UI. **Remaining:** manifest editor/simulator, provenance explorer, benchmark runs |
+| Web UI | #32 | **Phase 1 delivered:** manifests/decisions/traces/provenance/benchmark-report ops tabs. **Remaining:** manifest editor/simulator, diff/coverage/tune, provenance graph explorer, benchmark run trigger |
 | Hello-world tutorial | #33 | A developer can wire up a new agent in under an hour |
 | Positioning and comparisons | #34 | Clear differentiation from guardrails, sandboxes, and policy engines |
 
@@ -124,7 +124,7 @@ Stage 3 is a mini-product, not a universal framework. The scope is bounded: one 
 | M2 Core Engine | Complete |
 | M3 Tool Boundary | Complete |
 | M4 Proof | Complete — 0% ASR, 80% utility (clean + under attack) on 560-pair workspace benchmark |
-| M5 Beta Product | In progress — Docker stack present, hello-world and positioning docs complete; Web UI partially complete (ops dashboard shipped, advanced tabs pending) |
+| M5 Beta Product | In progress — Docker stack present, hello-world and positioning docs complete; Web UI ops tabs shipped (manifests/decisions/traces/provenance/benchmark reports), authoring/simulation features pending |
 
 ---
 
@@ -153,8 +153,8 @@ A developer unfamiliar with the project can run `docker compose up`, complete th
 - [ ] Manifest editor with inline validation (`ahc validate`)
 - [ ] Simulation panel (`ahc simulate`) and decision table preview
 - [ ] Diff/coverage/tuning views (`ahc diff`, `ahc coverage`, `ahc tune`)
-- [ ] Provenance graph explorer tab
-- [ ] Benchmark run/report tab
+- [ ] Provenance graph explorer tab (current UI shows provenance rule table; graph explorer pending)
+- [ ] Benchmark run trigger tab (current UI renders benchmark reports from `_research/benchmarks/reports/`)
 
 ---
 

--- a/wiki/code/program_layer.md
+++ b/wiki/code/program_layer.md
@@ -29,7 +29,7 @@ The `program_layer` package is an **optional execution abstraction** that sits *
 | `sandbox_runtime.py` | `SandboxRuntime` | Minimal restricted execution environment |
 | `program_executor.py` | `ProgramExecutor` | Runs programs in sandbox |
 | `task_compiler.py` | `DeterministicTaskCompiler` | Compiles tasks to execution plans |
-| `interfaces.py` | `Executor` protocol | Protocol definition for executor implementations |
+| `interfaces.py` | `TaskCompiler`, `Executor`, `ProgramRegistry` | Protocols plus `ProgramRegistry` store/load stub interface |
 
 ## Execution Plan Types
 
@@ -105,6 +105,11 @@ Error types: `"timeout"`, `"security"`, `"runtime"`, `"validation"`.
 2. **Fail closed.** Unknown error → `SandboxError`; exceeds timeout → `SandboxTimeoutError`; forbidden AST node → `SandboxSecurityError`.
 3. **Offline by default.** No network, subprocess, or filesystem access permitted in sandbox.
 4. **Explicit bindings only.** The sandbox environment contains only what `allowed_bindings` declares.
+
+## Current implementation status
+
+- `ProgramRegistry.store()` and `ProgramRegistry.load()` are intentionally stubbed and raise `NotImplementedError` (planned persistence work).
+- `DeterministicTaskCompiler` + `ProgramExecutor` are implemented for current sandbox execution flow.
 
 ## See Also
 

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -1,5 +1,14 @@
 # Wiki Log
 
+## [2026-04-12] housekeeping | Roadmap/task reconciliation + wiki sync
+
+Performed a housekeeping pass to align planning docs and wiki summaries with current code state:
+
+- Updated `ROADMAP.md` M5/Web UI wording to match shipped tabs (`manifests`, `decisions`, `traces`, `provenance`, benchmark report viewer) while keeping authoring/simulation features as remaining work.
+- Clarified acceptance checklist language so "provenance graph explorer" and "benchmark run trigger" stay explicitly pending, with notes that rule-table/report-view surfaces already exist.
+- Updated `NEXT_TASKS.md` T3 note to reflect that approval persistence/recovery primitives already exist and that remaining work is hardening/parity.
+- Synced `wiki/code/program_layer.md` with real API surface by documenting `interfaces.py` as `TaskCompiler` + `Executor` + `ProgramRegistry`, and explicitly calling out `ProgramRegistry` persistence as still stubbed.
+
 ## [2026-04-10] ingest | Control plane, gateway wiring, and multi-scope approval system
 
 Reflected PRs #88 and #89 into the wiki. Three major features landed:


### PR DESCRIPTION
### Motivation
- Bring planning docs and the wiki into alignment with the repository's actual implemented surface for M5/Web UI and program-layer interfaces. 
- Make the M5 acceptance checklist and NEXT_TASKS guidance actionable and accurately reflect shipped UI tabs and remaining work. 
- Record the current `ProgramRegistry` persistence status so authors and reviewers do not assume it is implemented. 

### Description
- Update `ROADMAP.md` to reflect that the Web UI ops tabs for `manifests`, `decisions`, `traces`, `provenance` and benchmark report viewer are shipped and to clarify remaining features (`manifest editor`, `ahc simulate`, `diff/coverage/tune`, provenance graph explorer, and benchmark run trigger). 
- Amend `NEXT_TASKS.md` T3 text to note that approval persistence/recovery primitives exist (e.g. `ApprovalStore` and gateway recovery path) and that remaining work is hardening/parity before promotion. 
- Sync `wiki/code/program_layer.md` to list `TaskCompiler`, `Executor`, and `ProgramRegistry` in `interfaces.py` and add an explicit status note that `ProgramRegistry.store()`/`load()` are stubbed (`NotImplementedError`). 
- Add a housekeeping entry to `wiki/log.md` documenting the reconciliation pass and the items synchronized. 

### Testing
- No runtime code changes were made; this is documentation-only, so no new unit tests were added. 
- Attempted to run targeted approval-pathway tests with `pytest` (`tests/control_plane/test_phase8.py::TestApprovalServiceScopedVerdicts::test_expired_approval_returns_expired_status` and `tests/control_plane/test_phase8.py::TestControlPlaneAPIRespond::test_patch_respond_unknown_approval_returns_404`), but execution failed because the environment lacked the configured `pyenv` runtime and `pytest` (errors: missing `agent-hypervisor` python shim and missing `pytest` module). 
- Given the doc-only scope, no tests were required to validate behavior; the attempted test runs are recorded in the PR notes for follow-up in a properly provisioned CI/developer environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db6fed55348325b5181615f95979bb)