### PR TITLE
Phase 2: Add approval flow, side panel, and simulation mode

### DIFF
--- a/browser-extension-demo/docs/approval_flow.md
+++ b/browser-extension-demo/docs/approval_flow.md
@@ -1,0 +1,176 @@
+# Approval Flow
+
+## Overview
+
+When the deterministic policy returns `decision: 'ask'`, the agent does not silently skip the action. Instead, the action is surfaced to the user through a structured approval flow. Approval is not a UI hack — it is a first-class part of the execution pipeline.
+
+The background service worker is the sole authority for the approval queue. The side panel and popup are display-and-control surfaces only.
+
+---
+
+## ApprovalRequest Model
+
+```typescript
+interface ApprovalRequest {
+  id: string;                          // UUID
+  intent_id: string;                   // ID of the IntentProposal that triggered 'ask'
+  intent_type: IntentType;             // what the agent wanted to do
+  semantic_event_id: string;           // the page context
+  source_url: string;                  // URL of the page that triggered the intent
+  trust_level: TrustLevel;            // 'trusted' | 'untrusted'
+  taint: boolean;                      // whether hidden content was detected
+  rule_hit: string;                    // the rule_id that returned 'ask'
+  reason: string;                      // rule_description (human-readable)
+  status: 'pending' | 'approved' | 'denied';
+  created_at: string;                  // ISO timestamp
+  resolved_at?: string;               // ISO timestamp, set on resolution
+  _exec_intent: IntentType;           // re-execution context: original intent
+  _exec_payload: Record<string, unknown>; // re-execution context: original payload
+}
+```
+
+The `_exec_intent` and `_exec_payload` fields are stored on the approval request so the background can re-execute the exact original action on approval — no round-trip to the UI is needed.
+
+---
+
+## Status Transitions
+
+```
+pending ──approve──▶ approved ──execute──▶ [allow trace entry]
+        ──deny────▶ denied              ──▶ [deny trace entry]
+        ──page navigated──▶ denied      ──▶ [deny trace entry, auto]
+        ──page unavailable──▶ denied    ──▶ [deny trace entry, auto]
+```
+
+Once resolved, an approval request is never re-opened. Each user interaction is a separate approval request.
+
+---
+
+## Step-by-Step Lifecycle
+
+### Step 1: Intent triggered
+
+User clicks "Save Note" while on `malicious.html`. The popup or side panel sends:
+
+```
+chrome.runtime.sendMessage({ type: 'RUN_ACTION', intent: 'save_memory', payload: { value: '...' } })
+```
+
+### Step 2: Policy evaluation
+
+Background requests a page snapshot from the content script, builds a `SemanticEvent` via `governedAgent.ingest()`, then calls `evaluatePolicy()`.
+
+Result:
+```
+{ decision: 'ask', rule_id: 'ask_before_memory_write_from_untrusted', ... }
+```
+
+### Step 3: Pending result returned from agent
+
+`governed_agent.runIntent()` detects `decision === 'ask'` and returns:
+
+```typescript
+{ pending: true, approvalRequest: ApprovalRequest, policy: PolicyResult, trace: DecisionTrace }
+```
+
+The execute lambda is **not called**.
+
+### Step 4: Background enqueues and records
+
+The background:
+- Adds the approval request to `state.approval_queue` via `enqueue()`
+- Appends a provisional trace entry with `decision: 'ask'`
+- Persists state to `chrome.storage.local`
+- Responds to the UI: `{ ok: true, pending: true, approval_id: '...' }`
+
+### Step 5: Side panel surfaces the request
+
+The side panel polls `GET_STATE` every 1500ms. Within the next cycle it receives the updated `approval_queue` and renders the pending request in `ApprovalQueueSection` with intent type, reason, trust level, taint status, and Approve / Deny buttons.
+
+### Step 6a: User approves
+
+Side panel sends:
+```
+chrome.runtime.sendMessage({ type: 'RESOLVE_APPROVAL', approval_id: '...', status: 'approved' })
+```
+
+Background:
+1. Verifies the approval request exists and is still pending
+2. Re-requests a page snapshot from the content script
+3. Checks that the current page URL matches `req.source_url` — if it differs, auto-denies (see edge case below)
+4. Calls `governedAgent.ingest(snapshot)` to rebuild the semantic event
+5. Executes the original intent (`req._exec_intent`) directly — no policy re-evaluation (the approval is the authority)
+6. If `save_memory`: creates the memory entry and prepends to `state.memory`
+7. Marks the approval as `'approved'` via `resolve()`
+8. Appends a new trace entry: `{ decision: 'allow', approval_id: req.id }`
+9. Persists state, responds with `{ ok: true, state, result }`
+
+### Step 6b: User denies
+
+Background:
+1. Marks the approval as `'denied'` via `resolve()`
+2. Appends a trace entry: `{ decision: 'deny', rule_hit: 'user_denied_approval', approval_id: req.id }`
+3. No action executes
+4. Persists state, responds with `{ ok: true, state }`
+
+### Step 7: State propagates
+
+The side panel receives the updated state via the `sendMessage` callback (immediate) and via the next poll (1500ms backup). The approval queue shows the resolved entry; the trace shows the full decision path.
+
+---
+
+## Edge Cases
+
+### Page navigated away before approval
+
+If the user navigates to a different URL before approving, the background detects `snapshot.url !== req.source_url` and auto-denies the approval with the reason:
+> "Approval auto-denied: the page navigated away before approval was granted."
+
+A deny trace entry is recorded with `approval_id` set.
+
+### Page unavailable (tab closed / content script error)
+
+If the background cannot get a snapshot (e.g., the tab was closed), the approval is auto-denied with:
+> "Approval auto-denied: could not reach the original page."
+
+### Simulation mode active during approval
+
+If the user toggles simulation mode on, then approves an approval that was created before simulation was toggled, the re-executed action still runs through `applySimulationGuard`. If `simulation_mode` is `true` at approval time, the action produces no side effects and the trace records `simulated: true`.
+
+---
+
+## Trace After Approval
+
+A full approval flow produces **two trace entries**:
+
+| Entry | `decision` | `rule_hit` | `approval_id` |
+|-------|-----------|-----------|--------------|
+| 1 (at ask time) | `ask` | `ask_before_memory_write_from_untrusted` | — |
+| 2 (at approval time) | `allow` | `user_approved` | `<uuid>` |
+
+Both entries share the same `semantic_event_id`. The `approval_id` in entry 2 links back to the `ApprovalRequest.id`, providing a complete audit trail from policy decision to user decision to execution.
+
+---
+
+## Message Sequence Diagram
+
+```
+UI                  Background            Content Script
+ |                      |                      |
+ |── RUN_ACTION ────────▶|                      |
+ |                      |── GET_PAGE_SNAPSHOT ──▶|
+ |                      |◀── snapshot ──────────|
+ |                      | evaluatePolicy → 'ask'
+ |                      | enqueue approvalRequest
+ |◀── { pending: true } ─|
+ |                      |
+ | [user sees approval in side panel]
+ |                      |
+ |── RESOLVE_APPROVAL ──▶|
+ |                      |── GET_PAGE_SNAPSHOT ──▶|
+ |                      |◀── snapshot ──────────|
+ |                      | verify URL matches
+ |                      | execute intent
+ |                      | mark approved
+ |◀── { ok: true, state }|
+```

--- a/browser-extension-demo/docs/phase2.md
+++ b/browser-extension-demo/docs/phase2.md
@@ -1,0 +1,169 @@
+# Phase 2: Browser Agent Hypervisor Demo Extension
+
+## What Phase 2 Adds
+
+Phase 2 transforms the MVP demo into a system that makes one idea undeniable:
+
+> The system is not "blocking actions". The system is governing reality through explicit decisions.
+
+### New Features
+
+| Feature | Description |
+|---------|-------------|
+| Approval Flow | `decision: 'ask'` now surfaces a real approval UI. The agent waits. The user decides. |
+| Side Panel | A persistent Chrome side panel that stays open across navigation, showing the live governance state. |
+| Simulation Mode | Actions can be processed without side effects. The trace marks them `simulated: true`. |
+| World State Visibility | A read-only view of all active policy rules and source trust assignments. |
+| Enriched Trace | Every decision now includes `rule_description`, `explanation`, `simulated`, and `approval_id`. |
+| Trace Filtering | Filter trace entries by decision type. Click any entry to see full detail. |
+
+---
+
+## File Map
+
+### New Files
+
+```
+src/core/
+  approval.ts          ApprovalRequest model + createApprovalRequest() factory
+  simulation.ts        applySimulationGuard() pure function
+  world_state.ts       WorldStateSnapshot + buildWorldStateSnapshot()
+
+src/state/
+  approval_queue.ts    enqueue / resolve / pendingOnly — pure queue operations
+
+src/extension/sidepanel/
+  main.tsx             Standalone React app root with 1500ms polling
+
+src/ui/sidepanel/
+  SidePanelApp.tsx     Top-level layout, receives all props from main.tsx
+  CurrentPageSection.tsx   URL, title, hidden content, trust, taint badges
+  LastIntentSection.tsx    Intent type, payload keys, reason
+  DecisionSection.tsx      Decision badge, rule, description, explanation
+  ActionsSection.tsx       Action buttons + simulation mode toggle
+  ApprovalQueueSection.tsx Pending approvals with Approve / Deny buttons
+  TraceSection.tsx         Filterable trace log, clickable entries
+  WorldStateSection.tsx    Read-only world model display
+
+src/ui/trace_viewer/
+  TraceDetail.tsx      Expanded detail view for a single DecisionTrace
+
+docs/
+  phase2.md            This file
+  approval_flow.md     Approval lifecycle documentation
+  trace_model.md       Full DecisionTrace field reference
+```
+
+### Modified Files
+
+```
+src/core/policy.ts           Added PolicyRuleDescriptor, enriched PolicyResult
+src/core/trace.ts            Added simulated, approval_id, rule_id, rule_description, explanation
+src/agents/governed_agent.ts Returns pending result for 'ask'; applies simulation guard
+src/extension/background/index.ts  Extended AppState; new message handlers
+src/extension/popup/main.tsx       Updated AppState type; approval UI; simulated badge in trace
+src/extension/sidepanel/index.html Changed script src to ./main.tsx
+```
+
+---
+
+## How to Demo Each Feature
+
+### Setup
+
+1. `npm run build` in `browser-extension-demo/`
+2. Load unpacked extension from `dist/` in Chrome (chrome://extensions → Developer mode → Load unpacked)
+3. Open a demo page from `public/demo/` — open the file directly in Chrome
+
+### Flow E — Approval Interaction
+
+1. Open `public/demo/malicious.html`
+2. Click the extension icon → the popup opens in Governed mode
+3. Click "Open side panel" from the Chrome extensions area
+4. In the popup or side panel, type a note and click **Save note**
+5. The side panel shows an approval in the **Approval Queue** section
+6. Click **Approve** → the note is saved; trace shows `ask` entry + `allow` entry with `approval_id`
+7. Repeat, click **Deny** → nothing is saved; trace shows `ask` entry + `deny` entry
+
+### Flow F — Simulation Mode
+
+1. In the side panel's **Actions** section, check **Simulate mode ON**
+2. Click **Summarize**
+3. The side panel **Decision** section shows `SIMULATE` (blue), `simulated: true`
+4. The trace entry shows `decision: 'simulate'`, `simulated: true`
+5. No summarization result is returned — no side effect occurred
+
+### Flow G — Side Panel Persistent Governance
+
+1. Open the side panel
+2. Navigate from `benign.html` → `suspicious.html` → `malicious.html`
+3. Click **Summarize** on each page
+4. The **Current Page** section updates with each page's trust/taint status
+5. The **Trace** section accumulates all decisions across navigations
+6. The **World State** section remains constant (the rules didn't change)
+
+### Naive vs Governed Comparison
+
+1. Switch to **Naive** mode (orange button)
+2. On `malicious.html`, click **Save note**
+3. Note is saved immediately — no policy check, no approval, no trace entry
+4. Switch to **Governed** mode (green button)
+5. Same action → approval required → trace recorded
+
+---
+
+## Architecture Changes from MVP
+
+### MVP Gaps Filled
+
+| Gap | Phase 2 Solution |
+|-----|-----------------|
+| `'ask'` was silently skipped | Now surfaces to `ApprovalQueueSection`; action deferred |
+| Side panel loaded popup code | Now has dedicated `main.tsx` with persistent polling |
+| No simulation mode | `applySimulationGuard` + toggle in UI |
+| Policy rules were anonymous strings | Now have `rule_id`, `rule_description`, `explanation` |
+| Trace was a flat log | Now filterable, clickable, includes approval linkage |
+| No world model visibility | `WorldStateSection` shows all rules and trust assignments |
+
+### Data Flow (Approval Path)
+
+```
+User clicks "Save Note"
+  → RUN_ACTION { intent: 'save_memory' }
+  → Background: ingest → evaluatePolicy → 'ask'
+  → GovernedAgent returns { pending: true, approvalRequest }
+  → Background enqueues, records trace { decision: 'ask' }
+  → Side panel polls → shows ApprovalQueueSection
+  → User clicks Approve
+  → RESOLVE_APPROVAL { approval_id, status: 'approved' }
+  → Background: re-snapshot, verify URL, execute intent
+  → Memory written; trace { decision: 'allow', approval_id } appended
+  → Side panel re-renders with resolved queue + new trace
+```
+
+### What Simulation Mode Does and Does Not Do
+
+**Does:**
+- Convert `'allow'` decisions to `'simulate'` before execution
+- Record `{ simulated: true }` in the trace
+- Prevent all side effects (no memory writes, no exports)
+
+**Does not:**
+- Bypass `'deny'` decisions — policy still governs
+- Bypass `'ask'` decisions — approvals still required
+- Change what the policy evaluates — evaluation is identical
+
+---
+
+## Message Protocol (complete)
+
+| Message | Payload | Response |
+|---------|---------|----------|
+| `SET_MODE` | `{ mode }` | `{ ok, state }` |
+| `GET_STATE` | — | `{ ok, state }` |
+| `RUN_ACTION` | `{ intent, payload? }` | `{ ok, mode, event, governed, state }` |
+| `SET_SIMULATION_MODE` | `{ enabled }` | `{ ok, state }` |
+| `RESOLVE_APPROVAL` | `{ approval_id, status }` | `{ ok, state, result? }` |
+| `GET_APPROVAL_QUEUE` | — | `{ ok, queue }` |
+| `GET_WORLD_STATE` | — | `{ ok, world_state }` |
+| `CLEAR_TRACE` | — | `{ ok, state }` |

--- a/browser-extension-demo/docs/trace_model.md
+++ b/browser-extension-demo/docs/trace_model.md
@@ -1,0 +1,138 @@
+# Trace Model
+
+## Overview
+
+Every policy decision made in governed mode is recorded as a `DecisionTrace` entry. The trace is the primary mechanism for answering:
+
+> "What exactly happened and why?"
+
+The trace is append-only (newest first in `state.trace`). It survives the background service worker's sleep/wake cycle via `chrome.storage.local`.
+
+---
+
+## DecisionTrace Interface
+
+```typescript
+interface DecisionTrace {
+  id: string;                  // UUID — unique per decision
+  semantic_event_id: string;   // links to the SemanticEvent (page context)
+  intent_type: IntentType;     // what the agent proposed to do
+  trust_level: TrustLevel;    // 'trusted' | 'untrusted' at decision time
+  taint: boolean;              // whether the page was tainted at decision time
+  rule_hit: string;            // identical to rule_id (kept for compat)
+  rule_id: string;             // the ID of the rule that determined the decision
+  rule_description: string;   // human-readable description of the rule
+  explanation: string;         // why this rule fired for this specific event
+  decision: PolicyDecision;    // 'allow' | 'deny' | 'ask' | 'simulate'
+  simulated: boolean;          // true when simulation mode converted 'allow' → 'simulate'
+  approval_id?: string;        // present when this entry was created by RESOLVE_APPROVAL
+  timestamp: string;           // ISO 8601
+}
+```
+
+---
+
+## Field Reference
+
+### `rule_id` and `rule_description`
+
+The `rule_id` is a stable snake_case identifier for the policy rule. The `rule_description` is the human-readable sentence that describes the rule's purpose.
+
+| rule_id | rule_description |
+|---------|-----------------|
+| `always_allow_summarize` | Summarizing page content is a safe read-only operation always permitted regardless of source trust or taint. |
+| `allow_read_only_extraction` | Extracting links and action items are non-mutating read operations permitted from any source. |
+| `deny_export_for_tainted_content` | Exporting a summary is blocked when the page contains hidden or tainted content to prevent data exfiltration of injected payloads. |
+| `ask_before_memory_write_from_untrusted` | Writing to memory from an untrusted source requires explicit user approval to prevent prompt-injection-driven memory poisoning. |
+| `ask_before_export_from_untrusted` | Exporting content from an untrusted source requires explicit user approval since the content may have been manipulated. |
+| `fallback_simulate_unknown` | Any intent not matched by a specific rule is simulated rather than executed, ensuring unknown operations cannot cause unintended side effects. |
+| `user_approved` | The user explicitly approved this action after reviewing the governance decision. |
+| `user_denied_approval` | The user (or the system on their behalf) denied this approval request. |
+
+### `explanation`
+
+Unlike `rule_description` which is static, `explanation` is generated at policy evaluation time for the specific event. It includes the URL and the reason the rule fired for that particular page context. Example:
+
+> `"malicious.html" is untrusted; writing to memory without confirmation risks poisoning future agent behaviour.`
+
+### `simulated`
+
+`true` when simulation mode was active AND the original policy decision was `'allow'`. The `applySimulationGuard` function converts `'allow'` → `'simulate'` in this case. The `decision` field will be `'simulate'` and `simulated` will be `true`.
+
+When simulation mode is off, `simulated` is always `false`.
+
+### `approval_id`
+
+Present only when this trace entry was created as a result of a `RESOLVE_APPROVAL` message. The value is the `ApprovalRequest.id` that was resolved.
+
+An approval flow creates two trace entries with the same `semantic_event_id`:
+1. The initial `'ask'` entry (no `approval_id`)
+2. The resolution entry (has `approval_id`; `decision` is `'allow'` or `'deny'`)
+
+---
+
+## Decision Types
+
+| `decision` | Meaning |
+|-----------|---------|
+| `allow` | Policy permitted the action; the execute lambda ran. |
+| `deny` | Policy blocked the action; no execution occurred. |
+| `ask` | Policy required user approval; execution deferred. A corresponding `ApprovalRequest` exists in `state.approval_queue`. |
+| `simulate` | Action was processed but not executed — either the fallback rule applied, or simulation mode converted an `'allow'` decision. |
+
+---
+
+## Reading the Trace
+
+### Example: Memory write from malicious page, approved
+
+```
+[0] decision: 'allow'   intent: save_memory   rule: user_approved            approval_id: abc-123
+[1] decision: 'ask'     intent: save_memory   rule: ask_before_memory_write_from_untrusted
+```
+
+Read bottom-up: entry `[1]` was the initial policy check that produced `'ask'`. Entry `[0]` is the re-execution after the user approved. The `approval_id: 'abc-123'` in entry `[0]` links to the `ApprovalRequest`.
+
+### Example: Export attempt on tainted page, denied
+
+```
+[0] decision: 'deny'    intent: export_summary   rule: deny_export_for_tainted_content
+```
+
+A single trace entry. No approval was created; the policy immediately denied because the page had `taint: true`.
+
+### Example: Summarize in simulation mode
+
+```
+[0] decision: 'simulate'  intent: summarize_page  rule: always_allow_summarize  simulated: true
+```
+
+Policy would normally `'allow'`, but simulation mode was on. `applySimulationGuard` converted `'allow'` → `'simulate'`. The `simulated: true` field distinguishes this from the `fallback_simulate_unknown` case.
+
+### Example: Memory write denied by user
+
+```
+[0] decision: 'deny'    intent: save_memory   rule: user_denied_approval         approval_id: xyz-456
+[1] decision: 'ask'     intent: save_memory   rule: ask_before_memory_write_from_untrusted
+```
+
+Entry `[1]` is the initial ask. Entry `[0]` is the denial. The user saw the approval request and clicked Deny.
+
+---
+
+## Filtering
+
+The trace viewer in the side panel supports filtering by `decision` type:
+- **All** — show everything
+- **Allow** — only executed actions
+- **Deny** — only blocked actions
+- **Ask** — only approval requests (pending or resolved)
+- **Simulate** — only simulated executions
+
+Clicking any entry expands it to show the full `DecisionTrace` including `rule_description`, `explanation`, `approval_id`, and all metadata.
+
+---
+
+## Persistence
+
+The trace is stored in `chrome.storage.local` as part of `state.trace`. It persists across browser sessions and service worker restarts. Use `CLEAR_TRACE` to reset it for demo purposes.

--- a/browser-extension-demo/package-lock.json
+++ b/browser-extension-demo/package-lock.json
@@ -1,0 +1,1765 @@
+{
+  "name": "browser-agent-hypervisor-demo-extension",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "browser-agent-hypervisor-demo-extension",
+      "version": "0.1.0",
+      "dependencies": {
+        "react": "^18.3.1",
+        "react-dom": "^18.3.1"
+      },
+      "devDependencies": {
+        "@types/chrome": "^0.0.286",
+        "@types/react": "^18.3.11",
+        "@types/react-dom": "^18.3.0",
+        "@vitejs/plugin-react": "^4.3.1",
+        "typescript": "^5.6.3",
+        "vite": "^5.4.10"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz",
+      "integrity": "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
+      "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
+        "@babel/helper-compilation-targets": "^7.28.6",
+        "@babel/helper-module-transforms": "^7.28.6",
+        "@babel/helpers": "^7.28.6",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/traverse": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.29.1",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
+      "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
+      "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.28.6",
+        "@babel/helper-validator-option": "^7.27.1",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
+      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
+      "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
+      "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.28.6",
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/traverse": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-plugin-utils": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.28.6.tgz",
+      "integrity": "sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
+      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz",
+      "integrity": "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.29.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
+      "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-self": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.27.1.tgz",
+      "integrity": "sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-source": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.27.1.tgz",
+      "integrity": "sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
+      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.28.6",
+        "@babel/parser": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
+      "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
+        "@babel/helper-globals": "^7.28.0",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.29.0",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-beta.27",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
+      "integrity": "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.1.tgz",
+      "integrity": "sha512-d6FinEBLdIiK+1uACUttJKfgZREXrF0Qc2SmLII7W2AD8FfiZ9Wjd+rD/iRuf5s5dWrr1GgwXCvPqOuDquOowA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.1.tgz",
+      "integrity": "sha512-YjG/EwIDvvYI1YvYbHvDz/BYHtkY4ygUIXHnTdLhG+hKIQFBiosfWiACWortsKPKU/+dUwQQCKQM3qrDe8c9BA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.1.tgz",
+      "integrity": "sha512-mjCpF7GmkRtSJwon+Rq1N8+pI+8l7w5g9Z3vWj4T7abguC4Czwi3Yu/pFaLvA3TTeMVjnu3ctigusqWUfjZzvw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.1.tgz",
+      "integrity": "sha512-haZ7hJ1JT4e9hqkoT9R/19XW2QKqjfJVv+i5AGg57S+nLk9lQnJ1F/eZloRO3o9Scy9CM3wQ9l+dkXtcBgN5Ew==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.1.tgz",
+      "integrity": "sha512-czw90wpQq3ZsAVBlinZjAYTKduOjTywlG7fEeWKUA7oCmpA8xdTkxZZlwNJKWqILlq0wehoZcJYfBvOyhPTQ6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.1.tgz",
+      "integrity": "sha512-KVB2rqsxTHuBtfOeySEyzEOB7ltlB/ux38iu2rBQzkjbwRVlkhAGIEDiiYnO2kFOkJp+Z7pUXKyrRRFuFUKt+g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.1.tgz",
+      "integrity": "sha512-L+34Qqil+v5uC0zEubW7uByo78WOCIrBvci69E7sFASRl0X7b/MB6Cqd1lky/CtcSVTydWa2WZwFuWexjS5o6g==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.1.tgz",
+      "integrity": "sha512-n83O8rt4v34hgFzlkb1ycniJh7IR5RCIqt6mz1VRJD6pmhRi0CXdmfnLu9dIUS6buzh60IvACM842Ffb3xd6Gg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.1.tgz",
+      "integrity": "sha512-Nql7sTeAzhTAja3QXeAI48+/+GjBJ+QmAH13snn0AJSNL50JsDqotyudHyMbO2RbJkskbMbFJfIJKWA6R1LCJQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.1.tgz",
+      "integrity": "sha512-+pUymDhd0ys9GcKZPPWlFiZ67sTWV5UU6zOJat02M1+PiuSGDziyRuI/pPue3hoUwm2uGfxdL+trT6Z9rxnlMA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.1.tgz",
+      "integrity": "sha512-VSvgvQeIcsEvY4bKDHEDWcpW4Yw7BtlKG1GUT4FzBUlEKQK0rWHYBqQt6Fm2taXS+1bXvJT6kICu5ZwqKCnvlQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.1.tgz",
+      "integrity": "sha512-4LqhUomJqwe641gsPp6xLfhqWMbQV04KtPp7/dIp0nzPxAkNY1AbwL5W0MQpcalLYk07vaW9Kp1PBhdpZYYcEw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.1.tgz",
+      "integrity": "sha512-tLQQ9aPvkBxOc/EUT6j3pyeMD6Hb8QF2BTBnCQWP/uu1lhc9AIrIjKnLYMEroIz/JvtGYgI9dF3AxHZNaEH0rw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.1.tgz",
+      "integrity": "sha512-RMxFhJwc9fSXP6PqmAz4cbv3kAyvD1etJFjTx4ONqFP9DkTkXsAMU4v3Vyc5BgzC+anz7nS/9tp4obsKfqkDHg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.1.tgz",
+      "integrity": "sha512-QKgFl+Yc1eEk6MmOBfRHYF6lTxiiiV3/z/BRrbSiW2I7AFTXoBFvdMEyglohPj//2mZS4hDOqeB0H1ACh3sBbg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.1.tgz",
+      "integrity": "sha512-RAjXjP/8c6ZtzatZcA1RaQr6O1TRhzC+adn8YZDnChliZHviqIjmvFwHcxi4JKPSDAt6Uhf/7vqcBzQJy0PDJg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.1.tgz",
+      "integrity": "sha512-wcuocpaOlaL1COBYiA89O6yfjlp3RwKDeTIA0hM7OpmhR1Bjo9j31G1uQVpDlTvwxGn2nQs65fBFL5UFd76FcQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.1.tgz",
+      "integrity": "sha512-77PpsFQUCOiZR9+LQEFg9GClyfkNXj1MP6wRnzYs0EeWbPcHs02AXu4xuUbM1zhwn3wqaizle3AEYg5aeoohhg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.1.tgz",
+      "integrity": "sha512-5cIATbk5vynAjqqmyBjlciMJl1+R/CwX9oLk/EyiFXDWd95KpHdrOJT//rnUl4cUcskrd0jCCw3wpZnhIHdD9w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.1.tgz",
+      "integrity": "sha512-cl0w09WsCi17mcmWqqglez9Gk8isgeWvoUZ3WiJFYSR3zjBQc2J5/ihSjpl+VLjPqjQ/1hJRcqBfLjssREQILw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.1.tgz",
+      "integrity": "sha512-4Cv23ZrONRbNtbZa37mLSueXUCtN7MXccChtKpUnQNgF010rjrjfHx3QxkS2PI7LqGT5xXyYs1a7LbzAwT0iCA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.1.tgz",
+      "integrity": "sha512-i1okWYkA4FJICtr7KpYzFpRTHgy5jdDbZiWfvny21iIKky5YExiDXP+zbXzm3dUcFpkEeYNHgQ5fuG236JPq0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.1.tgz",
+      "integrity": "sha512-u09m3CuwLzShA0EYKMNiFgcjjzwqtUMLmuCJLeZWjjOYA3IT2Di09KaxGBTP9xVztWyIWjVdsB2E9goMjZvTQg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.1.tgz",
+      "integrity": "sha512-k+600V9Zl1CM7eZxJgMyTUzmrmhB/0XZnF4pRypKAlAgxmedUA+1v9R+XOFv56W4SlHEzfeMtzujLJD22Uz5zg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.1.tgz",
+      "integrity": "sha512-lWMnixq/QzxyhTV6NjQJ4SFo1J6PvOX8vUx5Wb4bBPsEb+8xZ89Bz6kOXpfXj9ak9AHTQVQzlgzBEc1SyM27xQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/babel__core": {
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7",
+        "@types/babel__generator": "*",
+        "@types/babel__template": "*",
+        "@types/babel__traverse": "*"
+      }
+    },
+    "node_modules/@types/babel__generator": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+      "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__template": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__traverse": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+      "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.2"
+      }
+    },
+    "node_modules/@types/chrome": {
+      "version": "0.0.286",
+      "resolved": "https://registry.npmjs.org/@types/chrome/-/chrome-0.0.286.tgz",
+      "integrity": "sha512-Valy/wWWAwfnxLL1zPM3KJEUM3xbO3O67sNT4SjHUSn39QwIhnXBfIQuJNchJfmb+5qKV+zv9O6fy6nq8cO+aQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/filesystem": "*",
+        "@types/har-format": "*"
+      }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/filesystem": {
+      "version": "0.0.36",
+      "resolved": "https://registry.npmjs.org/@types/filesystem/-/filesystem-0.0.36.tgz",
+      "integrity": "sha512-vPDXOZuannb9FZdxgHnqSwAG/jvdGM8Wq+6N4D/d80z+D4HWH+bItqsZaVRQykAn6WEVeEkLm2oQigyHtgb0RA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/filewriter": "*"
+      }
+    },
+    "node_modules/@types/filewriter": {
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/@types/filewriter/-/filewriter-0.0.33.tgz",
+      "integrity": "sha512-xFU8ZXTw4gd358lb2jw25nxY9QAgqn2+bKKjKOYfNCzN4DKCFetK7sPtrlpg66Ywe3vWY9FNxprZawAh9wfJ3g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/har-format": {
+      "version": "1.2.16",
+      "resolved": "https://registry.npmjs.org/@types/har-format/-/har-format-1.2.16.tgz",
+      "integrity": "sha512-fluxdy7ryD3MV6h8pTfTYpy/xQzCFC7m89nOH9y94cNqJ1mDIDPut7MnRHI3F6qRmh/cT2fUjG1MLdCNb4hE9A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/prop-types": {
+      "version": "15.7.15",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
+      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/react": {
+      "version": "18.3.28",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
+      "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/prop-types": "*",
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "18.3.7",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
+      "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^18.0.0"
+      }
+    },
+    "node_modules/@vitejs/plugin-react": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz",
+      "integrity": "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.28.0",
+        "@babel/plugin-transform-react-jsx-self": "^7.27.1",
+        "@babel/plugin-transform-react-jsx-source": "^7.27.1",
+        "@rolldown/pluginutils": "1.0.0-beta.27",
+        "@types/babel__core": "^7.20.5",
+        "react-refresh": "^0.17.0"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+      }
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.10.19",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.19.tgz",
+      "integrity": "sha512-qCkNLi2sfBOn8XhZQ0FXsT1Ki/Yo5P90hrkRamVFRS7/KV9hpfA4HkoWNU152+8w0zPjnxo5psx5NL3PSGgv5g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
+      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.10.12",
+        "caniuse-lite": "^1.0.30001782",
+        "electron-to-chromium": "^1.5.328",
+        "node-releases": "^2.0.36",
+        "update-browserslist-db": "^1.2.3"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001788",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001788.tgz",
+      "integrity": "sha512-6q8HFp+lOQtcf7wBK+uEenxymVWkGKkjFpCvw5W25cmMwEDU45p1xQFBQv8JDlMMry7eNxyBaR+qxgmTUZkIRQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.338",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.338.tgz",
+      "integrity": "sha512-KVQQ3xko9/coDX3qXLUEEbqkKT8L+1DyAovrtu0Khtrt9wjSZ+7CZV4GVzxFy9Oe1NbrIU1oVXCwHJruIA1PNg==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "license": "MIT"
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.37",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.37.tgz",
+      "integrity": "sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/postcss": {
+      "version": "8.5.10",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
+      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/react": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
+      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.23.2"
+      },
+      "peerDependencies": {
+        "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-refresh": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
+      "integrity": "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.1.tgz",
+      "integrity": "sha512-VmtB2rFU/GroZ4oL8+ZqXgSA38O6GR8KSIvWmEFv63pQ0G6KaBH9s07PO8XTXP4vI+3UJUEypOfjkGfmSBBR0w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.1",
+        "@rollup/rollup-android-arm64": "4.60.1",
+        "@rollup/rollup-darwin-arm64": "4.60.1",
+        "@rollup/rollup-darwin-x64": "4.60.1",
+        "@rollup/rollup-freebsd-arm64": "4.60.1",
+        "@rollup/rollup-freebsd-x64": "4.60.1",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.1",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.1",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.1",
+        "@rollup/rollup-linux-arm64-musl": "4.60.1",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.1",
+        "@rollup/rollup-linux-loong64-musl": "4.60.1",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.1",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.1",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.1",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.1",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.1",
+        "@rollup/rollup-linux-x64-gnu": "4.60.1",
+        "@rollup/rollup-linux-x64-musl": "4.60.1",
+        "@rollup/rollup-openbsd-x64": "4.60.1",
+        "@rollup/rollup-openharmony-arm64": "4.60.1",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.1",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.1",
+        "@rollup/rollup-win32-x64-gnu": "4.60.1",
+        "@rollup/rollup-win32-x64-msvc": "4.60.1",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      }
+    },
+    "node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true,
+      "license": "ISC"
+    }
+  }
+}

--- a/browser-extension-demo/src/agents/governed_agent.ts
+++ b/browser-extension-demo/src/agents/governed_agent.ts
@@ -5,12 +5,24 @@ import { createIntent, type IntentType } from '../core/intent';
 import { evaluatePolicy, type PolicyResult } from '../core/policy';
 import { createMemoryEntry, type MemoryEntry } from '../core/memory';
 import { makeTrace, type DecisionTrace } from '../core/trace';
+import { createApprovalRequest, type ApprovalRequest } from '../core/approval';
+import { applySimulationGuard } from '../core/simulation';
 
 export interface GovernedResult<T> {
   data?: T;
   policy: PolicyResult;
   trace: DecisionTrace;
+  pending?: false;
 }
+
+export interface GovernedPendingResult {
+  pending: true;
+  approvalRequest: ApprovalRequest;
+  policy: PolicyResult;
+  trace: DecisionTrace;
+}
+
+export type GovernedOutcome<T> = GovernedResult<T> | GovernedPendingResult;
 
 export class GovernedAgent {
   constructor(private readonly provider: AgentProvider) {}
@@ -22,21 +34,52 @@ export class GovernedAgent {
   async runIntent(
     event: SemanticEvent,
     intentType: IntentType,
-    execute: () => Promise<unknown> | unknown
-  ): Promise<GovernedResult<unknown>> {
+    execute: () => Promise<unknown> | unknown,
+    simulationMode = false,
+    approvalId?: string
+  ): Promise<GovernedOutcome<unknown>> {
     const intent = createIntent(event, intentType, {}, 'user_requested');
     const policy = evaluatePolicy(event, intent);
+
+    // When decision is 'ask', surface to approval queue rather than silently skipping
+    if (policy.decision === 'ask') {
+      const approvalRequest = createApprovalRequest(intent, event, policy);
+      const trace = makeTrace({
+        semantic_event_id: event.id,
+        intent_type: intentType,
+        trust_level: event.trust_level,
+        taint: event.taint,
+        rule_hit: policy.rule_hit,
+        rule_id: policy.rule_id,
+        rule_description: policy.rule_description,
+        explanation: policy.explanation,
+        decision: 'ask',
+        simulated: false
+      });
+      return { pending: true, approvalRequest, policy, trace };
+    }
+
+    // Apply simulation guard: converts 'allow' → 'simulate' when simulation mode is on
+    const effectiveDecision = applySimulationGuard(policy.decision, simulationMode);
+    const simulated = effectiveDecision === 'simulate' && policy.decision === 'allow';
+
     const trace = makeTrace({
       semantic_event_id: event.id,
       intent_type: intentType,
       trust_level: event.trust_level,
       taint: event.taint,
       rule_hit: policy.rule_hit,
-      decision: policy.decision
+      rule_id: policy.rule_id,
+      rule_description: policy.rule_description,
+      explanation: policy.explanation,
+      decision: effectiveDecision,
+      simulated,
+      ...(approvalId ? { approval_id: approvalId } : {})
     });
 
-    if (policy.decision !== 'allow') {
-      return { policy, trace };
+    // Only execute if the effective decision is 'allow'
+    if (effectiveDecision !== 'allow') {
+      return { policy: { ...policy, decision: effectiveDecision }, trace };
     }
 
     return { data: await execute(), policy, trace };

--- a/browser-extension-demo/src/core/approval.ts
+++ b/browser-extension-demo/src/core/approval.ts
@@ -1,0 +1,47 @@
+import type { IntentType } from './intent';
+import type { TrustLevel } from './semantic_event';
+import type { PolicyResult } from './policy';
+import type { IntentProposal } from './intent';
+import type { SemanticEvent } from './semantic_event';
+
+export type ApprovalStatus = 'pending' | 'approved' | 'denied';
+
+export interface ApprovalRequest {
+  id: string;
+  intent_id: string;
+  intent_type: IntentType;
+  semantic_event_id: string;
+  source_url: string;
+  trust_level: TrustLevel;
+  taint: boolean;
+  rule_hit: string;          // same as rule_id
+  reason: string;            // rule_description from the rule that triggered 'ask'
+  status: ApprovalStatus;
+  created_at: string;
+  resolved_at?: string;
+  // Re-execution context — stored so background can re-run the intent on approval
+  _exec_intent: IntentType;
+  _exec_payload: Record<string, unknown>;
+}
+
+export function createApprovalRequest(
+  intent: IntentProposal,
+  event: SemanticEvent,
+  policyResult: PolicyResult
+): ApprovalRequest {
+  return {
+    id: crypto.randomUUID(),
+    intent_id: intent.id,
+    intent_type: intent.intent_type,
+    semantic_event_id: event.id,
+    source_url: event.url,
+    trust_level: event.trust_level,
+    taint: event.taint,
+    rule_hit: policyResult.rule_id,
+    reason: policyResult.rule_description,
+    status: 'pending',
+    created_at: new Date().toISOString(),
+    _exec_intent: intent.intent_type,
+    _exec_payload: intent.payload ?? {}
+  };
+}

--- a/browser-extension-demo/src/core/policy.ts
+++ b/browser-extension-demo/src/core/policy.ts
@@ -3,31 +3,116 @@ import type { SemanticEvent } from './semantic_event';
 
 export type PolicyDecision = 'allow' | 'deny' | 'ask' | 'simulate';
 
-export interface PolicyResult {
+export interface PolicyRuleDescriptor {
+  rule_id: string;
+  rule_description: string;
   decision: PolicyDecision;
-  rule_hit: string;
 }
 
+export interface PolicyResult {
+  decision: PolicyDecision;
+  rule_hit: string;        // kept for backward compat — always equals rule_id
+  rule_id: string;
+  rule_description: string;
+  explanation: string;
+}
+
+// Exported static rule table — used by world_state.ts to render the world model
+export const POLICY_RULES: PolicyRuleDescriptor[] = [
+  {
+    rule_id: 'always_allow_summarize',
+    rule_description: 'Summarizing page content is a safe read-only operation always permitted regardless of source trust or taint.',
+    decision: 'allow'
+  },
+  {
+    rule_id: 'allow_read_only_extraction',
+    rule_description: 'Extracting links and action items are non-mutating read operations permitted from any source.',
+    decision: 'allow'
+  },
+  {
+    rule_id: 'deny_export_for_tainted_content',
+    rule_description: 'Exporting a summary is blocked when the page contains hidden or tainted content to prevent data exfiltration of injected payloads.',
+    decision: 'deny'
+  },
+  {
+    rule_id: 'ask_before_memory_write_from_untrusted',
+    rule_description: 'Writing to memory from an untrusted source requires explicit user approval to prevent prompt-injection-driven memory poisoning.',
+    decision: 'ask'
+  },
+  {
+    rule_id: 'ask_before_export_from_untrusted',
+    rule_description: 'Exporting content from an untrusted source requires explicit user approval since the content may have been manipulated.',
+    decision: 'ask'
+  },
+  {
+    rule_id: 'fallback_simulate_unknown',
+    rule_description: 'Any intent not matched by a specific rule is simulated rather than executed, ensuring unknown operations cannot cause unintended side effects.',
+    decision: 'simulate'
+  }
+];
+
 export function evaluatePolicy(event: SemanticEvent, intent: IntentProposal): PolicyResult {
+  // Rule 1: Always allow summarization
   if (intent.intent_type === 'summarize_page') {
-    return { decision: 'allow', rule_hit: 'always_allow_summarize' };
+    return {
+      decision: 'allow',
+      rule_hit: 'always_allow_summarize',
+      rule_id: 'always_allow_summarize',
+      rule_description: POLICY_RULES[0].rule_description,
+      explanation: `Summarizing "${event.url}" is a safe read-only operation; trust level and taint do not restrict this.`
+    };
   }
 
+  // Rule 2: Allow read-only extraction
   if (intent.intent_type === 'extract_links' || intent.intent_type === 'extract_action_items') {
-    return { decision: 'allow', rule_hit: 'allow_read_only_extraction' };
+    return {
+      decision: 'allow',
+      rule_hit: 'allow_read_only_extraction',
+      rule_id: 'allow_read_only_extraction',
+      rule_description: POLICY_RULES[1].rule_description,
+      explanation: `Extraction from "${event.url}" is non-mutating; no side effects are possible.`
+    };
   }
 
+  // Rule 3: Deny export if tainted (checked before trust level)
   if (event.taint && intent.intent_type === 'export_summary') {
-    return { decision: 'deny', rule_hit: 'deny_export_for_tainted_content' };
+    return {
+      decision: 'deny',
+      rule_hit: 'deny_export_for_tainted_content',
+      rule_id: 'deny_export_for_tainted_content',
+      rule_description: POLICY_RULES[2].rule_description,
+      explanation: `Page at "${event.url}" is tainted (hidden content detected); exporting could leak injected data.`
+    };
   }
 
+  // Rule 4: Ask before memory write from untrusted source
   if (event.trust_level === 'untrusted' && intent.intent_type === 'save_memory') {
-    return { decision: 'ask', rule_hit: 'ask_before_memory_write_from_untrusted' };
+    return {
+      decision: 'ask',
+      rule_hit: 'ask_before_memory_write_from_untrusted',
+      rule_id: 'ask_before_memory_write_from_untrusted',
+      rule_description: POLICY_RULES[3].rule_description,
+      explanation: `"${event.url}" is untrusted; writing to memory without confirmation risks poisoning future agent behaviour.`
+    };
   }
 
+  // Rule 5: Ask before export from untrusted source (only reached if taint is false)
   if (event.trust_level === 'untrusted' && intent.intent_type === 'export_summary') {
-    return { decision: 'ask', rule_hit: 'ask_before_export_from_untrusted' };
+    return {
+      decision: 'ask',
+      rule_hit: 'ask_before_export_from_untrusted',
+      rule_id: 'ask_before_export_from_untrusted',
+      rule_description: POLICY_RULES[4].rule_description,
+      explanation: `"${event.url}" is untrusted; exporting its content requires explicit confirmation.`
+    };
   }
 
-  return { decision: 'simulate', rule_hit: 'fallback_simulate_unknown' };
+  // Rule 6: Fallback — simulate unknown intents (no side effects)
+  return {
+    decision: 'simulate',
+    rule_hit: 'fallback_simulate_unknown',
+    rule_id: 'fallback_simulate_unknown',
+    rule_description: POLICY_RULES[5].rule_description,
+    explanation: `Intent "${intent.intent_type}" matched no explicit rule; defaulting to simulate to prevent unintended side effects.`
+  };
 }

--- a/browser-extension-demo/src/core/simulation.ts
+++ b/browser-extension-demo/src/core/simulation.ts
@@ -1,0 +1,27 @@
+import type { PolicyDecision } from './policy';
+
+/**
+ * Applies simulation guard to a policy decision.
+ *
+ * When simulation mode is active, any 'allow' decision becomes 'simulate'.
+ * 'deny' and 'ask' decisions are never bypassed by simulation mode —
+ * the policy still governs; simulation only suppresses side effects of allowed actions.
+ */
+export function applySimulationGuard(
+  decision: PolicyDecision,
+  simulationMode: boolean
+): PolicyDecision {
+  if (simulationMode && decision === 'allow') return 'simulate';
+  return decision;
+}
+
+/**
+ * Returns true when the effective outcome is a simulated execution
+ * (simulation mode was active and the policy allowed the action).
+ */
+export function isSimulatedExecution(
+  decision: PolicyDecision,
+  simulationMode: boolean
+): boolean {
+  return simulationMode && decision === 'allow';
+}

--- a/browser-extension-demo/src/core/trace.ts
+++ b/browser-extension-demo/src/core/trace.ts
@@ -9,14 +9,22 @@ export interface DecisionTrace {
   trust_level: TrustLevel;
   taint: boolean;
   rule_hit: string;
+  rule_id: string;
+  rule_description: string;
+  explanation: string;
   decision: PolicyDecision;
+  simulated: boolean;      // true when simulation mode was active and converted 'allow' → 'simulate'
+  approval_id?: string;    // present when this trace entry was the result of an approved ApprovalRequest
   timestamp: string;
 }
 
-export function makeTrace(input: Omit<DecisionTrace, 'id' | 'timestamp'>): DecisionTrace {
+export function makeTrace(
+  input: Omit<DecisionTrace, 'id' | 'timestamp'> & { simulated?: boolean }
+): DecisionTrace {
   return {
     id: crypto.randomUUID(),
     timestamp: new Date().toISOString(),
+    simulated: false,
     ...input
   };
 }

--- a/browser-extension-demo/src/core/world_state.ts
+++ b/browser-extension-demo/src/core/world_state.ts
@@ -1,0 +1,34 @@
+import type { SourceType } from './semantic_event';
+import { POLICY_RULES, type PolicyRuleDescriptor } from './policy';
+
+export interface CapabilitySummary {
+  can_read: boolean;           // summarize_page, extract_links, extract_action_items
+  can_write_memory: boolean;   // save_memory: allowed under some conditions (ask required from untrusted)
+  can_export: boolean;         // export_summary: allowed under some conditions (blocked if tainted)
+}
+
+export interface WorldStateSnapshot {
+  trusted_sources: SourceType[];
+  untrusted_sources: SourceType[];
+  current_rules: PolicyRuleDescriptor[];
+  capability_summary: CapabilitySummary;
+}
+
+/**
+ * Derives a read-only world model snapshot from the static policy rules and
+ * the trust mapping defined in world.ts.
+ *
+ * Pure function — no Chrome API calls, no side effects.
+ */
+export function buildWorldStateSnapshot(): WorldStateSnapshot {
+  return {
+    trusted_sources: ['user_manual_note', 'internal_extension_ui'],
+    untrusted_sources: ['web_page'],
+    current_rules: POLICY_RULES,
+    capability_summary: {
+      can_read: true,           // summarize + extract always allowed
+      can_write_memory: true,   // allowed but requires approval from untrusted
+      can_export: true          // allowed but blocked when tainted, requires approval when untrusted
+    }
+  };
+}

--- a/browser-extension-demo/src/extension/background/index.ts
+++ b/browser-extension-demo/src/extension/background/index.ts
@@ -3,25 +3,40 @@ import { NaiveAgent } from '../../agents/naive_agent';
 import { MockAgentProvider } from '../../agents/agent_provider';
 import type { MemoryEntry } from '../../core/memory';
 import type { DecisionTrace } from '../../core/trace';
+import { makeTrace } from '../../core/trace';
 import type { IntentType } from '../../core/intent';
+import type { ApprovalRequest } from '../../core/approval';
+import { buildWorldStateSnapshot, type WorldStateSnapshot } from '../../core/world_state';
+import { enqueue, resolve, pendingOnly } from '../../state/approval_queue';
 
 type AgentMode = 'naive' | 'governed';
 
 interface AppState {
   mode: AgentMode;
+  simulation_mode: boolean;
   memory: MemoryEntry[];
   trace: DecisionTrace[];
+  approval_queue: ApprovalRequest[];
+  world_state: WorldStateSnapshot;
 }
 
 const provider = new MockAgentProvider();
 const naiveAgent = new NaiveAgent(provider);
 const governedAgent = new GovernedAgent(provider);
 
-const defaultState: AppState = { mode: 'governed', memory: [], trace: [] };
+const defaultState: AppState = {
+  mode: 'governed',
+  simulation_mode: false,
+  memory: [],
+  trace: [],
+  approval_queue: [],
+  world_state: buildWorldStateSnapshot()
+};
 
 async function getState(): Promise<AppState> {
   const result = await chrome.storage.local.get('appState');
-  return (result.appState as AppState | undefined) ?? defaultState;
+  // Merge with defaultState to handle Phase 1 stored data missing new fields
+  return { ...defaultState, ...(result.appState as Partial<AppState> | undefined) };
 }
 
 async function setState(state: AppState) {
@@ -55,6 +70,151 @@ chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
       return;
     }
 
+    if (message.type === 'SET_SIMULATION_MODE') {
+      state.simulation_mode = Boolean(message.enabled);
+      await setState(state);
+      sendResponse({ ok: true, state });
+      return;
+    }
+
+    if (message.type === 'GET_APPROVAL_QUEUE') {
+      sendResponse({ ok: true, queue: state.approval_queue });
+      return;
+    }
+
+    if (message.type === 'GET_WORLD_STATE') {
+      sendResponse({ ok: true, world_state: buildWorldStateSnapshot() });
+      return;
+    }
+
+    if (message.type === 'CLEAR_TRACE') {
+      state.trace = [];
+      await setState(state);
+      sendResponse({ ok: true, state });
+      return;
+    }
+
+    if (message.type === 'RESOLVE_APPROVAL') {
+      const { approval_id, status } = message as { approval_id: string; status: 'approved' | 'denied' };
+
+      // Locate the pending approval
+      const pending = pendingOnly(state.approval_queue);
+      const req = pending.find((r) => r.id === approval_id);
+      if (!req) {
+        sendResponse({ ok: false, error: 'Approval not found or already resolved' });
+        return;
+      }
+
+      if (status === 'denied') {
+        // Deny: update queue, append deny trace entry
+        state.approval_queue = resolve(state.approval_queue, approval_id, 'denied');
+        const denyTrace = makeTrace({
+          semantic_event_id: req.semantic_event_id,
+          intent_type: req.intent_type,
+          trust_level: req.trust_level,
+          taint: req.taint,
+          rule_hit: 'user_denied_approval',
+          rule_id: 'user_denied_approval',
+          rule_description: 'The user explicitly denied this approval request.',
+          explanation: `User denied the approval request for "${req.intent_type}" from "${req.source_url}".`,
+          decision: 'deny',
+          simulated: false,
+          approval_id
+        });
+        state.trace.unshift(denyTrace);
+        await setState(state);
+        sendResponse({ ok: true, state });
+        return;
+      }
+
+      // Approved: re-execute the original intent on the current page
+      let snapshot: ReturnType<typeof getSnapshot> extends Promise<infer T> ? T : never;
+      try {
+        snapshot = await getSnapshot();
+      } catch {
+        // Can't get snapshot — page may have navigated away; auto-deny
+        state.approval_queue = resolve(state.approval_queue, approval_id, 'denied');
+        const denyTrace = makeTrace({
+          semantic_event_id: req.semantic_event_id,
+          intent_type: req.intent_type,
+          trust_level: req.trust_level,
+          taint: req.taint,
+          rule_hit: 'user_denied_approval',
+          rule_id: 'user_denied_approval',
+          rule_description: 'Approval auto-denied: could not reach the original page.',
+          explanation: `Page snapshot unavailable when resolving approval for "${req.intent_type}" — approval auto-denied.`,
+          decision: 'deny',
+          simulated: false,
+          approval_id
+        });
+        state.trace.unshift(denyTrace);
+        await setState(state);
+        sendResponse({ ok: false, error: 'page_unavailable', state });
+        return;
+      }
+
+      // Verify the page URL hasn't changed
+      if (snapshot.url && snapshot.url !== req.source_url) {
+        state.approval_queue = resolve(state.approval_queue, approval_id, 'denied');
+        const denyTrace = makeTrace({
+          semantic_event_id: req.semantic_event_id,
+          intent_type: req.intent_type,
+          trust_level: req.trust_level,
+          taint: req.taint,
+          rule_hit: 'user_denied_approval',
+          rule_id: 'user_denied_approval',
+          rule_description: 'Approval auto-denied: the page navigated away before approval was granted.',
+          explanation: `Page changed from "${req.source_url}" to "${snapshot.url}" — approval was granted for a different page context.`,
+          decision: 'deny',
+          simulated: false,
+          approval_id
+        });
+        state.trace.unshift(denyTrace);
+        await setState(state);
+        sendResponse({ ok: false, error: 'page_changed', state });
+        return;
+      }
+
+      // Re-execute the approved intent directly (approval is the authority)
+      const event = await governedAgent.ingest(snapshot);
+      const links = (snapshot.links || []).map((l: { href: string }) => l.href);
+      const intent: IntentType = req._exec_intent;
+      let result: unknown = null;
+
+      if (intent === 'summarize_page') result = await governedAgent.summarize(event);
+      if (intent === 'extract_action_items') result = await governedAgent.extractActionItems(event);
+      if (intent === 'extract_links') result = await governedAgent.extractLinks(links);
+      if (intent === 'save_memory') {
+        const value = String(req._exec_payload?.value || event.visible_text.slice(0, 120));
+        const entry = governedAgent.createMemoryFromPage(value, event);
+        state.memory.unshift(entry);
+        result = entry;
+      }
+      if (intent === 'export_summary') {
+        result = { exported: true, note: 'Governed mode export executed after user approval.' };
+      }
+
+      // Mark approved and append allow trace with approval_id
+      state.approval_queue = resolve(state.approval_queue, approval_id, 'approved');
+      const allowTrace = makeTrace({
+        semantic_event_id: event.id,
+        intent_type: intent,
+        trust_level: event.trust_level,
+        taint: event.taint,
+        rule_hit: 'user_approved',
+        rule_id: 'user_approved',
+        rule_description: 'The user explicitly approved this action after reviewing the governance decision.',
+        explanation: `User approved "${intent}" from "${req.source_url}"; action executed.`,
+        decision: 'allow',
+        simulated: state.simulation_mode,
+        approval_id
+      });
+      state.trace.unshift(allowTrace);
+      await setState(state);
+      sendResponse({ ok: true, state, result });
+      return;
+    }
+
     if (message.type === 'RUN_ACTION') {
       const snapshot = await getSnapshot();
       const links = (snapshot.links || []).map((l: { href: string }) => l.href);
@@ -80,27 +240,51 @@ chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
         return;
       }
 
+      // Governed mode
       const event = await governedAgent.ingest(snapshot);
       const intent: IntentType = message.intent;
 
-      const governed = await governedAgent.runIntent(event, intent, async () => {
-        if (intent === 'summarize_page') return governedAgent.summarize(event);
-        if (intent === 'extract_action_items') return governedAgent.extractActionItems(event);
-        if (intent === 'extract_links') return governedAgent.extractLinks(links);
-        if (intent === 'save_memory') {
-          const entry = governedAgent.createMemoryFromPage(String(message.payload?.value || event.visible_text.slice(0, 120)), event);
-          state.memory.unshift(entry);
-          return entry;
-        }
-        if (intent === 'export_summary') {
-          return { exported: true, note: 'Governed mode only exports when policy allows.' };
-        }
-        return null;
-      });
+      const outcome = await governedAgent.runIntent(
+        event,
+        intent,
+        async () => {
+          if (intent === 'summarize_page') return governedAgent.summarize(event);
+          if (intent === 'extract_action_items') return governedAgent.extractActionItems(event);
+          if (intent === 'extract_links') return governedAgent.extractLinks(links);
+          if (intent === 'save_memory') {
+            const entry = governedAgent.createMemoryFromPage(
+              String(message.payload?.value || event.visible_text.slice(0, 120)),
+              event
+            );
+            state.memory.unshift(entry);
+            return entry;
+          }
+          if (intent === 'export_summary') {
+            return { exported: true, note: 'Governed mode only exports when policy allows.' };
+          }
+          return null;
+        },
+        state.simulation_mode
+      );
 
-      state.trace.unshift(governed.trace);
+      if (outcome.pending === true) {
+        // 'ask' decision — enqueue for approval
+        state.approval_queue = enqueue(state.approval_queue, outcome.approvalRequest);
+        state.trace.unshift(outcome.trace);
+        await setState(state);
+        sendResponse({
+          ok: true,
+          mode: state.mode,
+          event,
+          governed: { policy: outcome.policy, trace: outcome.trace, pending: true, approval_id: outcome.approvalRequest.id },
+          state
+        });
+        return;
+      }
+
+      state.trace.unshift(outcome.trace);
       await setState(state);
-      sendResponse({ ok: true, mode: state.mode, event, governed, state });
+      sendResponse({ ok: true, mode: state.mode, event, governed: outcome, state });
       return;
     }
 

--- a/browser-extension-demo/src/extension/popup/main.tsx
+++ b/browser-extension-demo/src/extension/popup/main.tsx
@@ -2,21 +2,40 @@ import React, { useEffect, useMemo, useState } from 'react';
 import { createRoot } from 'react-dom/client';
 import type { MemoryEntry } from '../../core/memory';
 import type { DecisionTrace } from '../../core/trace';
+import type { ApprovalRequest } from '../../core/approval';
+import type { WorldStateSnapshot } from '../../core/world_state';
+import { buildWorldStateSnapshot } from '../../core/world_state';
 import { detectScenario } from '../../demo/demo_page_detector';
 
 type AgentMode = 'naive' | 'governed';
 type IntentType = 'summarize_page' | 'extract_links' | 'extract_action_items' | 'save_memory' | 'export_summary';
-
 type TabName = 'overview' | 'memory' | 'trace' | 'demo';
+
+const DECISION_COLORS: Record<string, string> = {
+  allow: '#27ae60',
+  deny: '#c0392b',
+  ask: '#e67e22',
+  simulate: '#2980b9'
+};
 
 interface AppState {
   mode: AgentMode;
+  simulation_mode: boolean;
   memory: MemoryEntry[];
   trace: DecisionTrace[];
+  approval_queue: ApprovalRequest[];
+  world_state: WorldStateSnapshot;
 }
 
 function App() {
-  const [state, setState] = useState<AppState>({ mode: 'governed', memory: [], trace: [] });
+  const [state, setState] = useState<AppState>({
+    mode: 'governed',
+    simulation_mode: false,
+    memory: [],
+    trace: [],
+    approval_queue: [],
+    world_state: buildWorldStateSnapshot()
+  });
   const [tab, setTab] = useState<TabName>('overview');
   const [lastEvent, setLastEvent] = useState<any>(null);
   const [lastResult, setLastResult] = useState<any>(null);
@@ -48,13 +67,57 @@ function App() {
     });
   }
 
+  function resolveApproval(approval_id: string, status: 'approved' | 'denied') {
+    chrome.runtime.sendMessage({ type: 'RESOLVE_APPROVAL', approval_id, status }, (resp) => {
+      if (resp?.state) setState(resp.state);
+    });
+  }
+
+  const pendingApprovals = state.approval_queue?.filter((r) => r.status === 'pending') ?? [];
+
   return (
     <div style={{ fontFamily: 'Inter, sans-serif', width: 420, padding: 10 }}>
       <h2 style={{ margin: '0 0 8px' }}>Browser Agent Hypervisor Demo</h2>
       <div style={{ display: 'flex', gap: 8, marginBottom: 8 }}>
         <button onClick={() => setMode('naive')} style={{ background: state.mode === 'naive' ? '#ffddcc' : undefined }}>Naive</button>
         <button onClick={() => setMode('governed')} style={{ background: state.mode === 'governed' ? '#d9fdd3' : undefined }}>Governed</button>
+        {state.mode === 'governed' && (
+          <label style={{ fontSize: 12, display: 'flex', alignItems: 'center', gap: 4, marginLeft: 8, cursor: 'pointer' }}>
+            <input
+              type="checkbox"
+              checked={state.simulation_mode}
+              onChange={(e) => {
+                chrome.runtime.sendMessage({ type: 'SET_SIMULATION_MODE', enabled: e.target.checked }, (resp) => {
+                  if (resp?.ok) setState(resp.state);
+                });
+              }}
+            />
+            <span style={{ color: state.simulation_mode ? '#2980b9' : '#555', fontWeight: state.simulation_mode ? 700 : 400 }}>
+              Simulate
+            </span>
+          </label>
+        )}
       </div>
+
+      {pendingApprovals.length > 0 && (
+        <div style={{ background: '#fff8f0', border: '1px solid #e67e22', borderRadius: 4, padding: '6px 10px', marginBottom: 8 }}>
+          <strong style={{ fontSize: 12, color: '#e67e22' }}>
+            {pendingApprovals.length} approval{pendingApprovals.length > 1 ? 's' : ''} pending
+          </strong>
+          {pendingApprovals.map((req) => (
+            <div key={req.id} style={{ marginTop: 6 }}>
+              <div style={{ fontSize: 12 }}>
+                <code>{req.intent_type}</code> from <em>{req.source_url.slice(0, 40)}</em>
+              </div>
+              <div style={{ fontSize: 11, color: '#555', margin: '2px 0' }}>{req.reason}</div>
+              <div style={{ display: 'flex', gap: 6, marginTop: 4 }}>
+                <button onClick={() => resolveApproval(req.id, 'approved')} style={{ fontSize: 11, padding: '2px 10px', background: '#27ae60', color: '#fff', border: 'none', borderRadius: 3, cursor: 'pointer' }}>Approve</button>
+                <button onClick={() => resolveApproval(req.id, 'denied')} style={{ fontSize: 11, padding: '2px 10px', background: '#c0392b', color: '#fff', border: 'none', borderRadius: 3, cursor: 'pointer' }}>Deny</button>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
 
       <div style={{ display: 'flex', gap: 6, marginBottom: 8 }}>
         {(['overview', 'memory', 'trace', 'demo'] as TabName[]).map((name) => (
@@ -103,10 +166,16 @@ function App() {
       )}
 
       {tab === 'trace' && (
-        <ul>
+        <ul style={{ padding: 0, listStyle: 'none' }}>
           {state.trace.map((t) => (
-            <li key={t.id}>
-              <strong>{t.intent_type}</strong> → {t.decision} ({t.rule_hit})
+            <li key={t.id} style={{ borderBottom: '1px solid #f0f0f0', paddingBottom: 6, marginBottom: 6 }}>
+              <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+                <strong>{t.intent_type}</strong>
+                <span style={{ fontWeight: 700, color: DECISION_COLORS[t.decision] ?? '#555' }}>→ {t.decision}</span>
+                {t.simulated && <span style={{ fontSize: 10, background: '#2980b9', color: '#fff', padding: '0 4px', borderRadius: 4 }}>SIM</span>}
+                {t.approval_id && <span style={{ fontSize: 10, background: '#27ae60', color: '#fff', padding: '0 4px', borderRadius: 4 }}>APR</span>}
+              </div>
+              <small style={{ color: '#888' }}>{t.rule_description}</small>
               <br />
               <small>{t.timestamp} | taint={String(t.taint)} | trust={t.trust_level}</small>
             </li>

--- a/browser-extension-demo/src/extension/sidepanel/index.html
+++ b/browser-extension-demo/src/extension/sidepanel/index.html
@@ -7,6 +7,6 @@
   </head>
   <body>
     <div id="root"></div>
-    <script type="module" src="../popup/main.tsx"></script>
+    <script type="module" src="./main.tsx"></script>
   </body>
 </html>

--- a/browser-extension-demo/src/extension/sidepanel/main.tsx
+++ b/browser-extension-demo/src/extension/sidepanel/main.tsx
@@ -1,0 +1,100 @@
+import React, { useEffect, useState } from 'react';
+import { createRoot } from 'react-dom/client';
+import type { SemanticEvent } from '../../core/semantic_event';
+import type { DecisionTrace } from '../../core/trace';
+import type { ApprovalRequest } from '../../core/approval';
+import type { WorldStateSnapshot } from '../../core/world_state';
+import type { MemoryEntry } from '../../core/memory';
+import type { IntentType } from '../../core/intent';
+import { buildWorldStateSnapshot } from '../../core/world_state';
+import { SidePanelApp } from '../../ui/sidepanel/SidePanelApp';
+
+interface RemoteState {
+  mode: 'naive' | 'governed';
+  simulation_mode: boolean;
+  memory: MemoryEntry[];
+  trace: DecisionTrace[];
+  approval_queue: ApprovalRequest[];
+  world_state: WorldStateSnapshot;
+}
+
+const defaultState: RemoteState = {
+  mode: 'governed',
+  simulation_mode: false,
+  memory: [],
+  trace: [],
+  approval_queue: [],
+  world_state: buildWorldStateSnapshot()
+};
+
+function SidePanelRoot() {
+  const [remoteState, setRemoteState] = useState<RemoteState>(defaultState);
+  const [currentEvent, setCurrentEvent] = useState<SemanticEvent | null>(null);
+  const [lastTrace, setLastTrace] = useState<DecisionTrace | null>(null);
+
+  // Initial load + polling at 1500ms
+  useEffect(() => {
+    function fetchState() {
+      chrome.runtime.sendMessage({ type: 'GET_STATE' }, (resp) => {
+        if (chrome.runtime.lastError) return; // ignore if background is sleeping
+        if (resp?.ok) setRemoteState(resp.state as RemoteState);
+      });
+    }
+
+    fetchState();
+    const id = setInterval(fetchState, 1500);
+    return () => clearInterval(id);
+  }, []);
+
+  // Keep lastTrace in sync with the top of the trace array
+  useEffect(() => {
+    setLastTrace(remoteState.trace[0] ?? null);
+  }, [remoteState.trace]);
+
+  function handleSetMode(mode: 'naive' | 'governed') {
+    chrome.runtime.sendMessage({ type: 'SET_MODE', mode }, (resp) => {
+      if (resp?.ok) setRemoteState(resp.state as RemoteState);
+    });
+  }
+
+  function handleToggleSimulation(enabled: boolean) {
+    chrome.runtime.sendMessage({ type: 'SET_SIMULATION_MODE', enabled }, (resp) => {
+      if (resp?.ok) setRemoteState(resp.state as RemoteState);
+    });
+  }
+
+  function handleRunAction(intent: IntentType, payload: Record<string, unknown> = {}) {
+    chrome.runtime.sendMessage({ type: 'RUN_ACTION', intent, payload }, (resp) => {
+      if (!resp?.ok) return;
+      if (resp.event) setCurrentEvent(resp.event as SemanticEvent);
+      if (resp.state) setRemoteState(resp.state as RemoteState);
+      // Update lastTrace immediately from the response
+      if (resp.governed?.trace) setLastTrace(resp.governed.trace as DecisionTrace);
+    });
+  }
+
+  function handleResolveApproval(approval_id: string, status: 'approved' | 'denied') {
+    chrome.runtime.sendMessage({ type: 'RESOLVE_APPROVAL', approval_id, status }, (resp) => {
+      if (resp?.state) setRemoteState(resp.state as RemoteState);
+    });
+  }
+
+  return (
+    <SidePanelApp
+      mode={remoteState.mode}
+      simulationMode={remoteState.simulation_mode}
+      currentEvent={currentEvent}
+      lastTrace={lastTrace}
+      trace={remoteState.trace}
+      approvalQueue={remoteState.approval_queue}
+      memory={remoteState.memory}
+      worldState={remoteState.world_state}
+      onSetMode={handleSetMode}
+      onToggleSimulation={handleToggleSimulation}
+      onRunAction={handleRunAction}
+      onResolveApproval={handleResolveApproval}
+    />
+  );
+}
+
+createRoot(document.getElementById('root')!).render(<SidePanelRoot />);

--- a/browser-extension-demo/src/state/approval_queue.ts
+++ b/browser-extension-demo/src/state/approval_queue.ts
@@ -1,0 +1,33 @@
+import type { ApprovalRequest, ApprovalStatus } from '../core/approval';
+
+export type ApprovalQueue = ApprovalRequest[];
+
+/**
+ * Returns a new queue with the request appended.
+ */
+export function enqueue(queue: ApprovalQueue, req: ApprovalRequest): ApprovalQueue {
+  return [...queue, req];
+}
+
+/**
+ * Returns a new queue with the matching entry's status updated.
+ * Sets resolved_at to now when the new status is 'approved' or 'denied'.
+ */
+export function resolve(
+  queue: ApprovalQueue,
+  id: string,
+  status: Extract<ApprovalStatus, 'approved' | 'denied'>
+): ApprovalQueue {
+  return queue.map((req) =>
+    req.id === id
+      ? { ...req, status, resolved_at: new Date().toISOString() }
+      : req
+  );
+}
+
+/**
+ * Returns only the pending entries.
+ */
+export function pendingOnly(queue: ApprovalQueue): ApprovalRequest[] {
+  return queue.filter((req) => req.status === 'pending');
+}

--- a/browser-extension-demo/src/ui/sidepanel/ActionsSection.tsx
+++ b/browser-extension-demo/src/ui/sidepanel/ActionsSection.tsx
@@ -1,0 +1,86 @@
+import React, { useState } from 'react';
+import type { IntentType } from '../../core/intent';
+
+interface Props {
+  simulationMode: boolean;
+  onRunAction: (intent: IntentType, payload?: Record<string, unknown>) => void;
+  onToggleSimulation: (enabled: boolean) => void;
+}
+
+export function ActionsSection({ simulationMode, onRunAction, onToggleSimulation }: Props) {
+  const [note, setNote] = useState('');
+
+  return (
+    <section style={{ marginBottom: 12 }}>
+      <h3 style={sectionTitle}>Actions</h3>
+
+      <div style={{ marginBottom: 8, display: 'flex', alignItems: 'center', gap: 10 }}>
+        <label style={{ fontSize: 12, color: '#555', display: 'flex', alignItems: 'center', gap: 6, cursor: 'pointer' }}>
+          <input
+            type="checkbox"
+            checked={simulationMode}
+            onChange={(e) => onToggleSimulation(e.target.checked)}
+            style={{ cursor: 'pointer' }}
+          />
+          <span style={{ fontWeight: 600, color: simulationMode ? '#2980b9' : '#555' }}>
+            {simulationMode ? 'Simulate mode ON' : 'Execute mode'}
+          </span>
+        </label>
+        {simulationMode && (
+          <span style={{ fontSize: 10, color: '#2980b9', fontStyle: 'italic' }}>
+            No side effects will occur
+          </span>
+        )}
+      </div>
+
+      <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 5, marginBottom: 8 }}>
+        <ActionButton label="Summarize" onClick={() => onRunAction('summarize_page')} />
+        <ActionButton label="Extract links" onClick={() => onRunAction('extract_links')} />
+        <ActionButton label="Action items" onClick={() => onRunAction('extract_action_items')} />
+        <ActionButton label="Export summary" onClick={() => onRunAction('export_summary')} />
+      </div>
+
+      <div style={{ display: 'flex', gap: 6 }}>
+        <input
+          value={note}
+          onChange={(e) => setNote(e.target.value)}
+          placeholder="note to save…"
+          style={{ flex: 1, fontSize: 12, padding: '4px 8px', border: '1px solid #ddd', borderRadius: 4 }}
+        />
+        <button
+          onClick={() => { onRunAction('save_memory', { value: note }); setNote(''); }}
+          style={btnStyle}
+        >
+          Save note
+        </button>
+      </div>
+    </section>
+  );
+}
+
+function ActionButton({ label, onClick }: { label: string; onClick: () => void }) {
+  return (
+    <button onClick={onClick} style={btnStyle}>{label}</button>
+  );
+}
+
+const sectionTitle: React.CSSProperties = {
+  fontSize: 11,
+  fontWeight: 700,
+  textTransform: 'uppercase',
+  letterSpacing: 1,
+  color: '#666',
+  margin: '0 0 6px',
+  borderBottom: '1px solid #e5e5e5',
+  paddingBottom: 4
+};
+
+const btnStyle: React.CSSProperties = {
+  fontSize: 12,
+  padding: '5px 10px',
+  border: '1px solid #ddd',
+  borderRadius: 4,
+  cursor: 'pointer',
+  background: '#fff',
+  color: '#333'
+};

--- a/browser-extension-demo/src/ui/sidepanel/ApprovalQueueSection.tsx
+++ b/browser-extension-demo/src/ui/sidepanel/ApprovalQueueSection.tsx
@@ -1,0 +1,120 @@
+import React from 'react';
+import type { ApprovalRequest } from '../../core/approval';
+
+interface Props {
+  approvalQueue: ApprovalRequest[];
+  onResolve: (id: string, status: 'approved' | 'denied') => void;
+}
+
+export function ApprovalQueueSection({ approvalQueue, onResolve }: Props) {
+  const pending = approvalQueue.filter((r) => r.status === 'pending');
+  const resolved = approvalQueue.filter((r) => r.status !== 'pending');
+
+  return (
+    <section style={{ marginBottom: 12 }}>
+      <h3 style={sectionTitle}>
+        Approval Queue
+        {pending.length > 0 && (
+          <span style={{
+            marginLeft: 8,
+            background: '#e67e22',
+            color: '#fff',
+            fontSize: 10,
+            fontWeight: 700,
+            padding: '1px 6px',
+            borderRadius: 10
+          }}>{pending.length} pending</span>
+        )}
+      </h3>
+
+      {pending.length === 0 && resolved.length === 0 && (
+        <p style={{ fontSize: 12, color: '#aaa', margin: 0 }}>No pending approvals.</p>
+      )}
+
+      {pending.map((req) => (
+        <div key={req.id} style={{
+          border: '1px solid #e67e22',
+          borderRadius: 6,
+          padding: '8px 10px',
+          marginBottom: 8,
+          background: '#fffaf5'
+        }}>
+          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', marginBottom: 6 }}>
+            <code style={{ fontSize: 12, fontWeight: 700, color: '#c0392b' }}>{req.intent_type}</code>
+            <span style={{
+              fontSize: 10,
+              background: req.taint ? '#c0392b' : '#e67e22',
+              color: '#fff',
+              padding: '1px 5px',
+              borderRadius: 8
+            }}>
+              {req.taint ? 'tainted' : req.trust_level}
+            </span>
+          </div>
+          <p style={{ fontSize: 11, color: '#555', margin: '0 0 4px', lineHeight: 1.4 }}>{req.reason}</p>
+          <p style={{ fontSize: 11, color: '#888', margin: '0 0 8px' }}>
+            Source: {truncate(req.source_url, 50)}
+          </p>
+          <div style={{ display: 'flex', gap: 6 }}>
+            <button
+              onClick={() => onResolve(req.id, 'approved')}
+              style={{ ...btnBase, background: '#27ae60', color: '#fff', border: 'none' }}
+            >
+              Approve
+            </button>
+            <button
+              onClick={() => onResolve(req.id, 'denied')}
+              style={{ ...btnBase, background: '#c0392b', color: '#fff', border: 'none' }}
+            >
+              Deny
+            </button>
+          </div>
+        </div>
+      ))}
+
+      {resolved.length > 0 && (
+        <div style={{ marginTop: 4 }}>
+          <p style={{ fontSize: 11, color: '#aaa', margin: '0 0 4px' }}>Recently resolved</p>
+          {resolved.slice(0, 3).map((req) => (
+            <div key={req.id} style={{
+              fontSize: 11,
+              color: '#888',
+              padding: '3px 0',
+              borderBottom: '1px solid #f0f0f0',
+              display: 'flex',
+              justifyContent: 'space-between'
+            }}>
+              <span>{req.intent_type}</span>
+              <span style={{ color: req.status === 'approved' ? '#27ae60' : '#c0392b', fontWeight: 600 }}>
+                {req.status}
+              </span>
+            </div>
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}
+
+function truncate(s: string, n: number) {
+  return s.length > n ? s.slice(0, n) + '…' : s;
+}
+
+const sectionTitle: React.CSSProperties = {
+  fontSize: 11,
+  fontWeight: 700,
+  textTransform: 'uppercase',
+  letterSpacing: 1,
+  color: '#666',
+  margin: '0 0 6px',
+  borderBottom: '1px solid #e5e5e5',
+  paddingBottom: 4
+};
+
+const btnBase: React.CSSProperties = {
+  fontSize: 12,
+  padding: '4px 12px',
+  borderRadius: 4,
+  cursor: 'pointer',
+  fontWeight: 600
+};

--- a/browser-extension-demo/src/ui/sidepanel/CurrentPageSection.tsx
+++ b/browser-extension-demo/src/ui/sidepanel/CurrentPageSection.tsx
@@ -1,0 +1,103 @@
+import React from 'react';
+import type { SemanticEvent } from '../../core/semantic_event';
+
+const badge = (label: string, color: string) => (
+  <span style={{
+    display: 'inline-block',
+    padding: '1px 7px',
+    borderRadius: 10,
+    fontSize: 11,
+    fontWeight: 600,
+    background: color,
+    color: '#fff',
+    marginLeft: 6
+  }}>{label}</span>
+);
+
+interface Props {
+  event: SemanticEvent | null;
+}
+
+export function CurrentPageSection({ event }: Props) {
+  return (
+    <section style={{ marginBottom: 12 }}>
+      <h3 style={sectionTitle}>Current Page</h3>
+      <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: 12 }}>
+        <tbody>
+          <tr>
+            <td style={label}>URL</td>
+            <td style={value}>{event ? truncate(event.url, 48) : <Dash />}</td>
+          </tr>
+          <tr>
+            <td style={label}>Title</td>
+            <td style={value}>{event?.title ?? <Dash />}</td>
+          </tr>
+          <tr>
+            <td style={label}>Hidden content</td>
+            <td style={value}>
+              {event
+                ? event.hidden_content_detected
+                  ? badge('detected', '#c0392b')
+                  : badge('none', '#27ae60')
+                : <Dash />}
+            </td>
+          </tr>
+          <tr>
+            <td style={label}>Trust</td>
+            <td style={value}>
+              {event
+                ? event.trust_level === 'trusted'
+                  ? badge('trusted', '#27ae60')
+                  : badge('untrusted', '#e67e22')
+                : <Dash />}
+            </td>
+          </tr>
+          <tr>
+            <td style={label}>Taint</td>
+            <td style={value}>
+              {event
+                ? event.taint
+                  ? badge('tainted', '#c0392b')
+                  : badge('clean', '#27ae60')
+                : <Dash />}
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
+  );
+}
+
+function Dash() {
+  return <span style={{ color: '#aaa' }}>—</span>;
+}
+
+function truncate(s: string, n: number) {
+  return s.length > n ? s.slice(0, n) + '…' : s;
+}
+
+const sectionTitle: React.CSSProperties = {
+  fontSize: 11,
+  fontWeight: 700,
+  textTransform: 'uppercase',
+  letterSpacing: 1,
+  color: '#666',
+  margin: '0 0 6px',
+  borderBottom: '1px solid #e5e5e5',
+  paddingBottom: 4
+};
+
+const label: React.CSSProperties = {
+  color: '#888',
+  fontWeight: 600,
+  paddingRight: 8,
+  paddingBottom: 4,
+  width: 110,
+  verticalAlign: 'top'
+};
+
+const value: React.CSSProperties = {
+  color: '#222',
+  paddingBottom: 4,
+  wordBreak: 'break-all'
+};

--- a/browser-extension-demo/src/ui/sidepanel/DecisionSection.tsx
+++ b/browser-extension-demo/src/ui/sidepanel/DecisionSection.tsx
@@ -1,0 +1,126 @@
+import React from 'react';
+import type { DecisionTrace } from '../../core/trace';
+
+const DECISION_COLORS: Record<string, string> = {
+  allow: '#27ae60',
+  deny: '#c0392b',
+  ask: '#e67e22',
+  simulate: '#2980b9'
+};
+
+interface Props {
+  lastTrace: DecisionTrace | null;
+}
+
+export function DecisionSection({ lastTrace }: Props) {
+  if (!lastTrace) {
+    return (
+      <section style={{ marginBottom: 12 }}>
+        <h3 style={sectionTitle}>Decision</h3>
+        <p style={{ fontSize: 12, color: '#aaa', margin: 0 }}>No decision yet.</p>
+      </section>
+    );
+  }
+
+  const color = DECISION_COLORS[lastTrace.decision] ?? '#555';
+
+  return (
+    <section style={{ marginBottom: 12 }}>
+      <h3 style={sectionTitle}>Decision</h3>
+      <div style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 10,
+        marginBottom: 8
+      }}>
+        <span style={{
+          fontSize: 18,
+          fontWeight: 800,
+          color,
+          textTransform: 'uppercase',
+          letterSpacing: 1
+        }}>
+          {lastTrace.decision}
+        </span>
+        {lastTrace.simulated && (
+          <span style={{
+            fontSize: 10,
+            fontWeight: 700,
+            background: '#2980b9',
+            color: '#fff',
+            padding: '1px 6px',
+            borderRadius: 10,
+            letterSpacing: 0.5
+          }}>SIMULATED</span>
+        )}
+        {lastTrace.approval_id && (
+          <span style={{
+            fontSize: 10,
+            fontWeight: 700,
+            background: '#27ae60',
+            color: '#fff',
+            padding: '1px 6px',
+            borderRadius: 10
+          }}>APPROVED</span>
+        )}
+      </div>
+
+      <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: 12 }}>
+        <tbody>
+          <tr>
+            <td style={label}>Rule</td>
+            <td style={value}><code style={{ background: '#f0f0f0', padding: '1px 4px', borderRadius: 3, fontSize: 11 }}>{lastTrace.rule_id}</code></td>
+          </tr>
+          <tr>
+            <td style={label}>Description</td>
+            <td style={value}>{lastTrace.rule_description}</td>
+          </tr>
+          <tr>
+            <td style={label}>Explanation</td>
+            <td style={{ ...value, color: '#555', fontStyle: 'italic' }}>{lastTrace.explanation}</td>
+          </tr>
+        </tbody>
+      </table>
+
+      {lastTrace.decision === 'ask' && (
+        <div style={{
+          marginTop: 8,
+          padding: '6px 10px',
+          background: '#fff8f0',
+          border: '1px solid #e67e22',
+          borderRadius: 4,
+          fontSize: 12,
+          color: '#e67e22'
+        }}>
+          Action paused — see Approval Queue below.
+        </div>
+      )}
+    </section>
+  );
+}
+
+const sectionTitle: React.CSSProperties = {
+  fontSize: 11,
+  fontWeight: 700,
+  textTransform: 'uppercase',
+  letterSpacing: 1,
+  color: '#666',
+  margin: '0 0 6px',
+  borderBottom: '1px solid #e5e5e5',
+  paddingBottom: 4
+};
+
+const label: React.CSSProperties = {
+  color: '#888',
+  fontWeight: 600,
+  paddingRight: 8,
+  paddingBottom: 6,
+  width: 90,
+  verticalAlign: 'top'
+};
+
+const value: React.CSSProperties = {
+  color: '#222',
+  paddingBottom: 6,
+  lineHeight: 1.4
+};

--- a/browser-extension-demo/src/ui/sidepanel/LastIntentSection.tsx
+++ b/browser-extension-demo/src/ui/sidepanel/LastIntentSection.tsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import type { IntentProposal } from '../../core/intent';
+
+interface Props {
+  lastIntent: IntentProposal | null;
+}
+
+export function LastIntentSection({ lastIntent }: Props) {
+  return (
+    <section style={{ marginBottom: 12 }}>
+      <h3 style={sectionTitle}>Last Intent</h3>
+      {lastIntent ? (
+        <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: 12 }}>
+          <tbody>
+            <tr>
+              <td style={label}>Type</td>
+              <td style={value}><code style={{ background: '#f0f0f0', padding: '1px 4px', borderRadius: 3 }}>{lastIntent.intent_type}</code></td>
+            </tr>
+            <tr>
+              <td style={label}>Reason</td>
+              <td style={value}>{lastIntent.reason || '—'}</td>
+            </tr>
+            {lastIntent.payload && Object.keys(lastIntent.payload).length > 0 && (
+              <tr>
+                <td style={label}>Payload keys</td>
+                <td style={value}>{Object.keys(lastIntent.payload).join(', ')}</td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      ) : (
+        <p style={{ fontSize: 12, color: '#aaa', margin: 0 }}>No intent recorded yet. Run an action to begin.</p>
+      )}
+    </section>
+  );
+}
+
+const sectionTitle: React.CSSProperties = {
+  fontSize: 11,
+  fontWeight: 700,
+  textTransform: 'uppercase',
+  letterSpacing: 1,
+  color: '#666',
+  margin: '0 0 6px',
+  borderBottom: '1px solid #e5e5e5',
+  paddingBottom: 4
+};
+
+const label: React.CSSProperties = {
+  color: '#888',
+  fontWeight: 600,
+  paddingRight: 8,
+  paddingBottom: 4,
+  width: 110,
+  verticalAlign: 'top'
+};
+
+const value: React.CSSProperties = {
+  color: '#222',
+  paddingBottom: 4,
+  wordBreak: 'break-all'
+};

--- a/browser-extension-demo/src/ui/sidepanel/SidePanelApp.tsx
+++ b/browser-extension-demo/src/ui/sidepanel/SidePanelApp.tsx
@@ -1,0 +1,134 @@
+import React from 'react';
+import type { SemanticEvent } from '../../core/semantic_event';
+import type { DecisionTrace } from '../../core/trace';
+import type { ApprovalRequest } from '../../core/approval';
+import type { WorldStateSnapshot } from '../../core/world_state';
+import type { MemoryEntry } from '../../core/memory';
+import type { IntentType } from '../../core/intent';
+
+import { CurrentPageSection } from './CurrentPageSection';
+import { DecisionSection } from './DecisionSection';
+import { ActionsSection } from './ActionsSection';
+import { ApprovalQueueSection } from './ApprovalQueueSection';
+import { TraceSection } from './TraceSection';
+import { WorldStateSection } from './WorldStateSection';
+
+interface Props {
+  mode: 'naive' | 'governed';
+  simulationMode: boolean;
+  currentEvent: SemanticEvent | null;
+  lastTrace: DecisionTrace | null;
+  trace: DecisionTrace[];
+  approvalQueue: ApprovalRequest[];
+  memory: MemoryEntry[];
+  worldState: WorldStateSnapshot;
+  onSetMode: (mode: 'naive' | 'governed') => void;
+  onToggleSimulation: (enabled: boolean) => void;
+  onRunAction: (intent: IntentType, payload?: Record<string, unknown>) => void;
+  onResolveApproval: (id: string, status: 'approved' | 'denied') => void;
+}
+
+export function SidePanelApp({
+  mode,
+  simulationMode,
+  currentEvent,
+  lastTrace,
+  trace,
+  approvalQueue,
+  worldState,
+  onSetMode,
+  onToggleSimulation,
+  onRunAction,
+  onResolveApproval
+}: Props) {
+  const pendingCount = approvalQueue.filter((r) => r.status === 'pending').length;
+
+  return (
+    <div style={{ fontFamily: 'Inter, system-ui, sans-serif', padding: '10px 14px', fontSize: 13, color: '#222' }}>
+      {/* Header */}
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 10 }}>
+        <div>
+          <h2 style={{ margin: 0, fontSize: 14, fontWeight: 700 }}>Agent Hypervisor</h2>
+          <p style={{ margin: 0, fontSize: 10, color: '#888' }}>Deterministic Governance Layer</p>
+        </div>
+        <div style={{ display: 'flex', gap: 4 }}>
+          <button
+            onClick={() => onSetMode('naive')}
+            style={{
+              fontSize: 11,
+              padding: '3px 10px',
+              borderRadius: 4,
+              border: '1px solid #ddd',
+              cursor: 'pointer',
+              background: mode === 'naive' ? '#ffddcc' : '#fff',
+              fontWeight: mode === 'naive' ? 700 : 400
+            }}
+          >
+            Naive
+          </button>
+          <button
+            onClick={() => onSetMode('governed')}
+            style={{
+              fontSize: 11,
+              padding: '3px 10px',
+              borderRadius: 4,
+              border: '1px solid #ddd',
+              cursor: 'pointer',
+              background: mode === 'governed' ? '#d9fdd3' : '#fff',
+              fontWeight: mode === 'governed' ? 700 : 400
+            }}
+          >
+            Governed
+          </button>
+        </div>
+      </div>
+
+      {mode === 'naive' && (
+        <div style={{
+          background: '#fff8e1',
+          border: '1px solid #f0c040',
+          borderRadius: 4,
+          padding: '6px 10px',
+          fontSize: 11,
+          color: '#7d5a00',
+          marginBottom: 12
+        }}>
+          Naive mode: no deterministic gating, no approvals, no trace.
+        </div>
+      )}
+
+      <CurrentPageSection event={currentEvent} />
+
+      <Divider />
+
+      <DecisionSection lastTrace={lastTrace} />
+
+      <Divider />
+
+      <ActionsSection
+        simulationMode={simulationMode}
+        onRunAction={onRunAction}
+        onToggleSimulation={onToggleSimulation}
+      />
+
+      <Divider />
+
+      <ApprovalQueueSection
+        approvalQueue={approvalQueue}
+        onResolve={onResolveApproval}
+      />
+
+      {pendingCount > 0 && <Divider />}
+
+      <TraceSection trace={trace} />
+
+      <Divider />
+
+      <WorldStateSection worldState={worldState} />
+    </div>
+  );
+}
+
+function Divider() {
+  return <hr style={{ border: 'none', borderTop: '1px solid #efefef', margin: '8px 0' }} />;
+}

--- a/browser-extension-demo/src/ui/sidepanel/TraceSection.tsx
+++ b/browser-extension-demo/src/ui/sidepanel/TraceSection.tsx
@@ -1,0 +1,126 @@
+import React, { useState } from 'react';
+import type { DecisionTrace } from '../../core/trace';
+import type { PolicyDecision } from '../../core/policy';
+import { TraceDetail } from '../trace_viewer/TraceDetail';
+
+const DECISION_COLORS: Record<string, string> = {
+  allow: '#27ae60',
+  deny: '#c0392b',
+  ask: '#e67e22',
+  simulate: '#2980b9'
+};
+
+const ALL_DECISIONS: Array<PolicyDecision | 'all'> = ['all', 'allow', 'deny', 'ask', 'simulate'];
+
+interface Props {
+  trace: DecisionTrace[];
+}
+
+export function TraceSection({ trace }: Props) {
+  const [filter, setFilter] = useState<PolicyDecision | 'all'>('all');
+  const [expanded, setExpanded] = useState<string | null>(null);
+
+  const displayed = (
+    filter === 'all' ? trace : trace.filter((t) => t.decision === filter)
+  ).slice(0, 20);
+
+  return (
+    <section style={{ marginBottom: 12 }}>
+      <h3 style={sectionTitle}>
+        Trace
+        <span style={{ fontSize: 10, fontWeight: 400, color: '#aaa', marginLeft: 8, textTransform: 'none', letterSpacing: 0 }}>
+          last {trace.length} decisions
+        </span>
+      </h3>
+
+      <div style={{ display: 'flex', gap: 4, marginBottom: 8, flexWrap: 'wrap' }}>
+        {ALL_DECISIONS.map((d) => (
+          <button
+            key={d}
+            onClick={() => setFilter(d)}
+            style={{
+              fontSize: 10,
+              padding: '2px 8px',
+              borderRadius: 10,
+              border: filter === d ? '2px solid #555' : '1px solid #ddd',
+              background: filter === d ? '#555' : '#fff',
+              color: filter === d ? '#fff' : '#555',
+              cursor: 'pointer',
+              fontWeight: filter === d ? 700 : 400
+            }}
+          >
+            {d}
+          </button>
+        ))}
+      </div>
+
+      {displayed.length === 0 && (
+        <p style={{ fontSize: 12, color: '#aaa', margin: 0 }}>No trace entries match this filter.</p>
+      )}
+
+      {displayed.map((t) => (
+        <div key={t.id} style={{ marginBottom: 4 }}>
+          <div
+            onClick={() => setExpanded(expanded === t.id ? null : t.id)}
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 8,
+              padding: '5px 8px',
+              borderRadius: 4,
+              cursor: 'pointer',
+              background: expanded === t.id ? '#f0f0f0' : '#fafafa',
+              border: '1px solid #e5e5e5',
+              fontSize: 12
+            }}
+          >
+            <span style={{
+              fontWeight: 700,
+              color: DECISION_COLORS[t.decision] ?? '#555',
+              textTransform: 'uppercase',
+              fontSize: 10,
+              minWidth: 52
+            }}>
+              {t.decision}
+            </span>
+            <code style={{ fontSize: 11, color: '#333', flex: 1 }}>{t.intent_type}</code>
+            {t.simulated && (
+              <span style={{ fontSize: 9, background: '#2980b9', color: '#fff', padding: '0 4px', borderRadius: 6, fontWeight: 700 }}>SIM</span>
+            )}
+            {t.approval_id && (
+              <span style={{ fontSize: 9, background: '#27ae60', color: '#fff', padding: '0 4px', borderRadius: 6, fontWeight: 700 }}>APR</span>
+            )}
+            <span style={{ fontSize: 10, color: '#aaa', marginLeft: 'auto' }}>
+              {formatTime(t.timestamp)}
+            </span>
+          </div>
+          {expanded === t.id && (
+            <div style={{ marginTop: 2, marginLeft: 4 }}>
+              <TraceDetail trace={t} />
+            </div>
+          )}
+        </div>
+      ))}
+    </section>
+  );
+}
+
+function formatTime(iso: string) {
+  try {
+    const d = new Date(iso);
+    return d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' });
+  } catch {
+    return iso;
+  }
+}
+
+const sectionTitle: React.CSSProperties = {
+  fontSize: 11,
+  fontWeight: 700,
+  textTransform: 'uppercase',
+  letterSpacing: 1,
+  color: '#666',
+  margin: '0 0 6px',
+  borderBottom: '1px solid #e5e5e5',
+  paddingBottom: 4
+};

--- a/browser-extension-demo/src/ui/sidepanel/WorldStateSection.tsx
+++ b/browser-extension-demo/src/ui/sidepanel/WorldStateSection.tsx
@@ -1,0 +1,122 @@
+import React from 'react';
+import type { WorldStateSnapshot } from '../../core/world_state';
+
+const DECISION_COLORS: Record<string, string> = {
+  allow: '#27ae60',
+  deny: '#c0392b',
+  ask: '#e67e22',
+  simulate: '#2980b9'
+};
+
+interface Props {
+  worldState: WorldStateSnapshot;
+}
+
+export function WorldStateSection({ worldState }: Props) {
+  return (
+    <section style={{ marginBottom: 12 }}>
+      <h3 style={sectionTitle}>World State</h3>
+      <p style={{ fontSize: 11, color: '#888', margin: '0 0 8px', fontStyle: 'italic' }}>
+        Read-only — derived from compiled policy. Not editable at runtime.
+      </p>
+
+      <div style={{ marginBottom: 8 }}>
+        <p style={{ fontSize: 11, fontWeight: 700, color: '#555', margin: '0 0 4px' }}>Source Trust</p>
+        <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap' }}>
+          {worldState.trusted_sources.map((s) => (
+            <span key={s} style={trustBadge('#27ae60')}>{s}: trusted</span>
+          ))}
+          {worldState.untrusted_sources.map((s) => (
+            <span key={s} style={trustBadge('#e67e22')}>{s}: untrusted</span>
+          ))}
+        </div>
+      </div>
+
+      <div style={{ marginBottom: 8 }}>
+        <p style={{ fontSize: 11, fontWeight: 700, color: '#555', margin: '0 0 4px' }}>Capability Summary</p>
+        <table style={{ fontSize: 11, width: '100%', borderCollapse: 'collapse' }}>
+          <tbody>
+            <CapRow label="Read (summarize, extract)" ok={worldState.capability_summary.can_read} />
+            <CapRow label="Write memory (may require approval)" ok={worldState.capability_summary.can_write_memory} />
+            <CapRow label="Export (may require approval / blocked if tainted)" ok={worldState.capability_summary.can_export} />
+          </tbody>
+        </table>
+      </div>
+
+      <div>
+        <p style={{ fontSize: 11, fontWeight: 700, color: '#555', margin: '0 0 4px' }}>Active Rules</p>
+        <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: 11 }}>
+          <thead>
+            <tr>
+              <th style={th}>Rule</th>
+              <th style={th}>Decision</th>
+            </tr>
+          </thead>
+          <tbody>
+            {worldState.current_rules.map((rule) => (
+              <tr key={rule.rule_id}>
+                <td style={td}>
+                  <div><code style={{ fontSize: 10 }}>{rule.rule_id}</code></div>
+                  <div style={{ color: '#777', marginTop: 2, lineHeight: 1.3 }}>{rule.rule_description}</div>
+                </td>
+                <td style={{ ...td, fontWeight: 700, color: DECISION_COLORS[rule.decision] ?? '#555', textTransform: 'uppercase', verticalAlign: 'top', width: 56 }}>
+                  {rule.decision}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </section>
+  );
+}
+
+function CapRow({ label, ok }: { label: string; ok: boolean }) {
+  return (
+    <tr>
+      <td style={{ paddingBottom: 3, color: '#555' }}>{label}</td>
+      <td style={{ paddingBottom: 3, color: ok ? '#27ae60' : '#c0392b', fontWeight: 700, width: 40 }}>
+        {ok ? '✓' : '✗'}
+      </td>
+    </tr>
+  );
+}
+
+function trustBadge(color: string): React.CSSProperties {
+  return {
+    display: 'inline-block',
+    padding: '2px 8px',
+    borderRadius: 10,
+    fontSize: 10,
+    fontWeight: 600,
+    background: color,
+    color: '#fff'
+  };
+}
+
+const sectionTitle: React.CSSProperties = {
+  fontSize: 11,
+  fontWeight: 700,
+  textTransform: 'uppercase',
+  letterSpacing: 1,
+  color: '#666',
+  margin: '0 0 6px',
+  borderBottom: '1px solid #e5e5e5',
+  paddingBottom: 4
+};
+
+const th: React.CSSProperties = {
+  textAlign: 'left',
+  color: '#888',
+  fontWeight: 600,
+  paddingBottom: 4,
+  borderBottom: '1px solid #eee',
+  fontSize: 10
+};
+
+const td: React.CSSProperties = {
+  paddingTop: 6,
+  paddingBottom: 6,
+  borderBottom: '1px solid #f5f5f5',
+  verticalAlign: 'middle'
+};

--- a/browser-extension-demo/src/ui/trace_viewer/TraceDetail.tsx
+++ b/browser-extension-demo/src/ui/trace_viewer/TraceDetail.tsx
@@ -1,0 +1,72 @@
+import React from 'react';
+import type { DecisionTrace } from '../../core/trace';
+
+const DECISION_COLORS: Record<string, string> = {
+  allow: '#27ae60',
+  deny: '#c0392b',
+  ask: '#e67e22',
+  simulate: '#2980b9'
+};
+
+interface Props {
+  trace: DecisionTrace;
+}
+
+export function TraceDetail({ trace }: Props) {
+  const color = DECISION_COLORS[trace.decision] ?? '#555';
+
+  return (
+    <div style={{
+      background: '#f9f9f9',
+      border: '1px solid #ddd',
+      borderRadius: 6,
+      padding: '10px 12px',
+      fontSize: 12
+    }}>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 8 }}>
+        <span style={{ fontSize: 14, fontWeight: 800, color, textTransform: 'uppercase' }}>
+          {trace.decision}
+        </span>
+        <code style={{ fontSize: 11, color: '#555' }}>{trace.intent_type}</code>
+        {trace.simulated && (
+          <span style={{ fontSize: 10, background: '#2980b9', color: '#fff', padding: '1px 5px', borderRadius: 8, fontWeight: 700 }}>
+            SIMULATED
+          </span>
+        )}
+        {trace.approval_id && (
+          <span style={{ fontSize: 10, background: '#27ae60', color: '#fff', padding: '1px 5px', borderRadius: 8, fontWeight: 700 }}>
+            APPROVED
+          </span>
+        )}
+      </div>
+
+      <table style={{ width: '100%', borderCollapse: 'collapse' }}>
+        <tbody>
+          <Row label="Rule ID" value={<code style={{ fontSize: 11 }}>{trace.rule_id}</code>} />
+          <Row label="Rule" value={trace.rule_description} />
+          <Row label="Explanation" value={<em style={{ color: '#555' }}>{trace.explanation}</em>} />
+          <Row label="Trust" value={trace.trust_level} />
+          <Row label="Taint" value={String(trace.taint)} />
+          <Row label="Timestamp" value={new Date(trace.timestamp).toLocaleString()} />
+          <Row label="Event ID" value={<code style={{ fontSize: 10 }}>{trace.semantic_event_id.slice(0, 16)}…</code>} />
+          {trace.approval_id && (
+            <Row label="Approval ID" value={<code style={{ fontSize: 10 }}>{trace.approval_id.slice(0, 16)}…</code>} />
+          )}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function Row({ label, value }: { label: string; value: React.ReactNode }) {
+  return (
+    <tr>
+      <td style={{ color: '#888', fontWeight: 600, paddingRight: 8, paddingBottom: 4, width: 90, verticalAlign: 'top' }}>
+        {label}
+      </td>
+      <td style={{ color: '#222', paddingBottom: 4, lineHeight: 1.4 }}>
+        {value}
+      </td>
+    </tr>
+  );
+}


### PR DESCRIPTION
## Summary

This PR implements Phase 2 of the browser agent hypervisor demo, transforming the MVP into a system that makes governance decisions explicit and visible. The core addition is a structured approval flow where `decision: 'ask'` surfaces a real UI, the agent waits, and the user decides. Additionally, a persistent side panel provides live visibility into the governance state, simulation mode allows risk-free testing, and the trace is enriched with rule descriptions and explanations.

## Key Changes

### New Core Models
- **`src/core/approval.ts`**: `ApprovalRequest` interface and `createApprovalRequest()` factory for modeling pending user decisions
- **`src/core/world_state.ts`**: `WorldStateSnapshot` and `buildWorldStateSnapshot()` for read-only visibility into active rules and source trust assignments
- **`src/core/simulation.ts`**: `applySimulationGuard()` pure function that converts `allow` → `simulate` when simulation mode is active
- **`src/state/approval_queue.ts`**: Pure queue operations (`enqueue`, `resolve`, `pendingOnly`) for managing approval lifecycle

### Enriched Policy & Trace
- **`src/core/policy.ts`**: Added `PolicyRuleDescriptor` table (`POLICY_RULES`) with static rule definitions; enriched `PolicyResult` with `rule_id`, `rule_description`, and `explanation`
- **`src/core/trace.ts`**: Extended `DecisionTrace` with `rule_id`, `rule_description`, `explanation`, `simulated`, and `approval_id` fields

### Agent & Background Updates
- **`src/agents/governed_agent.ts`**: 
  - Returns `GovernedPendingResult` when policy decision is `'ask'` (does not execute)
  - Applies simulation guard to convert `allow` → `simulate` when simulation mode is active
  - Stores re-execution context (`_exec_intent`, `_exec_payload`) on approval requests
- **`src/extension/background/index.ts`**:
  - Extended `AppState` with `simulation_mode`, `approval_queue`, and `world_state`
  - Added message handlers: `SET_SIMULATION_MODE`, `GET_APPROVAL_QUEUE`, `GET_WORLD_STATE`, `CLEAR_TRACE`, `RESOLVE_APPROVAL`
  - Implements full approval lifecycle: enqueue on `'ask'`, re-execute on approval, auto-deny on page navigation or unavailability
  - Merges stored state with defaults to handle Phase 1 data missing new fields

### Side Panel UI
- **`src/extension/sidepanel/main.tsx`**: New standalone React app root with 1500ms polling of background state
- **`src/ui/sidepanel/`**: Complete side panel layout with sections:
  - `CurrentPageSection.tsx`: URL, title, hidden content, trust, and taint badges
  - `DecisionSection.tsx`: Decision badge, rule, description, and explanation
  - `ActionsSection.tsx`: Action buttons and simulation mode toggle
  - `ApprovalQueueSection.tsx`: Pending approvals with Approve/Deny buttons
  - `TraceSection.tsx`: Filterable trace log with clickable entries
  - `WorldStateSection.tsx`: Read-only world model display
  - `LastIntentSection.tsx`: Last intent type and payload
  - `SidePanelApp.tsx`: Top-level layout component
- **`src/ui/trace_viewer/TraceDetail.tsx`**: Expanded detail view for individual trace entries

### Popup Updates
- **`src/extension/popup/main.tsx`**: Updated to handle new state fields and approval UI; added simulated badge in trace display

### Documentation
- **`docs/phase2.md`**: Overview of Phase 2 features, file map, and demo flows
- **`docs/approval_flow.md`**: Detailed approval lifecycle, status transitions, and edge case handling
- **`docs/trace_model.md`**: Complete `DecisionTrace` field reference and rule table

### Configuration
- **`src/extension/sidepanel/index.html`**: Fixed script src to point to `./

https://claude.ai/code/session_018PdfM47iW2fWwSa8wdRedg