### PR TITLE
fix(phase-3): wire live CompiledWorld into WorldState and TraceDetail

### DIFF
--- a/browser-extension-demo/docs/exported-comparison-format.md
+++ b/browser-extension-demo/docs/exported-comparison-format.md
@@ -1,0 +1,179 @@
+# Exported Comparison Format
+
+Documents the two export formats produced by the Comparative World Playground:
+Markdown and JSON.
+
+Both formats are generated deterministically from the comparison result — no
+AI-generated text, no approximations.
+
+---
+
+## Markdown Export
+
+Click **Export MD** in the Compare view to copy a Markdown report to clipboard.
+
+### Structure
+
+```markdown
+# World Comparison: <world_a_id> vs <world_b_id>
+
+**Scenario:** <scenario_label>
+
+## Observations
+- <neutral observation 1>
+- <neutral observation 2>
+...
+
+## Side-by-Side
+
+| Metric | <world_a_id> v<version> | <world_b_id> v<version> |
+|--------|------------------------|------------------------|
+| Allowed actions | N | N |
+| Requires approval | N | N |
+| Denied | N | N |
+| Simulated | N | N |
+| Deny/Ask rules | N | N |
+```
+
+### Example
+
+```markdown
+# World Comparison: strict-world vs balanced-world
+
+**Scenario:** Memory poisoning attempt
+
+## Observations
+- strict-world is more restrictive — denies more actions (2 vs 0).
+- balanced-world generates more approval requests (1 vs 0).
+- strict-world has more governance rules (3 deny/ask rules vs 2).
+
+## Side-by-Side
+
+| Metric | strict-world v2 | balanced-world v1 |
+|--------|-----------------|-------------------|
+| Allowed actions | 3 | 3 |
+| Requires approval | 0 | 1 |
+| Denied | 2 | 0 |
+| Simulated | 0 | 0 |
+| Deny/Ask rules | 3 | 2 |
+```
+
+### Use cases
+- Talks and presentations (paste into speaker notes)
+- GitHub issues and design reviews
+- Documentation PRs
+- Architecture decision records
+
+---
+
+## JSON Export
+
+Click **Copy JSON** in the Compare view to copy a structured JSON report.
+
+### Structure
+
+```json
+{
+  "scenario": "<scenario_label>",
+  "scenario_input": {
+    "source_type": "web_page",
+    "hidden_content_detected": false,
+    "taint": false,
+    "action": "save_memory",
+    "label": "Untrusted memory write"
+  },
+  "world_a": {
+    "id": "<world_id>",
+    "version": 2,
+    "decision": "deny",
+    "rule_id": "<rule_id>",
+    "explanation": "<policy explanation string>",
+    "effective_trust": "untrusted",
+    "effective_taint": false,
+    "metrics": {
+      "allowed": 3,
+      "requires_approval": 0,
+      "denied": 2,
+      "simulated": 0,
+      "read_only_actions": 3,
+      "external_side_effect_actions": 1,
+      "deny_ask_rules": 3
+    }
+  },
+  "world_b": {
+    "id": "<world_id>",
+    "version": 1,
+    "decision": "ask",
+    "rule_id": "<rule_id>",
+    "explanation": "<policy explanation string>",
+    "effective_trust": "untrusted",
+    "effective_taint": false,
+    "metrics": {
+      "allowed": 3,
+      "requires_approval": 1,
+      "denied": 0,
+      "simulated": 0,
+      "read_only_actions": 3,
+      "external_side_effect_actions": 1,
+      "deny_ask_rules": 2
+    }
+  },
+  "diverges": true,
+  "divergence_points": [
+    {
+      "stage": "decision",
+      "world_a_state": "deny (via deny_untrusted_writes)",
+      "world_b_state": "ask (via ask_before_memory_write_from_untrusted)",
+      "cause": "World A matched rule \"deny_untrusted_writes\" (→deny); World B matched rule \"ask_before_memory_write_from_untrusted\" (→ask). The two worlds have different rule sets for this condition."
+    }
+  ],
+  "observations": [
+    "strict-world is more restrictive — denies more actions (2 vs 0).",
+    "balanced-world generates more approval requests (1 vs 0).",
+    "strict-world has more governance rules (3 deny/ask rules vs 2)."
+  ]
+}
+```
+
+### Top-level fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `scenario` | string | Human-readable scenario label |
+| `scenario_input` | object | Full `ScenarioInput` that was evaluated |
+| `world_a` | object | Evaluation result for World A |
+| `world_b` | object | Evaluation result for World B |
+| `diverges` | boolean | Whether the two worlds produced different outcomes |
+| `divergence_points` | array | Structural divergence details (see `world-comparison-model.md`) |
+| `observations` | array | Neutral plain-language observations |
+
+### `world_a` / `world_b` fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | string | `world_id` from the manifest |
+| `version` | number | Manifest version number |
+| `decision` | string | `allow`, `deny`, `ask`, or `simulate` |
+| `rule_id` | string | ID of the rule that fired |
+| `explanation` | string | Human-readable policy explanation |
+| `effective_trust` | string | `trusted` or `untrusted` for this source |
+| `effective_taint` | boolean | Whether taint was active after propagation |
+| `metrics` | object | Action surface counts (see below) |
+
+### `metrics` fields
+
+| Field | Description |
+|-------|-------------|
+| `allowed` | Number of actions allowed without approval |
+| `requires_approval` | Number of actions that require user approval |
+| `denied` | Number of actions denied |
+| `simulated` | Number of actions simulated (not executed) |
+| `read_only_actions` | Actions with `effect: read_only` in this world |
+| `external_side_effect_actions` | Actions with `effect: external_side_effect` |
+| `deny_ask_rules` | Total deny + ask rules in this world's rule index |
+
+### Use cases
+- Programmatic analysis across many world pairs
+- Automated testing of world policy expectations
+- Archiving comparison results alongside world manifests
+- Loading into notebooks or scripts for further analysis

--- a/browser-extension-demo/docs/scenario-replay.md
+++ b/browser-extension-demo/docs/scenario-replay.md
@@ -1,0 +1,129 @@
+# Scenario Replay
+
+Explains the scenario format, determinism guarantees, and how the Comparative
+World Playground replays the same scenario across two different worlds.
+
+---
+
+## What Is a Scenario?
+
+A scenario is a fully deterministic description of one agent evaluation context.
+It captures everything the policy engine needs to make a decision:
+
+```typescript
+interface ScenarioInput {
+  source_type: string;            // where the content came from
+  hidden_content_detected: boolean; // whether the page had hidden DOM signals
+  taint: boolean;                 // explicit taint override
+  action: IntentType;             // what the agent is trying to do
+  label?: string;                 // display label (does not affect evaluation)
+}
+```
+
+No page URL, no actual browser state, no model output — only the fields that
+deterministically affect the policy decision.
+
+---
+
+## Determinism Guarantee
+
+For a fixed `ScenarioInput` and a fixed `CompiledWorld`:
+
+- `compareWorlds(scenario, worldA, worldB)` always produces the same result
+- No network calls, no randomness, no side effects
+- The same scenario can be run seconds or days later and produce identical output
+
+This makes scenarios safe to save, share, and replay without concern for
+environmental drift.
+
+---
+
+## How Replay Works
+
+The comparison engine builds a synthetic `SemanticEvent` from the scenario:
+
+```
+ScenarioInput
+  ├── source_type → SemanticEvent.source_type
+  │                 trust_level resolved from CompiledWorld.trust_lookup
+  ├── hidden_content_detected → SemanticEvent.hidden_content_detected
+  ├── taint → SemanticEvent.taint
+  └── action → IntentProposal.intent_type
+```
+
+The synthetic event is then evaluated by `evaluatePolicyFromWorld(compiledWorld, event, intent)`,
+which runs the full 4-pass deterministic evaluation (taint propagation → decision
+rules → action registry fallback → simulate).
+
+This evaluation is run independently against World A and World B, producing two
+`WorldEvalResult` objects that are then compared.
+
+---
+
+## Curated Scenarios
+
+Built-in scenarios in `src/compare/scenarios.ts`:
+
+| ID | Label | Source | Action | Hidden | Taint |
+|----|-------|--------|--------|--------|-------|
+| `hidden-page-export` | Hidden page instruction → export | web_page | export_summary | true | false |
+| `memory-poisoning` | Memory poisoning attempt | web_page | save_memory | false | false |
+| `benign-summarize` | Benign summarize | web_page | summarize_page | false | false |
+| `tainted-export` | Tainted content export | web_page | export_summary | true | true |
+| `trusted-memory-write` | Trusted source memory write | extension_ui | save_memory | false | false |
+| `external-action-pivot` | External action pivot (no hidden content) | web_page | export_summary | false | false |
+
+Each curated scenario targets a specific decision-surface property:
+- `hidden-page-export` — hidden content detection path
+- `memory-poisoning` — untrusted memory write path
+- `benign-summarize` — utility preservation (both worlds should agree)
+- `tainted-export` — explicit taint + hidden content combined
+- `trusted-memory-write` — trusted source baseline (both worlds should allow)
+- `external-action-pivot` — external side-effect from untrusted source, no other signals
+
+---
+
+## Custom Scenarios
+
+The Compare view also supports custom scenarios via the UI:
+
+- **Source**: any source_type defined in the world's trust_lookup
+- **Action**: any intent type (`summarize_page`, `extract_links`, `extract_action_items`, `save_memory`, `export_summary`)
+- **Hidden content**: toggleable boolean flag
+- **Taint**: toggleable boolean flag
+
+Custom scenarios are not saved — they are ephemeral inputs evaluated in real time.
+
+---
+
+## Effective Taint Calculation
+
+The effective taint for a scenario is:
+
+```
+effective_taint = scenario.taint
+               OR scenario.hidden_content_detected
+               OR CompiledWorld.taint_lookup[source_type]
+```
+
+This means two worlds can produce different `effective_taint` for the same
+scenario if their `taint_lookup` entries for the source type differ. This appears
+as a `taint_propagation` divergence point in the comparison result.
+
+---
+
+## Stretch Goal: Saved Trace Replay
+
+The spec mentions replaying saved trace entries as scenarios. This is not
+implemented because:
+
+1. A `DecisionTrace` captures the *outcome* of a policy evaluation, not all
+   inputs needed to reconstruct a `SemanticEvent` (visible_text, full URL, etc.)
+2. Replay semantics would require storing the full `SemanticEvent` alongside each
+   trace entry, which significantly increases storage overhead.
+3. The deterministic test input approach (curated + custom scenarios) covers the
+   same comparative use case without needing trace storage.
+
+Each `DecisionTrace` does record `active_world_version`, `active_world_id`, and
+`rule_version`, making it possible to identify which world governed a decision
+even without full replay capability.

--- a/browser-extension-demo/docs/world-comparison-model.md
+++ b/browser-extension-demo/docs/world-comparison-model.md
@@ -1,0 +1,191 @@
+# World Comparison Model
+
+Documents the data structures produced by the Comparative World Playground.
+
+---
+
+## Overview
+
+The comparison pipeline takes two compiled worlds and a scenario input and
+produces a structured `ComparisonResult`. Every field is deterministically
+derived from the manifest — no AI commentary, no randomness.
+
+```
+ScenarioInput + CompiledWorld A + CompiledWorld B
+    ↓
+compareWorlds()
+    ↓
+ComparisonResult
+    ├── world_a: WorldEvalResult
+    ├── world_b: WorldEvalResult
+    ├── diverges: boolean
+    ├── divergence_points: DivergencePoint[]
+    └── summary: string
+```
+
+---
+
+## ScenarioInput
+
+```typescript
+interface ScenarioInput {
+  source_type: string;           // e.g. 'web_page', 'extension_ui'
+  hidden_content_detected: boolean;
+  taint: boolean;
+  action: IntentType;            // e.g. 'save_memory', 'export_summary'
+  label?: string;                // human-readable label for display/export
+}
+```
+
+A scenario is a fully deterministic description of one evaluation context.
+The same `ScenarioInput` produces the same `ComparisonResult` for a given pair
+of compiled worlds — no external state, no randomness.
+
+---
+
+## WorldEvalResult
+
+```typescript
+interface WorldEvalResult {
+  world_id: string;
+  world_version: number;
+  version_id: string;            // 'preset:<name>' or UUID from version history
+  effective_trust: 'trusted' | 'untrusted';
+  effective_taint: boolean;
+  policy: PolicyResult;          // decision, rule_id, rule_description, explanation
+}
+```
+
+`effective_trust` is resolved from `CompiledWorld.trust_lookup[source_type]`.
+
+`effective_taint` is the logical OR of:
+- `scenario.taint` (explicit override)
+- `scenario.hidden_content_detected` (hidden content implies taint)
+- `CompiledWorld.taint_lookup[source_type]` (world's default taint for this source)
+
+---
+
+## ComparisonResult
+
+```typescript
+interface ComparisonResult {
+  scenario: ScenarioInput;
+  world_a: WorldEvalResult;
+  world_b: WorldEvalResult;
+  diverges: boolean;             // true if any DivergencePoint exists
+  divergence_points: DivergencePoint[];
+  summary: string;               // one-line human-readable summary
+}
+```
+
+`diverges` is true whenever the two worlds produce a different outcome for any
+of the three comparison dimensions: decision, taint propagation, or trust.
+
+---
+
+## DivergencePoint
+
+```typescript
+interface DivergencePoint {
+  stage: 'taint_propagation' | 'decision' | 'action_registry' | 'fallback';
+  world_a_state: string;   // what world A's state was at this stage
+  world_b_state: string;   // what world B's state was at this stage
+  cause: string;           // structural explanation (rule difference, missing rule, etc.)
+}
+```
+
+### Stages
+
+| Stage | When it fires |
+|-------|---------------|
+| `decision` | The two worlds reached different `policy.decision` values |
+| `taint_propagation` | The two worlds assigned different `effective_taint` or `effective_trust` for the same source |
+| `action_registry` | (Reserved) Action available in one world's registry but not the other |
+| `fallback` | One world fell through to `simulate` because no rule matched |
+
+### Cause text examples
+
+- `Both worlds matched rule "RULE-03", but produced different decisions. The rule may have been modified.`
+- `World A has no matching rule — action falls through to simulate. The other world has an explicit rule.`
+- `World A matched rule "ask_before_memory_write" (→ask); World B matched rule "deny_untrusted_writes" (→deny). The two worlds have different rule sets for this condition.`
+
+---
+
+## ActionSurface
+
+```typescript
+interface ActionSurface {
+  world_id: string;
+  world_version: number;
+  context: { source_type: string; trust: string; taint: boolean; hidden: boolean };
+  entries: ActionSurfaceEntry[];     // one per known action
+  allowed: IntentType[];
+  requires_approval: IntentType[];
+  denied: IntentType[];
+  simulated: IntentType[];
+}
+```
+
+Computed by evaluating every known action against the world for the given context.
+Known actions: `summarize_page`, `extract_links`, `extract_action_items`,
+`save_memory`, `export_summary`.
+
+---
+
+## ActionSurfaceDiff
+
+```typescript
+interface ActionSurfaceDiff {
+  only_in_a: IntentType[];           // allowed in A, denied/simulated in B
+  only_in_b: IntentType[];           // allowed in B, denied/simulated in A
+  moved_to_ask_in_b: IntentType[];   // allowed in A, ask in B (added friction)
+  moved_to_deny_in_b: IntentType[];  // allowed/ask in A, deny in B (restricted)
+  moved_to_allow_in_b: IntentType[]; // deny/ask in A, allow in B (relaxed)
+  same: IntentType[];                // identical decisions in both worlds
+}
+```
+
+This is the core of the "ontological difference" demo: `only_in_a` and `only_in_b`
+show that some actions are simply unreachable in one world.
+
+---
+
+## TradeoffSummary
+
+```typescript
+interface TradeoffSummary {
+  world_id: string;
+  world_version: number;
+  total_actions: number;
+  allowed_count: number;
+  ask_count: number;
+  deny_count: number;
+  simulate_count: number;
+  read_only_count: number;
+  external_side_effect_count: number;
+  deny_rule_count: number;
+  ask_rule_count: number;
+}
+```
+
+Counts are derived entirely from the compiled world's action registry and rule
+index — no runtime execution required.
+
+---
+
+## ComparisonSummaryResult
+
+```typescript
+interface ComparisonSummaryResult {
+  world_a: TradeoffSummary;
+  world_b: TradeoffSummary;
+  observations: string[];   // neutral plain-language observations
+}
+```
+
+`observations` examples:
+- `"strict-world permits fewer actions without approval (1 vs 3)."`
+- `"balanced-world generates more approval requests (2 vs 0)."`
+- `"The two worlds produce identical action surfaces for this context."`
+
+Observations are produced by direct numeric comparison — no AI generation.

--- a/browser-extension-demo/src/compare/comparison_summary.ts
+++ b/browser-extension-demo/src/compare/comparison_summary.ts
@@ -7,6 +7,7 @@
 
 import type { CompiledWorld } from '../world/manifest_schema';
 import type { ActionSurface } from './action_surface';
+import type { ComparisonResult } from './comparison_engine';
 
 export interface TradeoffSummary {
   world_id: string;
@@ -159,4 +160,61 @@ export function formatComparisonMarkdown(
     ''
   ];
   return lines.join('\n');
+}
+
+/**
+ * Format a comparison result as JSON for export.
+ *
+ * Includes the full structural diff, divergence points, and tradeoff metrics
+ * so the output can be used in reports, GitHub issues, and design reviews.
+ */
+export function formatComparisonJson(
+  summary: ComparisonSummaryResult,
+  result: ComparisonResult,
+  scenarioLabel: string
+): string {
+  const payload = {
+    scenario: scenarioLabel,
+    scenario_input: result.scenario,
+    world_a: {
+      id: summary.world_a.world_id,
+      version: summary.world_a.world_version,
+      decision: result.world_a.policy.decision,
+      rule_id: result.world_a.policy.rule_id,
+      explanation: result.world_a.policy.explanation,
+      effective_trust: result.world_a.effective_trust,
+      effective_taint: result.world_a.effective_taint,
+      metrics: {
+        allowed: summary.world_a.allowed_count,
+        requires_approval: summary.world_a.ask_count,
+        denied: summary.world_a.deny_count,
+        simulated: summary.world_a.simulate_count,
+        read_only_actions: summary.world_a.read_only_count,
+        external_side_effect_actions: summary.world_a.external_side_effect_count,
+        deny_ask_rules: summary.world_a.deny_rule_count + summary.world_a.ask_rule_count
+      }
+    },
+    world_b: {
+      id: summary.world_b.world_id,
+      version: summary.world_b.world_version,
+      decision: result.world_b.policy.decision,
+      rule_id: result.world_b.policy.rule_id,
+      explanation: result.world_b.policy.explanation,
+      effective_trust: result.world_b.effective_trust,
+      effective_taint: result.world_b.effective_taint,
+      metrics: {
+        allowed: summary.world_b.allowed_count,
+        requires_approval: summary.world_b.ask_count,
+        denied: summary.world_b.deny_count,
+        simulated: summary.world_b.simulate_count,
+        read_only_actions: summary.world_b.read_only_count,
+        external_side_effect_actions: summary.world_b.external_side_effect_count,
+        deny_ask_rules: summary.world_b.deny_rule_count + summary.world_b.ask_rule_count
+      }
+    },
+    diverges: result.diverges,
+    divergence_points: result.divergence_points,
+    observations: summary.observations
+  };
+  return JSON.stringify(payload, null, 2);
 }

--- a/browser-extension-demo/src/compare/scenarios.ts
+++ b/browser-extension-demo/src/compare/scenarios.ts
@@ -79,6 +79,21 @@ export const CURATED_SCENARIOS: CuratedScenario[] = [
       action: 'save_memory',
       label: 'Trusted memory save'
     }
+  },
+  {
+    id: 'external-action-pivot',
+    label: 'External action pivot (no hidden content)',
+    description:
+      'An untrusted web page attempts to trigger an external side-effect action (export_summary) ' +
+      'with no hidden content signals and no explicit taint. Reveals how worlds differ in their ' +
+      'external side-effect surface for plain untrusted sources.',
+    input: {
+      source_type: 'web_page',
+      hidden_content_detected: false,
+      taint: false,
+      action: 'export_summary',
+      label: 'External pivot attempt'
+    }
   }
 ];
 

--- a/browser-extension-demo/src/core/world_state.ts
+++ b/browser-extension-demo/src/core/world_state.ts
@@ -1,10 +1,11 @@
 import type { SourceType } from './semantic_event';
-import { POLICY_RULES, type PolicyRuleDescriptor } from './policy';
+import { POLICY_RULES, type PolicyDecision, type PolicyRuleDescriptor } from './policy';
+import type { CompiledRule, CompiledWorld } from '../world/manifest_schema';
 
 export interface CapabilitySummary {
   can_read: boolean;           // summarize_page, extract_links, extract_action_items
-  can_write_memory: boolean;   // save_memory: allowed under some conditions (ask required from untrusted)
-  can_export: boolean;         // export_summary: allowed under some conditions (blocked if tainted)
+  can_write_memory: boolean;   // save_memory: action exists in active world
+  can_export: boolean;         // export_summary: action exists in active world
 }
 
 export interface WorldStateSnapshot {
@@ -14,21 +15,73 @@ export interface WorldStateSnapshot {
   capability_summary: CapabilitySummary;
 }
 
+function describeCompiledRule(rule: CompiledRule): string {
+  const conditions: string[] = [];
+  const c = rule.conditions;
+  if (c.hidden_content_detected === true) conditions.push('hidden content detected');
+  if (c.taint === true) conditions.push('content is tainted');
+  if (c.trust !== undefined) conditions.push(`source is ${c.trust}`);
+  if (c.action !== undefined) conditions.push(`action is ${c.action}`);
+
+  const effects: string[] = [];
+  const e = rule.effects;
+  if (e.decision !== undefined) effects.push(e.decision.toUpperCase());
+  if (e.note) effects.push(`(${e.note})`);
+
+  const condStr = conditions.length > 0 ? `If ${conditions.join(' and ')}: ` : '';
+  const effStr = effects.join(', ') || 'no decision';
+  return `${condStr}${effStr}`;
+}
+
 /**
- * Derives a read-only world model snapshot from the static policy rules and
- * the trust mapping defined in world.ts.
+ * Derives a read-only world model snapshot.
+ *
+ * When `compiledWorld` is provided, trust sources, rules, and capabilities are
+ * derived from the live compiled world.  When absent, falls back to hardcoded
+ * defaults (used before the first world activation).
  *
  * Pure function — no Chrome API calls, no side effects.
  */
-export function buildWorldStateSnapshot(): WorldStateSnapshot {
-  return {
-    trusted_sources: ['user_manual_note', 'internal_extension_ui'],
-    untrusted_sources: ['web_page'],
-    current_rules: POLICY_RULES,
-    capability_summary: {
-      can_read: true,           // summarize + extract always allowed
-      can_write_memory: true,   // allowed but requires approval from untrusted
-      can_export: true          // allowed but blocked when tainted, requires approval when untrusted
-    }
+export function buildWorldStateSnapshot(compiledWorld?: CompiledWorld): WorldStateSnapshot {
+  if (!compiledWorld) {
+    return {
+      trusted_sources: ['user_manual_note', 'internal_extension_ui'],
+      untrusted_sources: ['web_page'],
+      current_rules: POLICY_RULES,
+      capability_summary: {
+        can_read: true,
+        can_write_memory: true,
+        can_export: true
+      }
+    };
+  }
+
+  const trusted_sources = (
+    Object.entries(compiledWorld.trust_lookup)
+      .filter(([, trust]) => trust === 'trusted')
+      .map(([src]) => src)
+  ) as SourceType[];
+
+  const untrusted_sources = (
+    Object.entries(compiledWorld.trust_lookup)
+      .filter(([, trust]) => trust === 'untrusted')
+      .map(([src]) => src)
+  ) as SourceType[];
+
+  // Only include rules that produce a policy decision (skip pure taint-propagation rules)
+  const current_rules: PolicyRuleDescriptor[] = compiledWorld.rule_index
+    .filter(rule => rule.effects.decision !== undefined)
+    .map(rule => ({
+      rule_id: rule.id,
+      rule_description: describeCompiledRule(rule),
+      decision: rule.effects.decision as PolicyDecision
+    }));
+
+  const capability_summary: CapabilitySummary = {
+    can_read: Object.values(compiledWorld.effect_map).some(e => e === 'read_only'),
+    can_write_memory: 'save_memory' in compiledWorld.action_registry,
+    can_export: 'export_summary' in compiledWorld.action_registry
   };
+
+  return { trusted_sources, untrusted_sources, current_rules, capability_summary };
 }

--- a/browser-extension-demo/src/extension/background/index.ts
+++ b/browser-extension-demo/src/extension/background/index.ts
@@ -128,7 +128,8 @@ async function applyNewWorld(
   const newState: AppState = {
     ...state,
     active_world: buildActiveWorld(record, compiled),
-    version_history: updatedHistory
+    version_history: updatedHistory,
+    world_state: buildWorldStateSnapshot(compiled)
   };
 
   return { state: newState, record };
@@ -178,7 +179,7 @@ chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
     }
 
     if (message.type === 'GET_WORLD_STATE') {
-      sendResponse({ ok: true, world_state: buildWorldStateSnapshot() });
+      sendResponse({ ok: true, world_state: buildWorldStateSnapshot(state.active_world?.compiled_world) });
       return;
     }
 

--- a/browser-extension-demo/src/ui/compare/CompareWorldsView.tsx
+++ b/browser-extension-demo/src/ui/compare/CompareWorldsView.tsx
@@ -6,7 +6,7 @@ import { PRESET_YAMLS, PRESET_LABELS } from '../../world/presets';
 import { compareWorlds } from '../../compare/comparison_engine';
 import type { ComparisonResult, ScenarioInput } from '../../compare/comparison_engine';
 import { computeActionSurfaces } from '../../compare/action_surface';
-import { buildComparisonSummary, formatComparisonMarkdown } from '../../compare/comparison_summary';
+import { buildComparisonSummary, formatComparisonMarkdown, formatComparisonJson } from '../../compare/comparison_summary';
 import { CURATED_SCENARIOS, WORLD_MATCHUPS } from '../../compare/scenarios';
 import type { IntentType } from '../../core/intent';
 import { SideBySideDecisionPanel } from './SideBySideDecisionPanel';
@@ -62,6 +62,7 @@ export function CompareWorldsView({ versions, activeVersionId }: Props) {
 
   const [activeTab, setActiveTab] = useState<TabId>('scenario');
   const [exportCopied, setExportCopied] = useState(false);
+  const [jsonCopied, setJsonCopied] = useState(false);
 
   // Resolve worlds from presets
   const worldAData = useMemo(() => getCompiledFromPreset(worldAPreset), [worldAPreset]);
@@ -133,6 +134,15 @@ export function CompareWorldsView({ versions, activeVersionId }: Props) {
     navigator.clipboard.writeText(md).then(() => {
       setExportCopied(true);
       setTimeout(() => setExportCopied(false), 2000);
+    });
+  }
+
+  function handleCopyJson() {
+    if (!summaryData || !comparisonResult) return;
+    const json = formatComparisonJson(summaryData, comparisonResult, scenarioLabel);
+    navigator.clipboard.writeText(json).then(() => {
+      setJsonCopied(true);
+      setTimeout(() => setJsonCopied(false), 2000);
     });
   }
 
@@ -242,6 +252,12 @@ export function CompareWorldsView({ versions, activeVersionId }: Props) {
               style={{ ...tabBtn(false), marginLeft: 'auto' }}
             >
               {exportCopied ? '✓ Copied!' : 'Export MD'}
+            </button>
+            <button
+              onClick={handleCopyJson}
+              style={tabBtn(false)}
+            >
+              {jsonCopied ? '✓ Copied!' : 'Copy JSON'}
             </button>
           </div>
 

--- a/browser-extension-demo/src/ui/trace_viewer/TraceDetail.tsx
+++ b/browser-extension-demo/src/ui/trace_viewer/TraceDetail.tsx
@@ -52,6 +52,16 @@ export function TraceDetail({ trace }: Props) {
           {trace.approval_id && (
             <Row label="Approval ID" value={<code style={{ fontSize: 10 }}>{trace.approval_id.slice(0, 16)}…</code>} />
           )}
+          {trace.active_world_id && (
+            <Row label="World" value={
+              <code style={{ fontSize: 10 }}>{trace.active_world_id} v{trace.rule_version}</code>
+            } />
+          )}
+          {trace.active_world_version && (
+            <Row label="World Ver." value={
+              <code style={{ fontSize: 10 }}>{trace.active_world_version.slice(0, 16)}…</code>
+            } />
+          )}
         </tbody>
       </table>
     </div>


### PR DESCRIPTION
Three gaps from the Phase 3 second-pass audit:

1. world_state.ts — buildWorldStateSnapshot() was hardcoded; now accepts an
   optional CompiledWorld and derives trust sources, decision rules, and
   capability summary from it. Falls back to static defaults when no world is
   active (first-run state).

2. background/index.ts — two call sites updated:
   - applyNewWorld() now sets world_state from the freshly compiled world so
     the side panel reflects the newly activated world immediately.
   - GET_WORLD_STATE handler passes the active compiled world so polling
     updates also reflect the live world.

3. TraceDetail.tsx — renders active_world_id, rule_version, and
   active_world_version rows so every trace entry shows which world version
   governed the decision (required by Phase 3 spec §6).

https://claude.ai/code/session_01Ns53WTmBZbiWDk1trewYYb