### PR TITLE
feat(ui): add Editor, Simulator tabs and flow-view Provenance for M5 completion

### DIFF
--- a/src/agent_hypervisor/ui/router.py
+++ b/src/agent_hypervisor/ui/router.py
@@ -1,21 +1,27 @@
 """
 router.py — Web UI FastAPI router for Agent Hypervisor.
 
-Serves a dashboard at /ui with five tabs:
+Serves a dashboard at /ui with seven tabs:
   - Manifests:  Loaded world manifest and visible tool surface.
+  - Editor:     Inline YAML manifest editor with validate and save.
   - Decisions:  Approval queue and resolved action authorizations (policy reasoning).
   - Traces:     Session event logs — tool calls, mode changes, approvals.
-  - Provenance: Active provenance firewall policy rules.
+  - Provenance: Active provenance firewall policy rules with flow visualization.
+  - Simulator:  Dry-run tool call evaluation against the loaded manifest.
   - Benchmarks: AgentDojo benchmark run results.
 
 Mount via create_ui_router() and app.include_router() in create_mcp_app().
 
 Data API (all GET, JSON):
-  /ui/api/status      — gateway status + manifest summary
-  /ui/api/decisions   — all approvals (pending + history)
-  /ui/api/traces      — sessions with their event logs
-  /ui/api/provenance  — provenance policy rule list
-  /ui/api/benchmarks  — benchmark report files
+  /ui/api/status              — gateway status + manifest summary
+  /ui/api/manifest/source     — raw YAML text of the loaded manifest file
+  /ui/api/manifest/validate   — validate YAML content against manifest schema (POST)
+  /ui/api/manifest/save       — write content to disk and hot-reload (POST)
+  /ui/api/decisions           — all approvals (pending + history)
+  /ui/api/traces              — sessions with their event logs
+  /ui/api/provenance          — provenance policy rule list
+  /ui/api/simulate            — dry-run a tool call against the manifest (POST)
+  /ui/api/benchmarks          — benchmark report files
 """
 
 from __future__ import annotations
@@ -24,8 +30,11 @@ from pathlib import Path
 from typing import Any, Optional
 
 import yaml
-from fastapi import APIRouter
+from fastapi import APIRouter, Request
 from fastapi.responses import HTMLResponse, JSONResponse, Response
+
+from agent_hypervisor.compiler.schema import manifest_from_dict
+from agent_hypervisor.compiler.enforcer import Step, evaluate
 
 _STATIC = Path(__file__).parent / "static"
 # Reports live in _research/ at the repo root.
@@ -158,5 +167,119 @@ def create_ui_router(
                 except Exception:
                     pass
         return JSONResponse({"reports": reports, "count": len(reports)})
+
+    # ── Manifest Editor API ───────────────────────────────────────────────────
+
+    @router.get("/ui/api/manifest/source")
+    def api_manifest_source() -> JSONResponse:
+        """Return the raw YAML text of the currently loaded manifest file."""
+        path = gw_state.manifest_path
+        try:
+            content = Path(path).read_text(encoding="utf-8")
+        except Exception as exc:
+            return JSONResponse(
+                {"content": "", "path": str(path), "error": str(exc)},
+                status_code=500,
+            )
+        return JSONResponse({"content": content, "path": str(path)})
+
+    @router.post("/ui/api/manifest/validate")
+    async def api_manifest_validate(request: Request) -> JSONResponse:
+        """Parse and validate YAML manifest content without writing to disk."""
+        body = await request.json()
+        content = body.get("content", "")
+        errors: list[str] = []
+        try:
+            raw = yaml.safe_load(content)
+            if not isinstance(raw, dict):
+                errors.append("Manifest must be a YAML mapping at the top level.")
+            else:
+                try:
+                    manifest_from_dict(raw)
+                except KeyError as exc:
+                    errors.append(f"Missing required field: {exc}")
+                except Exception as exc:
+                    errors.append(f"Schema error: {exc}")
+        except yaml.YAMLError as exc:
+            errors.append(f"YAML syntax error: {exc}")
+        return JSONResponse({"valid": len(errors) == 0, "errors": errors})
+
+    @router.post("/ui/api/manifest/save")
+    async def api_manifest_save(request: Request) -> JSONResponse:
+        """Validate, write manifest content to disk, and hot-reload the gateway."""
+        body = await request.json()
+        content = body.get("content", "")
+
+        # Validate before writing
+        errors: list[str] = []
+        try:
+            raw = yaml.safe_load(content)
+            if not isinstance(raw, dict):
+                errors.append("Manifest must be a YAML mapping at the top level.")
+            else:
+                try:
+                    manifest_from_dict(raw)
+                except KeyError as exc:
+                    errors.append(f"Missing required field: {exc}")
+                except Exception as exc:
+                    errors.append(f"Schema error: {exc}")
+        except yaml.YAMLError as exc:
+            errors.append(f"YAML syntax error: {exc}")
+
+        if errors:
+            return JSONResponse(
+                {"status": "validation_failed", "errors": errors},
+                status_code=400,
+            )
+
+        path = gw_state.manifest_path
+        try:
+            Path(path).write_text(content, encoding="utf-8")
+        except Exception as exc:
+            return JSONResponse(
+                {"status": "write_failed", "error": str(exc)},
+                status_code=500,
+            )
+
+        ok = gw_state.reload_manifest()
+        return JSONResponse({
+            "status": "saved" if ok else "saved_reload_failed",
+            "path": str(path),
+            "reloaded": ok,
+        })
+
+    # ── Simulator API ─────────────────────────────────────────────────────────
+
+    @router.post("/ui/api/simulate")
+    async def api_simulate(request: Request) -> JSONResponse:
+        """Dry-run a tool call through the enforcer against the loaded manifest."""
+        body = await request.json()
+        tool = body.get("tool", "")
+        action = body.get("action", "")
+        resource = body.get("resource", "")
+        tainted = bool(body.get("tainted", False))
+
+        manifest = gw_state.resolver.manifest
+        if manifest is None:
+            return JSONResponse({"error": "No manifest loaded"}, status_code=503)
+
+        input_sources = ["tainted"] if tainted else []
+        step = Step(tool=tool, action=action, resource=resource, input_sources=input_sources)
+        result = evaluate(step, manifest)
+
+        return JSONResponse({
+            "decision": result.decision.value,
+            "reason": result.reason,
+            "allowed": result.allowed,
+            "denied": result.denied,
+            "failure_type": result.failure_type,
+            "step": {
+                "tool": tool,
+                "action": action,
+                "resource": resource,
+                "tainted": tainted,
+                "display_name": step.display_name,
+            },
+        })
 
     return router

--- a/src/agent_hypervisor/ui/static/app.js
+++ b/src/agent_hypervisor/ui/static/app.js
@@ -15,6 +15,12 @@ let expandedDecisionId = null;
 // Traces tab state
 let selectedSessionId = null;
 
+// Editor tab state — never auto-refreshed so edits aren't clobbered
+let editorDirty = false;
+
+// Provenance tab state
+let provenanceViewMode = 'flow'; // 'flow' | 'table'
+
 // ── Boot ──────────────────────────────────────────────────────────────────
 
 document.addEventListener('DOMContentLoaded', () => {
@@ -34,16 +40,23 @@ function switchTab(tab) {
   document.querySelectorAll('.tab-btn').forEach(b => b.classList.toggle('active', b.dataset.tab === tab));
   document.querySelectorAll('.tab-panel').forEach(p => p.classList.toggle('active', p.id === `tab-${tab}`));
   clearInterval(refreshTimer);
-  loadTab(tab);
-  refreshTimer = setInterval(() => loadTab(tab), REFRESH_MS);
+  if (tab === 'editor') {
+    // Load once on switch; do not poll — avoids clobbering unsaved edits
+    loadEditor();
+  } else {
+    loadTab(tab);
+    refreshTimer = setInterval(() => loadTab(tab), REFRESH_MS);
+  }
 }
 
 async function loadTab(tab) {
   try {
     if (tab === 'manifests')  await loadManifests();
+    // Editor is not auto-refreshed to protect unsaved edits
     if (tab === 'decisions')  await loadDecisions();
     if (tab === 'traces')     await loadTraces();
     if (tab === 'provenance') await loadProvenance();
+    if (tab === 'simulator')  await loadSimulator();
     if (tab === 'benchmarks') await loadBenchmarks();
     lastRefresh = Date.now();
     setRefreshLabel();
@@ -151,6 +164,109 @@ async function reloadManifest() {
     await loadManifests();
   } catch (e) {
     console.error('[ui] reload failed', e);
+  }
+}
+
+// ── Editor tab ────────────────────────────────────────────────────────────
+
+async function loadEditor(forceReload) {
+  const panel = document.getElementById('tab-editor');
+  // Only fetch from disk if the panel is empty or a reload was explicitly requested
+  const textarea = panel.querySelector('.editor-textarea');
+  if (textarea && !forceReload) return; // Preserve unsaved edits on tab re-focus
+
+  let data;
+  try {
+    data = await apiFetch('/ui/api/manifest/source');
+  } catch (e) {
+    panel.innerHTML = emptyState('Cannot load manifest', String(e));
+    return;
+  }
+
+  panel.innerHTML = `
+    <div class="editor-layout">
+      <div class="editor-toolbar">
+        <span class="editor-path mono small">${esc(data.path)}</span>
+        <div class="editor-actions">
+          <button class="btn btn-sm" onclick="editorReloadFromDisk()">Reload from disk</button>
+          <button class="btn btn-sm" id="editor-validate-btn" onclick="editorValidate()">Validate</button>
+          <button class="btn btn-sm btn-allow" id="editor-save-btn" onclick="editorSave()">Save &amp; Reload</button>
+        </div>
+      </div>
+      <textarea
+        id="editor-textarea"
+        class="editor-textarea"
+        spellcheck="false"
+        autocomplete="off"
+        oninput="editorMarkDirty()"
+      >${esc(data.content)}</textarea>
+      <div id="editor-status" class="editor-status"></div>
+    </div>
+  `;
+  editorDirty = false;
+}
+
+function editorMarkDirty() {
+  editorDirty = true;
+  const status = document.getElementById('editor-status');
+  if (status) status.innerHTML = '<span class="editor-status-msg muted">Unsaved changes</span>';
+}
+
+function editorReloadFromDisk() {
+  if (editorDirty) {
+    if (!confirm('You have unsaved changes. Reload from disk and discard them?')) return;
+  }
+  editorDirty = false;
+  loadEditor(true);
+}
+
+async function editorValidate() {
+  const ta = document.getElementById('editor-textarea');
+  const status = document.getElementById('editor-status');
+  if (!ta || !status) return;
+
+  status.innerHTML = '<span class="editor-status-msg muted">Validating…</span>';
+  try {
+    const resp = await fetch('/ui/api/manifest/validate', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ content: ta.value }),
+    });
+    const data = await resp.json();
+    if (data.valid) {
+      status.innerHTML = '<span class="editor-status-msg ok">Valid — no errors found</span>';
+    } else {
+      const errList = data.errors.map(e => `<div class="editor-error-item">${esc(e)}</div>`).join('');
+      status.innerHTML = `<div class="editor-status-msg error">Validation failed</div>${errList}`;
+    }
+  } catch (e) {
+    status.innerHTML = `<span class="editor-status-msg error">Request failed: ${esc(String(e))}</span>`;
+  }
+}
+
+async function editorSave() {
+  const ta = document.getElementById('editor-textarea');
+  const status = document.getElementById('editor-status');
+  if (!ta || !status) return;
+
+  status.innerHTML = '<span class="editor-status-msg muted">Saving…</span>';
+  try {
+    const resp = await fetch('/ui/api/manifest/save', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ content: ta.value }),
+    });
+    const data = await resp.json();
+    if (resp.ok) {
+      const reloadNote = data.reloaded ? 'Gateway reloaded.' : 'Gateway reload failed — check logs.';
+      status.innerHTML = `<span class="editor-status-msg ok">Saved to <span class="mono">${esc(data.path)}</span>. ${reloadNote}</span>`;
+      editorDirty = false;
+    } else {
+      const errList = (data.errors || [data.error]).map(e => `<div class="editor-error-item">${esc(e)}</div>`).join('');
+      status.innerHTML = `<div class="editor-status-msg error">${esc(data.status || 'Error')}</div>${errList}`;
+    }
+  } catch (e) {
+    status.innerHTML = `<span class="editor-status-msg error">Request failed: ${esc(String(e))}</span>`;
   }
 }
 
@@ -424,6 +540,9 @@ function renderProvenance(data) {
   const askCount   = data.rules.filter(r => r.verdict === 'ask').length;
   const allowCount = data.rules.filter(r => r.verdict === 'allow').length;
 
+  const flowBtn  = provenanceViewMode === 'flow'  ? 'active' : '';
+  const tableBtn = provenanceViewMode === 'table' ? 'active' : '';
+
   panel.innerHTML = `
     <div class="stats-row">
       <div class="stat"><div class="stat-val">${data.count}</div><div class="stat-label">rules</div></div>
@@ -438,6 +557,52 @@ function renderProvenance(data) {
       Source: <span class="mono small">${esc(data.source || '—')}</span>
     </div>
 
+    <div class="view-toggle" style="margin-bottom:16px">
+      <button class="filter-btn ${flowBtn}"  onclick="setProvenanceView('flow')">Flow view</button>
+      <button class="filter-btn ${tableBtn}" onclick="setProvenanceView('table')">Table view</button>
+    </div>
+
+    ${provenanceViewMode === 'flow'
+      ? renderProvenanceFlow(data.rules)
+      : renderProvenanceTable(data.rules)
+    }
+  `;
+}
+
+function setProvenanceView(mode) {
+  provenanceViewMode = mode;
+  loadProvenance();
+}
+
+function renderProvenanceFlow(rules) {
+  // Group rules by provenance source for visual clarity
+  const byProvenance = {};
+  for (const r of rules) {
+    const key = r.provenance || '*';
+    if (!byProvenance[key]) byProvenance[key] = [];
+    byProvenance[key].push(r);
+  }
+
+  const groups = Object.entries(byProvenance).map(([prov, rulesInGroup]) => {
+    const rows = rulesInGroup.map(r => `
+      <div class="flow-rule">
+        <span class="flow-node flow-prov">${esc(r.provenance || '*')}</span>
+        <span class="flow-arrow">→</span>
+        <span class="flow-node flow-tool mono">${esc(r.tool || '*')}</span>
+        ${r.argument ? `<span class="flow-arrow">·</span><span class="flow-node flow-arg mono">${esc(r.argument)}</span>` : ''}
+        <span class="flow-arrow">→</span>
+        <span class="flow-node tag ${verdictTagCls(r.verdict)}">${esc(r.verdict || '—')}</span>
+        ${r.id ? `<span class="muted small mono" style="margin-left:8px">${esc(r.id)}</span>` : ''}
+      </div>
+    `).join('');
+    return `<div class="flow-group">${rows}</div>`;
+  });
+
+  return `<div class="flow-list">${groups.join('')}</div>`;
+}
+
+function renderProvenanceTable(rules) {
+  return `
     <table class="data-table">
       <thead>
         <tr>
@@ -450,7 +615,7 @@ function renderProvenance(data) {
         </tr>
       </thead>
       <tbody>
-        ${data.rules.map((r, i) => `
+        ${rules.map((r, i) => `
           <tr>
             <td class="muted small">${i + 1}</td>
             <td class="mono small">${esc(r.id || '—')}</td>
@@ -466,6 +631,121 @@ function renderProvenance(data) {
 
 function verdictTagCls(v) {
   return { allow: 'tag-allow', ask: 'tag-ask', deny: 'tag-deny' }[v] || 'tag-muted';
+}
+
+// ── Simulator tab ─────────────────────────────────────────────────────────
+
+async function loadSimulator() {
+  const panel = document.getElementById('tab-simulator');
+  // Only render the form skeleton if it doesn't exist yet; preserve field values on poll
+  if (panel.querySelector('.sim-form')) return;
+
+  let tools = [];
+  try {
+    const status = await apiFetch('/ui/api/status');
+    tools = status.manifest.visible_tools || [];
+  } catch (_) {}
+
+  const toolOptions = tools.length
+    ? tools.map(t => `<option value="${esc(t)}">${esc(t)}</option>`).join('')
+    : '<option value="">— no tools in manifest —</option>';
+
+  panel.innerHTML = `
+    <div class="sim-layout">
+      <div class="sim-form-card">
+        <div class="section-title">Tool call</div>
+        <div class="sim-form">
+          <div class="sim-field">
+            <label class="sim-label">Tool</label>
+            <div class="sim-input-row">
+              <select id="sim-tool" class="sim-select" oninput="simSyncTool()">
+                <option value="">— type or select —</option>
+                ${toolOptions}
+              </select>
+              <input id="sim-tool-custom" class="sim-input mono" placeholder="or type tool name" oninput="simSyncCustom()">
+            </div>
+          </div>
+          <div class="sim-field">
+            <label class="sim-label">Action</label>
+            <input id="sim-action" class="sim-input mono" placeholder="e.g. push, exec, read">
+          </div>
+          <div class="sim-field">
+            <label class="sim-label">Resource</label>
+            <input id="sim-resource" class="sim-input mono" placeholder="e.g. /path/to/file, origin, https://…">
+          </div>
+          <div class="sim-field sim-field-inline">
+            <label class="sim-label">Tainted input</label>
+            <input id="sim-tainted" type="checkbox" class="sim-checkbox">
+            <span class="muted small">Mark inputs as tainted (simulates prompt-injection context)</span>
+          </div>
+          <button class="btn btn-sm btn-allow" style="margin-top:8px" onclick="runSimulation()">Run simulation</button>
+        </div>
+      </div>
+      <div id="sim-result" class="sim-result-card" style="display:none"></div>
+    </div>
+  `;
+}
+
+function simSyncTool() {
+  const sel = document.getElementById('sim-tool');
+  const custom = document.getElementById('sim-tool-custom');
+  if (sel && custom && sel.value) custom.value = sel.value;
+}
+
+function simSyncCustom() {
+  const sel = document.getElementById('sim-tool');
+  if (sel) sel.value = '';
+}
+
+async function runSimulation() {
+  const tool     = (document.getElementById('sim-tool-custom')?.value || document.getElementById('sim-tool')?.value || '').trim();
+  const action   = (document.getElementById('sim-action')?.value || '').trim();
+  const resource = (document.getElementById('sim-resource')?.value || '').trim();
+  const tainted  = document.getElementById('sim-tainted')?.checked || false;
+  const result   = document.getElementById('sim-result');
+  if (!result) return;
+
+  if (!tool) {
+    result.style.display = 'block';
+    result.innerHTML = `<div class="sim-result-inner error"><span class="tag tag-deny">error</span> Tool name is required.</div>`;
+    return;
+  }
+
+  result.style.display = 'block';
+  result.innerHTML = `<div class="sim-result-inner"><div class="loading"><div class="spinner"></div>Evaluating…</div></div>`;
+
+  try {
+    const resp = await fetch('/ui/api/simulate', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ tool, action, resource, tainted }),
+    });
+    const data = await resp.json();
+
+    const decisionCls = data.allowed ? 'tag-allow' : data.decision === 'REQUIRE_APPROVAL' ? 'tag-ask' : 'tag-deny';
+    const taintNote = tainted
+      ? `<div class="sim-taint-note"><span class="tag tag-deny">tainted</span> Input marked as tainted — this simulates data from an untrusted provenance source.</div>`
+      : '';
+
+    result.innerHTML = `
+      <div class="sim-result-inner">
+        <div class="sim-verdict">
+          <span class="tag ${decisionCls} sim-verdict-tag">${esc(data.decision)}</span>
+          <span class="sim-reason">${esc(data.reason)}</span>
+        </div>
+        ${taintNote}
+        <div class="kv-list" style="margin-top:14px">
+          <div class="kv"><span class="k">display_name</span><span class="v mono">${esc(data.step.display_name)}</span></div>
+          <div class="kv"><span class="k">tool</span>        <span class="v mono">${esc(data.step.tool)}</span></div>
+          ${action   ? `<div class="kv"><span class="k">action</span>   <span class="v mono">${esc(data.step.action)}</span></div>` : ''}
+          ${resource ? `<div class="kv"><span class="k">resource</span> <span class="v mono">${esc(data.step.resource)}</span></div>` : ''}
+          ${data.failure_type ? `<div class="kv"><span class="k">failure</span>  <span class="v mono">${esc(data.failure_type)}</span></div>` : ''}
+        </div>
+      </div>
+    `;
+  } catch (e) {
+    result.innerHTML = `<div class="sim-result-inner error"><span class="tag tag-deny">error</span> ${esc(String(e))}</div>`;
+  }
 }
 
 // ── Benchmarks tab ────────────────────────────────────────────────────────

--- a/src/agent_hypervisor/ui/static/index.html
+++ b/src/agent_hypervisor/ui/static/index.html
@@ -25,9 +25,11 @@
 
     <nav class="tab-bar">
       <button class="tab-btn active" data-tab="manifests">Manifests</button>
+      <button class="tab-btn" data-tab="editor">Editor</button>
       <button class="tab-btn" data-tab="decisions">Decisions</button>
       <button class="tab-btn" data-tab="traces">Traces</button>
       <button class="tab-btn" data-tab="provenance">Provenance</button>
+      <button class="tab-btn" data-tab="simulator">Simulator</button>
       <button class="tab-btn" data-tab="benchmarks">Benchmarks</button>
       <div class="tab-refresh">
         <span class="refresh-label" id="refresh-label">—</span>
@@ -36,9 +38,11 @@
 
     <main>
       <div id="tab-manifests"  class="tab-panel active"><div class="loading"><div class="spinner"></div>Loading…</div></div>
+      <div id="tab-editor"     class="tab-panel"><div class="loading"><div class="spinner"></div>Loading…</div></div>
       <div id="tab-decisions"  class="tab-panel"><div class="loading"><div class="spinner"></div>Loading…</div></div>
       <div id="tab-traces"     class="tab-panel"><div class="loading"><div class="spinner"></div>Loading…</div></div>
       <div id="tab-provenance" class="tab-panel"><div class="loading"><div class="spinner"></div>Loading…</div></div>
+      <div id="tab-simulator"  class="tab-panel"><div class="loading"><div class="spinner"></div>Loading…</div></div>
       <div id="tab-benchmarks" class="tab-panel"><div class="loading"><div class="spinner"></div>Loading…</div></div>
     </main>
   </div>

--- a/src/agent_hypervisor/ui/static/style.css
+++ b/src/agent_hypervisor/ui/static/style.css
@@ -667,6 +667,248 @@ main {
 .md-li::before { content: '–'; position: absolute; left: 0; color: var(--text-muted); }
 .md-table { margin-top: 8px; margin-bottom: 16px; }
 
+/* ── Editor tab ── */
+
+.editor-layout {
+  display: flex;
+  flex-direction: column;
+  height: calc(100vh - var(--header-h) - var(--tabbar-h) - 48px);
+  gap: 10px;
+}
+
+.editor-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  flex-shrink: 0;
+}
+
+.editor-path {
+  color: var(--text-muted);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.editor-actions {
+  display: flex;
+  gap: 6px;
+  flex-shrink: 0;
+}
+
+.editor-textarea {
+  flex: 1;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  color: var(--text);
+  font-family: var(--mono);
+  font-size: 12px;
+  line-height: 1.65;
+  padding: 14px 16px;
+  resize: none;
+  outline: none;
+  tab-size: 2;
+  transition: border-color 0.15s;
+}
+
+.editor-textarea:focus { border-color: var(--accent); }
+
+.editor-status {
+  flex-shrink: 0;
+  min-height: 28px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.editor-status-msg {
+  font-size: 12px;
+  padding: 4px 10px;
+  border-radius: 5px;
+}
+
+.editor-status-msg.ok    { background: var(--allow-bg);   color: var(--allow); }
+.editor-status-msg.error { background: var(--deny-bg);    color: var(--deny); }
+.editor-status-msg.muted { color: var(--text-muted); }
+
+.editor-error-item {
+  font-size: 12px;
+  font-family: var(--mono);
+  color: var(--deny);
+  padding: 2px 10px;
+}
+
+/* ── Provenance flow view ── */
+
+.flow-list {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.flow-group {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 10px 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.flow-rule {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.flow-node {
+  padding: 2px 10px;
+  border-radius: 99px;
+  font-size: 12px;
+  border: 1px solid var(--border);
+}
+
+.flow-prov { background: var(--pending-bg); color: var(--pending); border-color: rgba(129,140,248,0.3); }
+.flow-tool { background: var(--surface2); color: var(--text-dim); }
+.flow-arg  { background: var(--surface2); color: var(--text-muted); font-size: 11px; }
+
+.flow-arrow {
+  color: var(--text-muted);
+  font-size: 14px;
+  line-height: 1;
+}
+
+/* ── Simulator tab ── */
+
+.sim-layout {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  max-width: 640px;
+}
+
+.sim-form-card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 20px 22px;
+}
+
+.sim-form {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  margin-top: 12px;
+}
+
+.sim-field {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+}
+
+.sim-field-inline {
+  flex-direction: row;
+  align-items: center;
+  gap: 10px;
+}
+
+.sim-label {
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.sim-input-row {
+  display: flex;
+  gap: 8px;
+}
+
+.sim-input,
+.sim-select {
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  color: var(--text);
+  font-family: var(--font);
+  font-size: 13px;
+  padding: 6px 10px;
+  outline: none;
+  transition: border-color 0.15s;
+  width: 100%;
+}
+
+.sim-input:focus,
+.sim-select:focus { border-color: var(--accent); }
+
+.sim-select { font-family: var(--font); max-width: 220px; }
+
+.sim-input.mono { font-family: var(--mono); font-size: 12px; }
+
+.sim-checkbox {
+  width: 16px;
+  height: 16px;
+  accent-color: var(--accent);
+  flex-shrink: 0;
+}
+
+.sim-result-card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  overflow: hidden;
+}
+
+.sim-result-inner {
+  padding: 18px 22px;
+}
+
+.sim-result-inner.error {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  color: var(--deny);
+  font-size: 13px;
+}
+
+.sim-verdict {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.sim-verdict-tag {
+  font-size: 13px;
+  padding: 3px 12px;
+}
+
+.sim-reason {
+  font-size: 13px;
+  color: var(--text-dim);
+}
+
+.sim-taint-note {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 10px;
+  font-size: 12px;
+  color: var(--text-muted);
+}
+
+/* ── View toggle (shared by provenance) ── */
+
+.view-toggle {
+  display: flex;
+  gap: 6px;
+}
+
 /* ── Scrollbar ── */
 
 ::-webkit-scrollbar { width: 6px; height: 6px; }


### PR DESCRIPTION
Adds three missing M5 Web UI features:

• Editor tab — inline YAML manifest editor with Validate and Save & Reload
  actions. Loads manifest from disk on first visit; does not auto-refresh so
  edits are never clobbered. Backend: GET/POST /ui/api/manifest/{source,
  validate,save}. Save validates before writing and calls reload_manifest().

• Simulator tab — dry-run form that submits tool/action/resource/tainted to
  POST /ui/api/simulate, which runs the call through enforcer.evaluate() and
  returns ALLOW/DENY/REQUIRE_APPROVAL with reason and failure_type. Tool
  dropdown is populated from the live manifest tool surface.

• Provenance flow view — adds a toggleable "Flow view" to the existing
  Provenance tab that renders each rule as a pill chain:
  [source] → [tool] · [arg] → [verdict]. Table view still available via
  toggle. Default is flow view.

https://claude.ai/code/session_01BaQqRnptzQhfJvRpSKmFis