### PR TITLE
feat(program_layer): Phase 1 — minimal task compiler + safe program execution

### DIFF
--- a/docs/program_layer.md
+++ b/docs/program_layer.md
@@ -1,8 +1,43 @@
-# Program Layer — Phase 1
+# Program Layer — Phase 1: Executable Programs
 
 The Program Layer is an optional, pluggable execution abstraction that sits above the World Kernel. It allows execution to be driven by a **structured, linear program** rather than a single direct tool call.
 
 All policy enforcement happens in the World Kernel before the program layer is ever reached. The program layer defines *how* a task executes within the boundaries already established by the world manifest; it never re-evaluates or overrides policy.
+
+**Core principle:** Programs orchestrate. The World Kernel decides what is possible.
+
+---
+
+## Execution Flow
+
+```
+intent
+    ↓
+SimpleTaskCompiler.compile(intent, world)   ← keyword matching / dict dispatch
+    ↓
+ProgramExecutionPlan (or DirectExecutionPlan fallback)
+    ↓
+validate_program(program, allowed_actions)  ← static pre-execution check
+    ↓  (if ok)
+ProgramRunner.run(program, context)
+    │
+    ├── for each Step:
+    │     ├── 1. Check action ∈ allowed_actions          → deny + abort if not
+    │     ├── 2. DeterministicTaskCompiler.compile()     → ProgramExecutionPlan
+    │     ├── 3. ProgramExecutor.execute()               → sandbox execution
+    │     │       └── SandboxRuntime.run()
+    │     │             ├── AST security validation
+    │     │             ├── Compile to code object
+    │     │             ├── Restricted globals + filtered bindings
+    │     │             └── exec() in daemon thread (timeout enforced)
+    │     └── StepTrace (allow | deny | skip)
+    │
+    └── ProgramTrace (ok, step_traces, aborted_at_step, total_duration_seconds)
+    ↓
+ProgramTraceStore.append(trace)             ← JSONL persistence
+```
+
+If `ENABLE_PROGRAM_LAYER = False`, the system falls back to `DirectExecutionPlan` (existing behavior, unchanged).
 
 ---
 
@@ -19,6 +54,7 @@ A **Program** is a finite, ordered sequence of **Steps**. There are no branches,
 A **Step** specifies:
 - `action` — the action name to invoke (matched against the world's allowed set)
 - `params` — key-value parameters forwarded to the executor (e.g. `{"input": "text..."}`)
+- `description` — optional human-readable note (no effect on execution; excluded from equality/hash)
 
 ```python
 from agent_hypervisor.program_layer import Program, Step
@@ -26,10 +62,83 @@ from agent_hypervisor.program_layer import Program, Step
 program = Program(
     program_id="analysis-v1",
     steps=(
-        Step(action="count_words", params={"input": "hello world foo"}),
-        Step(action="normalize_text", params={"input": "HELLO WORLD"}),
+        Step(
+            action="count_words",
+            params={"input": "hello world foo"},
+            description="Count words in the input text",
+        ),
+        Step(
+            action="normalize_text",
+            params={"input": "HELLO WORLD"},
+            description="Lowercase and strip whitespace",
+        ),
     ),
 )
+```
+
+### SimpleTaskCompiler
+
+**SimpleTaskCompiler** translates a loosely-structured intent (string or dict) into an `ExecutionPlan` using deterministic keyword matching. No LLM, no probabilistic scoring.
+
+```python
+from agent_hypervisor.program_layer import SimpleTaskCompiler
+
+compiler = SimpleTaskCompiler()
+
+# String intent → keyword matching
+plan = compiler.compile("count the words in this document")
+# → ProgramExecutionPlan(workflow="count_words", ...)
+
+# Dict intent → delegated to DeterministicTaskCompiler
+plan = compiler.compile({"workflow": "count_lines"})
+# → ProgramExecutionPlan(workflow="count_lines", ...)
+
+# Unknown intent → safe fallback
+plan = compiler.compile("send email to alice@example.com")
+# → DirectExecutionPlan(...)   (no capability granted, no error)
+
+# World-filtered: only emit plans for workflows the world allows
+plan = compiler.compile("count words", world=frozenset({"count_lines"}))
+# → DirectExecutionPlan(...)   (count_words not in world)
+```
+
+Supported `world` argument shapes:
+- `None` — no constraint
+- `frozenset[str]` or `set[str]` — used directly as allowed workflow set
+- Object with `allowed_workflows` attribute
+- Object with `action_space` attribute (e.g. `CompiledPolicy`) — intersected with `SUPPORTED_WORKFLOWS`
+
+### World Validation
+
+**`validate_program()`** performs a static pre-execution check of every step before any step runs. This is stricter than the step-by-step abort in `ProgramRunner` — it catches all violations upfront before any side effects occur.
+
+```python
+from agent_hypervisor.program_layer import validate_program
+from agent_hypervisor.program_layer import DeterministicTaskCompiler
+
+result = validate_program(program, DeterministicTaskCompiler.SUPPORTED_WORKFLOWS)
+if not result.ok:
+    for v in result.violations:
+        print(f"DENY: {v}")   # "step[1] action='send_email': action not in allowed set; allowed: [...]"
+else:
+    trace = runner.run(program)
+```
+
+`ValidationResult` fields:
+- `ok: bool` — True only if all steps pass
+- `violations: tuple[StepViolation, ...]` — one entry per failing step
+
+`StepViolation` fields:
+- `step_index: int` — 0-based position
+- `action: str` — the rejected action name
+- `reason: str` — human-readable explanation
+
+For single-step validation:
+
+```python
+from agent_hypervisor.program_layer import validate_step
+violation = validate_step(step, allowed_actions=frozenset({"count_words"}), step_index=0)
+# None if valid, StepViolation if rejected
 ```
 
 ### ProgramRunner
@@ -50,7 +159,7 @@ Execution contract:
 3. **Execute** — plan runs inside the AST-validated sandbox (`SandboxRuntime`).
 4. **Abort on deny** — any denied step causes all remaining steps to get verdict `skip`.
 
-The runner never re-evaluates policy. The `allowed_actions` set passed to the runner represents post-enforcement knowledge from the world.
+The runner never re-evaluates policy. The `allowed_actions` set represents post-enforcement knowledge from the world.
 
 ### ProgramTrace and StepTrace
 
@@ -84,6 +193,118 @@ else:
     print(f"Step {failed.step_index} ({failed.action}) denied: {failed.error}")
 ```
 
+### JSONL Trace Storage
+
+**ProgramTraceStore** persists execution traces to a JSONL file (one JSON object per line, append-only).
+
+```python
+from agent_hypervisor.program_layer import ProgramTraceStore
+
+store = ProgramTraceStore("traces/program_traces.jsonl")
+
+# Persist a trace
+trace = runner.run(program)
+store.append(trace)
+
+# Read recent traces (newest first)
+recent = store.list_recent(limit=10)
+for entry in recent:
+    print(entry["program_id"], entry["ok"])
+
+# Filter by outcome
+failures = store.list_recent(ok=False)
+for program_traces in store.list_recent(program_id="analysis-v1"):
+    print(program_traces)
+```
+
+Each stored entry is `ProgramTrace.to_dict()` plus a `_stored_at` ISO-8601 timestamp.
+
+---
+
+## Example: ProgramExecutionPlan
+
+```python
+ProgramExecutionPlan(
+    plan_id="prog-count_words-a1b2c3d4",
+    language="python",
+    program_source="""
+text = read_input()
+words = text.split()
+lines = text.splitlines()
+emit_result({
+    "word_count": len(words),
+    "line_count": len(lines),
+    "char_count": len(text),
+})
+""",
+    allowed_bindings=("read_input", "emit_result", "json_dumps", "json_loads"),
+    timeout_seconds=5.0,
+    metadata={"workflow": "count_words", "compiled_by": "DeterministicTaskCompiler"},
+)
+```
+
+---
+
+## Example: Execution Trace (JSONL line)
+
+```json
+{
+  "program_id": "analysis-v1",
+  "ok": true,
+  "total_duration_seconds": 0.012,
+  "aborted_at_step": null,
+  "step_traces": [
+    {
+      "step_index": 0,
+      "action": "count_words",
+      "verdict": "allow",
+      "result": {"word_count": 3, "line_count": 1, "char_count": 15},
+      "error": null,
+      "duration_seconds": 0.006
+    },
+    {
+      "step_index": 1,
+      "action": "normalize_text",
+      "verdict": "allow",
+      "result": {"normalized": "hello world", "line_count": 1, "char_count": 11},
+      "error": null,
+      "duration_seconds": 0.004
+    }
+  ],
+  "_stored_at": "2024-01-01T00:00:00.000000+00:00"
+}
+```
+
+Denied trace example:
+
+```json
+{
+  "program_id": "unsafe-prog",
+  "ok": false,
+  "total_duration_seconds": 0.001,
+  "aborted_at_step": 0,
+  "step_traces": [
+    {
+      "step_index": 0,
+      "action": "send_email",
+      "verdict": "deny",
+      "result": null,
+      "error": "action 'send_email' is not in the allowed action set; allowed: ['count_lines', 'count_words', 'normalize_text', 'word_frequency']",
+      "duration_seconds": 0.0
+    },
+    {
+      "step_index": 1,
+      "action": "count_words",
+      "verdict": "skip",
+      "result": null,
+      "error": "execution aborted by a prior denied step",
+      "duration_seconds": 0.0
+    }
+  ],
+  "_stored_at": "2024-01-01T00:00:01.000000+00:00"
+}
+```
+
 ---
 
 ## Supported Actions (Phase 1)
@@ -97,19 +318,48 @@ Phase 1 supports four **named workflows** compiled deterministically — no LLM,
 | `normalize_text` | `input: str` | `{normalized, line_count, char_count}` |
 | `word_frequency` | `input: str`, `top_n: int` (opt, 1–100, default 10) | `{top_words, unique_word_count, total_word_count}` |
 
-All workflows execute inside the `SandboxRuntime` — a restricted Python environment with AST-level security validation and a hard wall-clock timeout.
+All workflows execute inside the `SandboxRuntime`.
 
 ---
 
-## Sandbox Constraints
+## How Validation Works
 
-The `SandboxRuntime` enforces:
+There are two independent validation layers:
 
-- **No imports** — `import` and `from...import` are blocked at the AST level
-- **No dangerous builtins** — `eval`, `exec`, `open`, `getattr`, `globals`, `locals`, and others are not available
-- **No dunder attribute access** — `__builtins__`, `__class__`, `__dict__`, etc. are blocked
-- **Hard timeout** — programs exceeding `timeout_seconds` (default 5.0) are killed; verdict → `deny`
-- **Explicit bindings only** — programs can only call functions explicitly injected (`read_input`, `emit_result`, `json_dumps`, `json_loads`)
+### 1. Static pre-validation (`validate_program`)
+
+Before execution starts, `validate_program(program, allowed_actions)` checks every step's `action` against the allowed set. This is a pure, deterministic check:
+
+- Iterates all steps; collects ALL violations before returning
+- Returns `ValidationResult(ok=False, violations=[...])` if any step fails
+- Caller can gate execution: do not call `runner.run()` if `result.ok is False`
+- Completely independent of the sandbox; runs in microseconds
+
+### 2. Runtime per-step validation (`ProgramRunner`)
+
+During execution, `ProgramRunner._execute_step()` re-validates each step immediately before compiling it:
+
+- If action not in `allowed_actions` → `StepTrace(verdict="deny")`, runner aborts
+- If compiler cannot produce a `ProgramExecutionPlan` → `StepTrace(verdict="deny")`, runner aborts
+- If sandbox raises any error → `StepTrace(verdict="deny")`, runner aborts
+- Runner is fail-closed: errors become `deny` verdicts, never propagate as exceptions
+
+The two layers are complementary: static pre-validation gives the caller an upfront picture; runtime validation is the hard gate.
+
+---
+
+## How the Sandbox Is Enforced
+
+The `SandboxRuntime` enforces four independent constraints:
+
+| Constraint | Mechanism | Failure mode |
+|-----------|-----------|-------------|
+| No imports | AST visitor: `visit_Import`, `visit_ImportFrom` | `SandboxSecurityError` at parse time |
+| No dangerous builtins | `_FORBIDDEN_CALL_NAMES` checked in AST visitor | `SandboxSecurityError` at parse time |
+| No dunder attribute access | `_FORBIDDEN_ATTRS` checked in AST visitor | `SandboxSecurityError` at parse time |
+| Hard timeout | Daemon thread + `thread.join(timeout)` | `SandboxTimeoutError` after `timeout_seconds` |
+
+AST validation runs before `exec()` — no code is ever executed if the AST check fails. The safe builtins whitelist (66 names) is explicit: programs only see what is listed in `_SAFE_BUILTINS_NAMES`. Everything else is absent from the program's namespace; access produces `NameError`.
 
 ---
 
@@ -128,7 +378,7 @@ import agent_hypervisor.program_layer.config as program_config
 program_config.ENABLE_PROGRAM_LAYER = False
 ```
 
-Check the flag before using the layer:
+When disabled, callers should bypass the program layer entirely:
 
 ```python
 from agent_hypervisor.program_layer import ENABLE_PROGRAM_LAYER, ProgramRunner
@@ -136,51 +386,36 @@ from agent_hypervisor.program_layer import ENABLE_PROGRAM_LAYER, ProgramRunner
 if ENABLE_PROGRAM_LAYER:
     runner = ProgramRunner(allowed_actions={"count_words"})
     trace = runner.run(program)
+else:
+    # fall back to direct execution (existing behavior)
+    ...
 ```
 
 ---
 
-## Execution Flow
+## Phase 1 Limitations
 
-```
-Program (frozen dataclass)
-    ↓
-ProgramRunner.run()
-    │
-    ├── for each Step:
-    │     ├── 1. Validate action ∈ allowed_actions    → deny + abort if not found
-    │     ├── 2. DeterministicTaskCompiler.compile()  → ProgramExecutionPlan
-    │     ├── 3. ProgramExecutor.execute()             → sandbox execution
-    │     │       └── SandboxRuntime.run()
-    │     │             ├── AST security validation
-    │     │             ├── Compile to code object
-    │     │             ├── Build restricted globals + filtered bindings
-    │     │             └── exec() in daemon thread (timeout enforced)
-    │     └── StepTrace (allow | deny | skip)
-    │
-    └── ProgramTrace (ok, step_traces, aborted_at_step, total_duration_seconds)
-```
-
----
-
-## What Is Intentionally Not In Phase 1
-
-| Not implemented | Reason |
-|----------------|---------|
-| Branching / loops in programs | Determinism and auditability require linear structure |
-| LLM-generated program steps | No LLM on the enforcement path |
-| Data flow between steps | Steps are independent; output-to-input wiring is planned for Phase 2 |
-| ProgramRegistry (store/load) | Stub only; reviewed program attestation is future work |
-| Arbitrary Python actions | Only the 4 pre-written workflows are supported in Phase 1 |
-| World-aware action validation | `allowed_actions` is caller-supplied; deeper world integration is Phase 2 |
+| Limitation | Reason |
+|-----------|--------|
+| No branching or loops in programs | Determinism and auditability require linear structure |
+| No LLM-generated program steps | No LLM on the enforcement path |
+| No data flow between steps | Steps are independent; output-to-input wiring is planned for Phase 2 |
+| `SimpleTaskCompiler` uses keyword matching, not NLP | Deterministic; no probabilistic scoring |
+| `ProgramRegistry.store()` / `.load()` not implemented | Stub only; reviewed program attestation is future work |
+| Only 4 pre-written workflows | Arbitrary Python programs are not accepted; custom workflows require Phase 2 |
+| World validation checks action name only | Deep capability matrix validation (trust level × action type) is Phase 2 |
+| `SandboxRuntime` timeout uses daemon thread | Timed-out thread continues running until process exit (CPython limitation) |
+| No cross-step context sharing | Each step receives independent input; no shared state between steps |
+| JSONL store is not thread-safe | Single-process use only; shared storage requires external locking |
 
 ---
 
 ## API Reference
 
-### `Step(action: str, params: dict = {})`
+### `Step(action: str, params: dict = {}, description: Optional[str] = None)`
 
-Frozen dataclass. Raises `ValueError` if `action` is empty.
+Frozen dataclass. `description` is for display only; excluded from equality and hash.
+Raises `ValueError` if `action` is empty.
 
 ### `Program(program_id: str, steps: tuple[Step, ...])`
 
@@ -188,16 +423,35 @@ Frozen dataclass. Raises:
 - `ValueError` if `program_id` is empty, steps is empty, or `len(steps) > MAX_STEPS (10)`
 - `TypeError` if steps is not a tuple or contains non-Step elements
 
+### `SimpleTaskCompiler(extra_patterns=())`
+
+- `compile(intent, world=None)` → `ExecutionPlan`
+- String intents: keyword-matched to a workflow; first match wins
+- Dict intents: delegated to `DeterministicTaskCompiler`
+- Unknown/unmatched intents: `DirectExecutionPlan` fallback
+- `world` filters which workflows may be emitted
+
+### `validate_program(program: Program, allowed_actions: Collection[str]) → ValidationResult`
+
+Static pre-execution check. Returns `ValidationResult(ok=True)` if every step's action is in `allowed_actions`, `ValidationResult(ok=False, violations=(...))` otherwise. Collects all violations before returning. Raises `TypeError` if `program` is not a `Program`.
+
+### `validate_step(step: Step, allowed_actions, step_index: int = 0) → Optional[StepViolation]`
+
+Single-step variant. Returns `None` if valid, `StepViolation` if rejected.
+
 ### `ProgramRunner(allowed_actions=None, default_timeout=5.0, compiler=None, executor=None)`
 
 - `allowed_actions`: set of permitted action names (default: `DeterministicTaskCompiler.SUPPORTED_WORKFLOWS`)
 - `default_timeout`: per-step wall-clock limit in seconds (must be positive)
 - `compiler` / `executor`: injectable dependencies for testing
+- `run(program, context=None)` → `ProgramTrace` — never raises (errors are captured in `StepTrace.error`), except `TypeError` if `program` is not a `Program`
 
-### `ProgramRunner.run(program: Program, context: dict = None) → ProgramTrace`
+### `ProgramTraceStore(path: str | Path)`
 
-Executes the program and returns the trace. Never raises (errors are captured in `StepTrace.error`), except:
-- `TypeError` if `program` is not a `Program` instance
+- `append(trace: ProgramTrace)` — persist to JSONL, creates file and parent dirs
+- `list_recent(limit=50, ok=None, program_id=None)` → `list[dict]` — newest first
+- `count()` → `int` — total stored traces
+- Raises `TypeError` for non-`ProgramTrace` arguments to `append()`
 
 ### `ENABLE_PROGRAM_LAYER: bool`
 

--- a/src/agent_hypervisor/program_layer/__init__.py
+++ b/src/agent_hypervisor/program_layer/__init__.py
@@ -1,37 +1,44 @@
 """
-program_layer — Optional execution abstraction layer (Phase 1).
+program_layer — Executable program abstraction layer (Phase 1).
 
-This package introduces the Program Layer: an optional, pluggable extension
-above the World Kernel that allows execution to be driven by structured
-programs rather than direct tool adapter calls.
+This package is an optional, pluggable extension above the World Kernel that
+allows execution to be driven by structured, linear programs rather than
+direct tool adapter calls.
 
 The World Kernel (runtime/, hypervisor/) is not modified.
 All policy enforcement runs before any program layer code is reached.
+Programs orchestrate; the World Kernel decides what is possible.
 
-Phase 1 additions (this release):
-    Program / Step        — minimal linear program model (no branches/loops)
-    ProgramTrace          — per-step execution trace (allow/deny/skip verdicts)
-    ProgramRunner         — step-by-step executor: validates → compiles → runs
-    ENABLE_PROGRAM_LAYER  — feature flag (env: AGENT_HYPERVISOR_ENABLE_PROGRAM_LAYER)
+Phase 1 — Minimal Task Compiler + Safe Program Execution:
 
-Phase 1 (sandbox foundations, from prior release):
-    SandboxRuntime        — restricted exec() environment (AST-validated)
-    DeterministicTaskCompiler — converts named workflows to ProgramExecutionPlan
-    ProgramExecutor       — runs ProgramExecutionPlan in the sandbox
+    Program / Step            — linear program model (no branches/loops).
+                                Step gains an optional ``description`` field.
+    ProgramTrace / StepTrace  — per-step execution trace (allow/deny/skip).
+    ProgramRunner             — validates → compiles → executes step-by-step.
+    SimpleTaskCompiler        — maps string/dict intents to ExecutionPlan via
+                                keyword matching; falls back to DirectExecutionPlan.
+    validate_program()        — static pre-execution world constraint check.
+    ProgramTraceStore         — JSONL-backed persistent trace storage.
+    ENABLE_PROGRAM_LAYER      — master feature flag.
 
-Existing (scaffolding from prior phase):
-    ExecutionPlan         — base plan type
-    DirectExecutionPlan   — wraps existing direct execution (default, unchanged)
-    ProgramExecutionPlan  — code-based execution (now functional in Phase 1)
-    TaskCompiler          — protocol: intent + world → ExecutionPlan
-    Executor              — protocol: plan + context → result
-    ProgramRegistry       — stub: store/load reviewed programs (future)
+Prior phase (sandbox foundations):
+    SandboxRuntime            — restricted exec() (AST-validated, timeout).
+    DeterministicTaskCompiler — converts named workflows to ProgramExecutionPlan.
+    ProgramExecutor           — runs ProgramExecutionPlan in the sandbox.
+
+Plan types:
+    ExecutionPlan             — abstract base.
+    DirectExecutionPlan       — existing direct execution (unchanged behavior).
+    ProgramExecutionPlan      — sandbox execution (functional in Phase 1).
+
+Protocols:
+    TaskCompiler              — compile(intent, world) → ExecutionPlan.
+    Executor                  — execute(plan, context) → result.
+    ProgramRegistry           — stub for future reviewed-program store.
 
 Public surface:
     All names in __all__ are stable across Phase 1.
-    SandboxError hierarchy (SandboxSecurityError, SandboxTimeoutError,
-    SandboxRuntimeError) is exported for callers that need to handle
-    specific failure modes.
+    SandboxError hierarchy is exported for callers handling specific failures.
 """
 
 from .config import ENABLE_PROGRAM_LAYER
@@ -48,19 +55,27 @@ from .sandbox_runtime import (
     SandboxSecurityError,
     SandboxTimeoutError,
 )
+from .simple_task_compiler import SimpleTaskCompiler
 from .task_compiler import DeterministicTaskCompiler
+from .trace_storage import ProgramTraceStore
+from .world_validator import (
+    StepViolation,
+    ValidationResult,
+    validate_program,
+    validate_step,
+)
 
 __all__ = [
     # Feature flag
     "ENABLE_PROGRAM_LAYER",
-    # Program model (Phase 1)
+    # Program model
     "Step",
     "Program",
     "MAX_STEPS",
-    # Execution trace (Phase 1)
+    # Execution trace
     "StepTrace",
     "ProgramTrace",
-    # Runner (Phase 1)
+    # Runner
     "ProgramRunner",
     # Plan types
     "ExecutionPlan",
@@ -70,13 +85,22 @@ __all__ = [
     "TaskCompiler",
     "Executor",
     "ProgramRegistry",
-    # Implementations
-    "ProgramExecutor",
-    "SandboxRuntime",
+    # Compilers
     "DeterministicTaskCompiler",
-    # Sandbox error hierarchy
+    "SimpleTaskCompiler",
+    # Executor
+    "ProgramExecutor",
+    # Sandbox
+    "SandboxRuntime",
     "SandboxError",
     "SandboxSecurityError",
     "SandboxTimeoutError",
     "SandboxRuntimeError",
+    # World validation
+    "validate_program",
+    "validate_step",
+    "ValidationResult",
+    "StepViolation",
+    # Trace storage
+    "ProgramTraceStore",
 ]

--- a/src/agent_hypervisor/program_layer/program_model.py
+++ b/src/agent_hypervisor/program_layer/program_model.py
@@ -30,7 +30,7 @@ Usage::
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any
+from typing import Any, Optional
 
 # Hard upper bound on steps per program.
 # Caller receives ValueError at construction time if exceeded.
@@ -43,12 +43,15 @@ class Step:
     A single step in a linear program.
 
     Fields:
-        action  — the action name to invoke; matched against the world's
-                  allowed action set by ProgramRunner (unknown → deny).
-        params  — key-value parameters for the action.  Passed to the
-                  executor as execution context.  Must be JSON-serialisable.
-                  Excluded from hash and equality comparisons (structural
-                  identity is determined by action only).
+        action      — the action name to invoke; matched against the world's
+                      allowed action set by ProgramRunner (unknown → deny).
+        params      — key-value parameters for the action.  Passed to the
+                      executor as execution context.  Must be JSON-serialisable.
+                      Excluded from hash and equality comparisons (structural
+                      identity is determined by action only).
+        description — optional human-readable note explaining what this step
+                      does.  Used for logging and trace display only; it has
+                      no effect on execution.  Excluded from hash and equality.
 
     Raises:
         ValueError: action is empty or whitespace-only.
@@ -56,6 +59,7 @@ class Step:
 
     action: str
     params: dict[str, Any] = field(default_factory=dict, hash=False, compare=False)
+    description: Optional[str] = field(default=None, hash=False, compare=False)
 
     def __post_init__(self) -> None:
         if not isinstance(self.action, str) or not self.action.strip():

--- a/src/agent_hypervisor/program_layer/simple_task_compiler.py
+++ b/src/agent_hypervisor/program_layer/simple_task_compiler.py
@@ -1,0 +1,277 @@
+"""
+simple_task_compiler.py — SimpleTaskCompiler for Phase 1.
+
+Translates a loosely-structured intent (string or dict) into an ExecutionPlan
+using keyword matching and simple heuristics.  No LLM, no dynamic synthesis,
+no probabilistic scoring.
+
+Design contract:
+    - Deterministic: the same intent always produces the same plan.
+    - Fail-safe: unknown or ambiguous intents fall back to DirectExecutionPlan.
+    - World-aware: if a compiled world (or action set) is supplied, the compiler
+      only emits plans for workflows the world permits.
+    - Non-expanding: the compiler cannot grant capabilities not already present
+      in the world.
+
+Intent formats accepted:
+    str   — free-text description, e.g. "count the words in this text".
+            Matched against keyword patterns; first match wins.
+    dict  — structured intent with a "workflow" key, e.g.
+            {"workflow": "count_words", "input": "hello world"}.
+            Delegated directly to DeterministicTaskCompiler.
+    other — treated as unknown; fallback to DirectExecutionPlan.
+
+Supported workflows (same set as DeterministicTaskCompiler):
+    count_lines, count_words, normalize_text, word_frequency
+
+Keyword patterns:
+    Each pattern is a (workflow, keyword) pair.  The compiler scans the
+    lower-cased intent string for each keyword in order; the first match
+    determines the workflow.  Patterns are ordered from most specific to
+    least specific so "count lines" wins over "count" (which would otherwise
+    match "count_words" first).
+
+Usage::
+
+    compiler = SimpleTaskCompiler()
+
+    # String intent
+    plan = compiler.compile("please count the words in this document")
+    # → ProgramExecutionPlan(workflow="count_words", ...)
+
+    # Dict intent (delegated to DeterministicTaskCompiler)
+    plan = compiler.compile({"workflow": "count_lines", "timeout_seconds": 3.0})
+    # → ProgramExecutionPlan(workflow="count_lines", ...)
+
+    # Unknown intent → fallback
+    plan = compiler.compile("send an email to alice")
+    # → DirectExecutionPlan(...)
+
+    # World-filtered: only workflows in world_actions are emitted
+    plan = compiler.compile("count words", world_actions=frozenset({"count_lines"}))
+    # → DirectExecutionPlan(...)   (count_words not in world_actions)
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any
+
+from .execution_plan import DirectExecutionPlan, ExecutionPlan
+from .task_compiler import DeterministicTaskCompiler
+
+# ---------------------------------------------------------------------------
+# Keyword → workflow mapping (ordered; first match wins)
+# ---------------------------------------------------------------------------
+# Patterns are tuples of (workflow_name, keyword_substring).
+# Keywords are matched against the lower-cased, stripped intent string.
+# Order matters: more specific patterns should come first.
+
+_KEYWORD_PATTERNS: tuple[tuple[str, str], ...] = (
+    # count_lines — must precede count_words to avoid "count" matching first
+    ("count_lines",    "count_lines"),
+    ("count_lines",    "count lines"),
+    ("count_lines",    "count line"),
+    ("count_lines",    "line_count"),
+    ("count_lines",    "line count"),
+    ("count_lines",    "number of lines"),
+    ("count_lines",    "how many lines"),
+    # word_frequency — most specific "frequency" patterns first
+    ("word_frequency", "word_frequency"),
+    ("word_frequency", "word frequency"),
+    ("word_frequency", "word freq"),
+    ("word_frequency", "most frequent"),
+    ("word_frequency", "most common word"),
+    ("word_frequency", "top words"),
+    ("word_frequency", "word distribution"),
+    ("word_frequency", "frequency"),
+    # normalize_text
+    ("normalize_text", "normalize_text"),
+    ("normalize_text", "normalize text"),
+    ("normalize_text", "normalise text"),
+    ("normalize_text", "normalise"),
+    ("normalize_text", "normalize"),
+    ("normalize_text", "lowercase"),
+    ("normalize_text", "lower case"),
+    ("normalize_text", "lower-case"),
+    ("normalize_text", "clean text"),
+    ("normalize_text", "strip whitespace"),
+    # count_words — least specific, comes last
+    ("count_words",    "count_words"),
+    ("count_words",    "count words"),
+    ("count_words",    "count word"),
+    ("count_words",    "count the words"),
+    ("count_words",    "count the word"),
+    ("count_words",    "word_count"),
+    ("count_words",    "word count"),
+    ("count_words",    "number of words"),
+    ("count_words",    "how many words"),
+    ("count_words",    "wordcount"),
+)
+
+
+class SimpleTaskCompiler:
+    """
+    Maps an intent (string or dict) to an ExecutionPlan.
+
+    Accepts string intents via keyword matching and dict intents via
+    DeterministicTaskCompiler.  Falls back to DirectExecutionPlan for
+    anything it cannot map to a supported workflow.
+
+    This is intentionally NOT smart.  It is a deterministic lookup table,
+    not an LLM or a classifier.  Phase 2 will replace the matching strategy;
+    the interface (compile → ExecutionPlan) stays stable.
+
+    Satisfies the TaskCompiler protocol (interfaces.py).
+
+    Args:
+        extra_patterns: Additional (workflow, keyword) pairs to prepend
+                        to the default patterns.  Useful for extending
+                        the compiler in tests or custom deployments.
+    """
+
+    # The frozen set of workflows this compiler can produce plans for.
+    # Mirrors DeterministicTaskCompiler.SUPPORTED_WORKFLOWS.
+    SUPPORTED_WORKFLOWS: frozenset[str] = DeterministicTaskCompiler.SUPPORTED_WORKFLOWS
+
+    def __init__(
+        self,
+        extra_patterns: tuple[tuple[str, str], ...] = (),
+    ) -> None:
+        self._base = DeterministicTaskCompiler()
+        # Extra patterns are prepended so callers can override defaults.
+        self._patterns: tuple[tuple[str, str], ...] = extra_patterns + _KEYWORD_PATTERNS
+
+    # ------------------------------------------------------------------
+    # Public interface
+    # ------------------------------------------------------------------
+
+    def compile(
+        self,
+        intent: Any,
+        world: Any = None,
+    ) -> ExecutionPlan:
+        """
+        Compile an intent into an ExecutionPlan.
+
+        Args:
+            intent: string or dict describing the task.  Unknown types
+                    fall back to DirectExecutionPlan.
+            world:  optional compiled world context.  Accepted shapes:
+                    - None — no world constraint; all supported workflows
+                      are available.
+                    - frozenset[str] or set[str] — treated as the allowed
+                      action set; workflows not in this set are blocked.
+                    - object with an ``action_space`` attribute (frozenset)
+                      — the compiler derives allowed workflows by
+                      intersecting SUPPORTED_WORKFLOWS with action_space.
+                    - object with ``allowed_workflows`` attribute
+                      (frozenset[str]) — used directly as the allowed set.
+                    Unknown world types → no filtering (treat as None).
+
+        Returns:
+            ProgramExecutionPlan on success, DirectExecutionPlan on fallback.
+        """
+        allowed = self._resolve_allowed_workflows(world)
+
+        if isinstance(intent, dict):
+            return self._compile_dict(intent, allowed)
+
+        if isinstance(intent, str):
+            return self._compile_string(intent, allowed)
+
+        return self._fallback("unsupported intent type")
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _compile_dict(
+        self,
+        intent: dict,
+        allowed: frozenset[str] | None,
+    ) -> ExecutionPlan:
+        """Handle structured dict intents."""
+        workflow = intent.get("workflow")
+        if not workflow or workflow not in self.SUPPORTED_WORKFLOWS:
+            return self._fallback(f"workflow={workflow!r} not supported")
+
+        if allowed is not None and workflow not in allowed:
+            return self._fallback(
+                f"workflow={workflow!r} not permitted by world"
+            )
+
+        try:
+            return self._base.compile(intent, world=None)
+        except ValueError:
+            return self._fallback(f"compile error for workflow={workflow!r}")
+
+    def _compile_string(
+        self,
+        intent: str,
+        allowed: frozenset[str] | None,
+    ) -> ExecutionPlan:
+        """Handle free-text string intents via keyword matching."""
+        normalised = intent.lower().strip()
+        workflow = self._match_keyword(normalised)
+
+        if workflow is None:
+            return self._fallback(f"no workflow matched for intent={intent!r}")
+
+        if allowed is not None and workflow not in allowed:
+            return self._fallback(
+                f"workflow={workflow!r} not permitted by world"
+            )
+
+        # Delegate plan generation to DeterministicTaskCompiler
+        try:
+            return self._base.compile({"workflow": workflow}, world=None)
+        except ValueError:
+            return self._fallback(f"compile error for workflow={workflow!r}")
+
+    def _match_keyword(self, normalised_text: str) -> str | None:
+        """
+        Scan normalised_text for the first matching keyword.
+
+        Returns the workflow name or None if no pattern matches.
+        """
+        for workflow, keyword in self._patterns:
+            if keyword in normalised_text:
+                return workflow
+        return None
+
+    def _resolve_allowed_workflows(self, world: Any) -> frozenset[str] | None:
+        """
+        Derive the allowed workflow set from the world argument.
+
+        Returns None if world imposes no constraint.
+        """
+        if world is None:
+            return None
+
+        # frozenset or set of strings → use directly
+        if isinstance(world, (frozenset, set)):
+            return frozenset(world)
+
+        # Object with allowed_workflows attribute
+        if hasattr(world, "allowed_workflows"):
+            aw = world.allowed_workflows
+            if isinstance(aw, (frozenset, set)):
+                return frozenset(aw)
+
+        # Object with action_space attribute (CompiledPolicy-like)
+        # Intersect with SUPPORTED_WORKFLOWS since action_space contains
+        # manifest actions, not program workflow names.
+        if hasattr(world, "action_space"):
+            return frozenset(
+                w for w in self.SUPPORTED_WORKFLOWS
+                if w in world.action_space
+            )
+
+        # Unknown world type — no filtering
+        return None
+
+    def _fallback(self, reason: str) -> DirectExecutionPlan:  # noqa: ARG002
+        return DirectExecutionPlan(
+            plan_id=f"direct-simple-{uuid.uuid4().hex[:8]}"
+        )

--- a/src/agent_hypervisor/program_layer/trace_storage.py
+++ b/src/agent_hypervisor/program_layer/trace_storage.py
@@ -1,0 +1,149 @@
+"""
+trace_storage.py — JSONL-backed persistent storage for ProgramTrace.
+
+Each program execution trace is appended as a single JSON object on its own
+line (JSON Lines / JSONL format).  Lines are never modified after they are
+written — the file is append-only.
+
+File format (one JSON object per line)::
+
+    {"program_id":"p1","ok":true,"total_duration_seconds":0.012,
+     "aborted_at_step":null,"step_traces":[...],"_stored_at":"2024-01-01T00:00:00+00:00"}
+
+Thread safety:
+    ProgramTraceStore is NOT thread-safe.  Use one instance per process or
+    synchronise externally.  This matches the existing TraceStore semantics in
+    hypervisor/storage/trace_store.py.
+
+Usage::
+
+    from program_layer.trace_storage import ProgramTraceStore
+
+    store = ProgramTraceStore("traces/program_traces.jsonl")
+    trace = runner.run(program)
+    store.append(trace)
+
+    recent = store.list_recent(limit=10)
+    for entry in recent:
+        print(entry["program_id"], entry["ok"])
+
+Integration with the existing TraceStore:
+    ProgramTraceStore is self-contained and does not import from
+    hypervisor/storage/.  If you need both stores in one deployment, run them
+    side by side or write a thin adapter.  Keeping the layers separate avoids
+    a runtime → hypervisor dependency.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Optional
+
+from .program_trace import ProgramTrace
+
+
+class ProgramTraceStore:
+    """
+    Append-only JSONL store for ProgramTrace objects.
+
+    Each append() writes one line: the trace dict from ProgramTrace.to_dict()
+    plus a ``_stored_at`` ISO-8601 timestamp.
+
+    Args:
+        path: path to the .jsonl file.  Parent directories are created
+              on first write.  The file need not exist in advance.
+    """
+
+    def __init__(self, path: str | Path) -> None:
+        self._path = Path(path)
+
+    # ------------------------------------------------------------------
+    # Write
+    # ------------------------------------------------------------------
+
+    def append(self, trace: ProgramTrace) -> None:
+        """
+        Append a ProgramTrace to the JSONL file.
+
+        Creates the file (and parent directories) if it does not exist.
+
+        Args:
+            trace: the ProgramTrace to persist.
+
+        Raises:
+            TypeError: trace is not a ProgramTrace.
+            OSError:   file cannot be opened for writing.
+        """
+        if not isinstance(trace, ProgramTrace):
+            raise TypeError(
+                f"ProgramTraceStore.append() requires a ProgramTrace, "
+                f"got {type(trace).__name__!r}"
+            )
+
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+
+        entry = trace.to_dict()
+        entry["_stored_at"] = datetime.now(tz=timezone.utc).isoformat()
+
+        with open(self._path, "a", encoding="utf-8") as f:
+            f.write(json.dumps(entry, default=str) + "\n")
+
+    # ------------------------------------------------------------------
+    # Read
+    # ------------------------------------------------------------------
+
+    def list_recent(
+        self,
+        limit: int = 50,
+        ok: Optional[bool] = None,
+        program_id: Optional[str] = None,
+    ) -> list[dict[str, Any]]:
+        """
+        Return trace entries, newest first, up to ``limit`` items.
+
+        Optional filters (ANDed):
+            ok          — match the ``ok`` field (True/False)
+            program_id  — match the ``program_id`` field
+
+        Filters are applied before the limit, so the result may contain
+        fewer than ``limit`` items.
+
+        Returns an empty list if the file does not exist.
+        """
+        if not self._path.exists():
+            return []
+
+        entries: list[dict[str, Any]] = []
+        with open(self._path, encoding="utf-8") as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    entry = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if ok is not None and entry.get("ok") != ok:
+                    continue
+                if program_id is not None and entry.get("program_id") != program_id:
+                    continue
+                entries.append(entry)
+
+        return list(reversed(entries))[:limit]
+
+    def count(self) -> int:
+        """Return the total number of stored traces (reads the whole file)."""
+        if not self._path.exists():
+            return 0
+        count = 0
+        with open(self._path, encoding="utf-8") as f:
+            for line in f:
+                if line.strip():
+                    count += 1
+        return count
+
+    def path(self) -> Path:
+        """Return the underlying file path."""
+        return self._path

--- a/src/agent_hypervisor/program_layer/world_validator.py
+++ b/src/agent_hypervisor/program_layer/world_validator.py
@@ -1,0 +1,185 @@
+"""
+world_validator.py — Pre-execution program validation against the world.
+
+Before any step executes, the world validator checks the entire program
+for constraint violations.  This is a static, deterministic check:
+
+    For each step:
+        1. Check the action exists in the allowed action set.
+        2. Reject the step if the action is absent.
+
+If any step violates a constraint, execution of the ENTIRE program is
+denied — no steps run.  This is stricter than the step-by-step abort
+in ProgramRunner (which runs steps until the first deny); the pre-check
+catches violations before any side effects occur.
+
+The validator operates on an ``allowed_actions`` frozenset, not on a live
+CompiledPolicy.  The caller is responsible for deriving ``allowed_actions``
+from the world:
+
+    - From a CompiledPolicy: ``frozenset(policy.action_space)`` gives
+      manifest-level actions.  For program-layer workflows, use the
+      intersection with ``DeterministicTaskCompiler.SUPPORTED_WORKFLOWS``.
+    - From ProgramRunner: pass the same ``allowed_actions`` used to
+      construct the runner.
+    - Default: ``DeterministicTaskCompiler.SUPPORTED_WORKFLOWS``.
+
+Why static pre-validation?
+    Step-by-step execution aborts on first deny but the earlier steps have
+    already run.  Pre-validation rejects the program before any step runs,
+    which is safer when steps have side effects (even sandboxed ones) or
+    when the caller wants an up-front list of all violations.
+
+Usage::
+
+    from program_layer.world_validator import validate_program
+    from program_layer.task_compiler import DeterministicTaskCompiler
+
+    violations = validate_program(program, DeterministicTaskCompiler.SUPPORTED_WORKFLOWS)
+    if violations:
+        # Reject the program before any execution
+        for v in violations:
+            print(f"DENY: {v}")
+    else:
+        trace = runner.run(program)
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Collection
+
+from .program_model import Program, Step
+
+
+# ---------------------------------------------------------------------------
+# ValidationResult
+# ---------------------------------------------------------------------------
+
+@dataclass(frozen=True)
+class StepViolation:
+    """A constraint violation for a single step."""
+
+    step_index: int
+    action: str
+    reason: str
+
+    def __str__(self) -> str:
+        return f"step[{self.step_index}] action={self.action!r}: {self.reason}"
+
+
+@dataclass(frozen=True)
+class ValidationResult:
+    """
+    Outcome of validate_program().
+
+    Fields:
+        ok         — True if no violations were found; the program may execute.
+        violations — ordered list of constraint violations (empty when ok=True).
+    """
+
+    ok: bool
+    violations: tuple[StepViolation, ...] = field(default_factory=tuple)
+
+    def to_dict(self) -> dict:
+        """JSON-safe dict, suitable for logging."""
+        return {
+            "ok": self.ok,
+            "violations": [
+                {
+                    "step_index": v.step_index,
+                    "action": v.action,
+                    "reason": v.reason,
+                }
+                for v in self.violations
+            ],
+        }
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+def validate_program(
+    program: Program,
+    allowed_actions: Collection[str],
+) -> ValidationResult:
+    """
+    Validate every step of program against allowed_actions.
+
+    Checks each step in order.  Collects ALL violations before returning
+    so the caller gets a complete picture, not just the first failure.
+
+    Args:
+        program:         the Program to validate (frozen; not mutated).
+        allowed_actions: collection of action names the program may use.
+                         Any step whose action is absent → violation.
+
+    Returns:
+        ValidationResult with ok=True and empty violations if every step's
+        action is in allowed_actions.
+        ValidationResult with ok=False and one StepViolation per failing
+        step otherwise.
+
+    Raises:
+        TypeError: program is not a Program instance.
+    """
+    if not isinstance(program, Program):
+        raise TypeError(
+            f"validate_program() requires a Program, "
+            f"got {type(program).__name__!r}"
+        )
+
+    allowed = frozenset(allowed_actions)
+    violations: list[StepViolation] = []
+
+    for i, step in enumerate(program.steps):
+        violation = _check_step(i, step, allowed)
+        if violation is not None:
+            violations.append(violation)
+
+    return ValidationResult(
+        ok=len(violations) == 0,
+        violations=tuple(violations),
+    )
+
+
+def validate_step(
+    step: Step,
+    allowed_actions: Collection[str],
+    step_index: int = 0,
+) -> StepViolation | None:
+    """
+    Validate a single step against allowed_actions.
+
+    Returns a StepViolation if the step is invalid, None if it is valid.
+    Useful for incremental validation or early-exit scenarios.
+
+    Args:
+        step:            the Step to validate.
+        allowed_actions: collection of allowed action names.
+        step_index:      0-based position used in the StepViolation message.
+    """
+    return _check_step(step_index, step, frozenset(allowed_actions))
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+def _check_step(
+    index: int,
+    step: Step,
+    allowed: frozenset[str],
+) -> StepViolation | None:
+    """Return a StepViolation if the step violates a constraint, else None."""
+    if step.action not in allowed:
+        return StepViolation(
+            step_index=index,
+            action=step.action,
+            reason=(
+                f"action not in allowed set; "
+                f"allowed: {sorted(allowed)}"
+            ),
+        )
+    return None

--- a/tests/program_layer/test_program_execution.py
+++ b/tests/program_layer/test_program_execution.py
@@ -570,3 +570,394 @@ class TestIntegration:
         )
         assert MAX_STEPS == 10
         assert isinstance(ENABLE_PROGRAM_LAYER, bool)
+
+
+# ---------------------------------------------------------------------------
+# 11. Step.description field
+# ---------------------------------------------------------------------------
+
+class TestStepDescription:
+    def test_step_description_defaults_to_none(self):
+        s = Step(action="count_words")
+        assert s.description is None
+
+    def test_step_description_can_be_set(self):
+        s = Step(action="count_words", description="Count words in the input text")
+        assert s.description == "Count words in the input text"
+
+    def test_step_description_excluded_from_equality(self):
+        s1 = Step(action="count_words", description="version A")
+        s2 = Step(action="count_words", description="version B")
+        assert s1 == s2
+
+    def test_step_description_excluded_from_hash(self):
+        s1 = Step(action="count_words", description="one")
+        s2 = Step(action="count_words", description="two")
+        assert hash(s1) == hash(s2)
+
+    def test_step_description_in_to_dict_via_trace(self):
+        """Description doesn't affect trace dict (not a trace field), but
+        step construction with description must not break ProgramRunner."""
+        runner = ProgramRunner()
+        program = Program(
+            program_id="desc-test",
+            steps=(
+                Step(
+                    action="count_words",
+                    params={"input": "hello world"},
+                    description="Count words in hello world",
+                ),
+            ),
+        )
+        trace = runner.run(program)
+        assert trace.ok is True
+        assert trace.step_traces[0].result["word_count"] == 2
+
+
+# ---------------------------------------------------------------------------
+# 12. SimpleTaskCompiler — keyword matching
+# ---------------------------------------------------------------------------
+
+class TestSimpleTaskCompiler:
+    def setup_method(self):
+        from agent_hypervisor.program_layer.simple_task_compiler import SimpleTaskCompiler
+        self.compiler = SimpleTaskCompiler()
+
+    def test_string_intent_count_words(self):
+        from agent_hypervisor.program_layer.execution_plan import ProgramExecutionPlan
+        plan = self.compiler.compile("count the words in this document")
+        assert isinstance(plan, ProgramExecutionPlan)
+        assert plan.metadata.get("workflow") == "count_words"
+
+    def test_string_intent_count_lines(self):
+        from agent_hypervisor.program_layer.execution_plan import ProgramExecutionPlan
+        plan = self.compiler.compile("count lines in the file")
+        assert isinstance(plan, ProgramExecutionPlan)
+        assert plan.metadata.get("workflow") == "count_lines"
+
+    def test_string_intent_normalize_text(self):
+        from agent_hypervisor.program_layer.execution_plan import ProgramExecutionPlan
+        plan = self.compiler.compile("normalize the text content")
+        assert isinstance(plan, ProgramExecutionPlan)
+        assert plan.metadata.get("workflow") == "normalize_text"
+
+    def test_string_intent_word_frequency(self):
+        from agent_hypervisor.program_layer.execution_plan import ProgramExecutionPlan
+        plan = self.compiler.compile("show word frequency distribution")
+        assert isinstance(plan, ProgramExecutionPlan)
+        assert plan.metadata.get("workflow") == "word_frequency"
+
+    def test_unknown_string_falls_back_to_direct(self):
+        from agent_hypervisor.program_layer.execution_plan import DirectExecutionPlan
+        plan = self.compiler.compile("send an email to alice@example.com")
+        assert isinstance(plan, DirectExecutionPlan)
+
+    def test_dict_intent_delegated(self):
+        from agent_hypervisor.program_layer.execution_plan import ProgramExecutionPlan
+        plan = self.compiler.compile({"workflow": "count_words"})
+        assert isinstance(plan, ProgramExecutionPlan)
+
+    def test_dict_unknown_workflow_falls_back(self):
+        from agent_hypervisor.program_layer.execution_plan import DirectExecutionPlan
+        plan = self.compiler.compile({"workflow": "send_email"})
+        assert isinstance(plan, DirectExecutionPlan)
+
+    def test_non_string_non_dict_falls_back(self):
+        from agent_hypervisor.program_layer.execution_plan import DirectExecutionPlan
+        plan = self.compiler.compile(42)
+        assert isinstance(plan, DirectExecutionPlan)
+
+    def test_none_intent_falls_back(self):
+        from agent_hypervisor.program_layer.execution_plan import DirectExecutionPlan
+        plan = self.compiler.compile(None)
+        assert isinstance(plan, DirectExecutionPlan)
+
+    def test_world_as_frozenset_filters_workflows(self):
+        from agent_hypervisor.program_layer.execution_plan import DirectExecutionPlan
+        # count_words not in world → fallback
+        plan = self.compiler.compile(
+            "count words", world=frozenset({"count_lines", "normalize_text"})
+        )
+        assert isinstance(plan, DirectExecutionPlan)
+
+    def test_world_as_frozenset_allows_workflow(self):
+        from agent_hypervisor.program_layer.execution_plan import ProgramExecutionPlan
+        plan = self.compiler.compile(
+            "count words", world=frozenset({"count_words"})
+        )
+        assert isinstance(plan, ProgramExecutionPlan)
+
+    def test_world_none_imposes_no_filter(self):
+        from agent_hypervisor.program_layer.execution_plan import ProgramExecutionPlan
+        plan = self.compiler.compile("count words", world=None)
+        assert isinstance(plan, ProgramExecutionPlan)
+
+    def test_case_insensitive_matching(self):
+        from agent_hypervisor.program_layer.execution_plan import ProgramExecutionPlan
+        plan = self.compiler.compile("COUNT WORDS in THIS TEXT")
+        assert isinstance(plan, ProgramExecutionPlan)
+
+    def test_extra_patterns_prepended(self):
+        from agent_hypervisor.program_layer.simple_task_compiler import SimpleTaskCompiler
+        from agent_hypervisor.program_layer.execution_plan import ProgramExecutionPlan
+        compiler = SimpleTaskCompiler(
+            extra_patterns=(("count_lines", "audit log"),)
+        )
+        plan = compiler.compile("process the audit log")
+        assert isinstance(plan, ProgramExecutionPlan)
+        assert plan.metadata.get("workflow") == "count_lines"
+
+    def test_compiler_exported_from_package(self):
+        from agent_hypervisor.program_layer import SimpleTaskCompiler  # noqa: F401
+        assert SimpleTaskCompiler.SUPPORTED_WORKFLOWS == frozenset({
+            "count_lines", "count_words", "normalize_text", "word_frequency"
+        })
+
+    def test_count_lines_wins_over_count_words_for_line_input(self):
+        """'count lines' keyword must not accidentally match 'count_words'."""
+        from agent_hypervisor.program_layer.execution_plan import ProgramExecutionPlan
+        plan = self.compiler.compile("how many lines are there?")
+        assert isinstance(plan, ProgramExecutionPlan)
+        assert plan.metadata.get("workflow") == "count_lines"
+
+    def test_end_to_end_string_intent(self):
+        """SimpleTaskCompiler plan is executable by ProgramExecutor."""
+        from agent_hypervisor.program_layer.program_executor import ProgramExecutor
+        from agent_hypervisor.program_layer.execution_plan import ProgramExecutionPlan
+        plan = self.compiler.compile("count the words in this text")
+        assert isinstance(plan, ProgramExecutionPlan)
+        executor = ProgramExecutor()
+        result = executor.execute(plan, context={"input": "hello world foo"})
+        assert result["ok"] is True
+        assert result["result"]["word_count"] == 3
+
+
+# ---------------------------------------------------------------------------
+# 13. World validation (validate_program / validate_step)
+# ---------------------------------------------------------------------------
+
+class TestWorldValidator:
+    def test_valid_program_returns_ok(self):
+        from agent_hypervisor.program_layer.world_validator import validate_program
+        from agent_hypervisor.program_layer.task_compiler import DeterministicTaskCompiler
+        program = make_program(
+            Step(action="count_words", params={"input": "hello"}),
+            Step(action="normalize_text", params={"input": "HELLO"}),
+        )
+        result = validate_program(program, DeterministicTaskCompiler.SUPPORTED_WORKFLOWS)
+        assert result.ok is True
+        assert len(result.violations) == 0
+
+    def test_invalid_action_produces_violation(self):
+        from agent_hypervisor.program_layer.world_validator import validate_program
+        program = make_program(Step(action="send_email"))
+        result = validate_program(program, frozenset({"count_words"}))
+        assert result.ok is False
+        assert len(result.violations) == 1
+        assert result.violations[0].action == "send_email"
+        assert result.violations[0].step_index == 0
+
+    def test_multiple_violations_collected(self):
+        from agent_hypervisor.program_layer.world_validator import validate_program
+        program = make_program(
+            Step(action="bad_action_1"),
+            Step(action="count_words", params={"input": "ok"}),  # allowed
+            Step(action="bad_action_2"),
+        )
+        result = validate_program(program, frozenset({"count_words"}))
+        assert result.ok is False
+        assert len(result.violations) == 2
+        assert result.violations[0].step_index == 0
+        assert result.violations[1].step_index == 2
+
+    def test_empty_allowed_set_denies_everything(self):
+        from agent_hypervisor.program_layer.world_validator import validate_program
+        program = make_program(Step(action="count_words"))
+        result = validate_program(program, frozenset())
+        assert result.ok is False
+        assert len(result.violations) == 1
+
+    def test_validate_program_requires_program(self):
+        from agent_hypervisor.program_layer.world_validator import validate_program
+        with pytest.raises(TypeError, match="Program"):
+            validate_program("not-a-program", frozenset())  # type: ignore[arg-type]
+
+    def test_violation_str_representation(self):
+        from agent_hypervisor.program_layer.world_validator import validate_program
+        program = make_program(Step(action="unknown_op"))
+        result = validate_program(program, frozenset())
+        v = result.violations[0]
+        assert "unknown_op" in str(v)
+        assert "step[0]" in str(v)
+
+    def test_to_dict_shape(self):
+        from agent_hypervisor.program_layer.world_validator import validate_program
+        program = make_program(Step(action="bad_action"))
+        result = validate_program(program, frozenset({"count_words"}))
+        d = result.to_dict()
+        assert d["ok"] is False
+        assert len(d["violations"]) == 1
+        assert d["violations"][0]["step_index"] == 0
+        assert d["violations"][0]["action"] == "bad_action"
+
+    def test_validate_step_valid(self):
+        from agent_hypervisor.program_layer.world_validator import validate_step
+        s = Step(action="count_words")
+        result = validate_step(s, frozenset({"count_words"}))
+        assert result is None
+
+    def test_validate_step_invalid(self):
+        from agent_hypervisor.program_layer.world_validator import validate_step
+        s = Step(action="delete_all")
+        result = validate_step(s, frozenset({"count_words"}), step_index=3)
+        assert result is not None
+        assert result.action == "delete_all"
+        assert result.step_index == 3
+
+    def test_symbols_exported_from_package(self):
+        from agent_hypervisor.program_layer import (  # noqa: F401
+            StepViolation,
+            ValidationResult,
+            validate_program,
+            validate_step,
+        )
+
+
+# ---------------------------------------------------------------------------
+# 14. ProgramTraceStore — JSONL persistence
+# ---------------------------------------------------------------------------
+
+class TestProgramTraceStore:
+    def _make_trace(self, program_id: str = "store-test", ok: bool = True) -> ProgramTrace:
+        t = ProgramTrace(program_id=program_id)
+        t.step_traces.append(
+            StepTrace(
+                step_index=0,
+                action="count_words",
+                verdict="allow" if ok else "deny",
+                result={"word_count": 3} if ok else None,
+                error=None if ok else "denied",
+            )
+        )
+        t.ok = ok
+        t.total_duration_seconds = 0.001
+        return t
+
+    def test_append_creates_file(self, tmp_path):
+        from agent_hypervisor.program_layer.trace_storage import ProgramTraceStore
+        store = ProgramTraceStore(tmp_path / "traces.jsonl")
+        assert not (tmp_path / "traces.jsonl").exists()
+        trace = self._make_trace()
+        store.append(trace)
+        assert (tmp_path / "traces.jsonl").exists()
+
+    def test_append_writes_valid_jsonl(self, tmp_path):
+        import json
+        from agent_hypervisor.program_layer.trace_storage import ProgramTraceStore
+        store = ProgramTraceStore(tmp_path / "traces.jsonl")
+        store.append(self._make_trace("prog-1"))
+        store.append(self._make_trace("prog-2"))
+        lines = (tmp_path / "traces.jsonl").read_text().strip().splitlines()
+        assert len(lines) == 2
+        for line in lines:
+            entry = json.loads(line)  # must not raise
+            assert "program_id" in entry
+            assert "_stored_at" in entry
+
+    def test_list_recent_order(self, tmp_path):
+        from agent_hypervisor.program_layer.trace_storage import ProgramTraceStore
+        store = ProgramTraceStore(tmp_path / "traces.jsonl")
+        store.append(self._make_trace("first"))
+        store.append(self._make_trace("second"))
+        store.append(self._make_trace("third"))
+        recent = store.list_recent(limit=10)
+        # Newest first
+        assert recent[0]["program_id"] == "third"
+        assert recent[2]["program_id"] == "first"
+
+    def test_list_recent_limit(self, tmp_path):
+        from agent_hypervisor.program_layer.trace_storage import ProgramTraceStore
+        store = ProgramTraceStore(tmp_path / "traces.jsonl")
+        for i in range(5):
+            store.append(self._make_trace(f"prog-{i}"))
+        recent = store.list_recent(limit=3)
+        assert len(recent) == 3
+
+    def test_list_recent_filter_ok(self, tmp_path):
+        from agent_hypervisor.program_layer.trace_storage import ProgramTraceStore
+        store = ProgramTraceStore(tmp_path / "traces.jsonl")
+        store.append(self._make_trace("ok-1", ok=True))
+        store.append(self._make_trace("fail-1", ok=False))
+        store.append(self._make_trace("ok-2", ok=True))
+        ok_traces = store.list_recent(ok=True)
+        assert all(t["ok"] is True for t in ok_traces)
+        assert len(ok_traces) == 2
+
+    def test_list_recent_filter_program_id(self, tmp_path):
+        from agent_hypervisor.program_layer.trace_storage import ProgramTraceStore
+        store = ProgramTraceStore(tmp_path / "traces.jsonl")
+        store.append(self._make_trace("alpha"))
+        store.append(self._make_trace("beta"))
+        store.append(self._make_trace("alpha"))
+        results = store.list_recent(program_id="alpha")
+        assert all(t["program_id"] == "alpha" for t in results)
+        assert len(results) == 2
+
+    def test_count(self, tmp_path):
+        from agent_hypervisor.program_layer.trace_storage import ProgramTraceStore
+        store = ProgramTraceStore(tmp_path / "traces.jsonl")
+        assert store.count() == 0
+        store.append(self._make_trace())
+        store.append(self._make_trace())
+        assert store.count() == 2
+
+    def test_nonexistent_file_returns_empty_list(self, tmp_path):
+        from agent_hypervisor.program_layer.trace_storage import ProgramTraceStore
+        store = ProgramTraceStore(tmp_path / "no_such_file.jsonl")
+        assert store.list_recent() == []
+        assert store.count() == 0
+
+    def test_append_requires_program_trace(self, tmp_path):
+        from agent_hypervisor.program_layer.trace_storage import ProgramTraceStore
+        store = ProgramTraceStore(tmp_path / "traces.jsonl")
+        with pytest.raises(TypeError, match="ProgramTrace"):
+            store.append({"not": "a trace"})  # type: ignore[arg-type]
+
+    def test_creates_parent_directories(self, tmp_path):
+        from agent_hypervisor.program_layer.trace_storage import ProgramTraceStore
+        store = ProgramTraceStore(tmp_path / "deep" / "nested" / "traces.jsonl")
+        store.append(self._make_trace())
+        assert (tmp_path / "deep" / "nested" / "traces.jsonl").exists()
+
+    def test_stored_at_is_iso8601(self, tmp_path):
+        import json
+        from agent_hypervisor.program_layer.trace_storage import ProgramTraceStore
+        store = ProgramTraceStore(tmp_path / "traces.jsonl")
+        store.append(self._make_trace())
+        line = (tmp_path / "traces.jsonl").read_text().strip()
+        entry = json.loads(line)
+        # _stored_at must be a non-empty ISO-8601 string
+        assert isinstance(entry["_stored_at"], str)
+        assert "T" in entry["_stored_at"]
+
+    def test_store_exported_from_package(self):
+        from agent_hypervisor.program_layer import ProgramTraceStore  # noqa: F401
+
+    def test_integration_run_and_store(self, tmp_path):
+        """End-to-end: run a program and persist its trace."""
+        from agent_hypervisor.program_layer.trace_storage import ProgramTraceStore
+        store = ProgramTraceStore(tmp_path / "run_traces.jsonl")
+
+        runner = ProgramRunner()
+        program = Program(
+            program_id="store-integration",
+            steps=(Step(action="count_words", params={"input": "hello world foo"}),),
+        )
+        trace = runner.run(program)
+        store.append(trace)
+
+        recent = store.list_recent()
+        assert len(recent) == 1
+        assert recent[0]["program_id"] == "store-integration"
+        assert recent[0]["ok"] is True
+        assert recent[0]["step_traces"][0]["result"]["word_count"] == 3


### PR DESCRIPTION
Implements the full Phase 1 spec for executable programs in the program layer.
Programs orchestrate; the World Kernel decides what is possible.

New files:
- simple_task_compiler.py: SimpleTaskCompiler with keyword matching for string
  intents and dict dispatch. Falls back to DirectExecutionPlan for unknown
  intents. World-aware: filters allowed workflows by caller-supplied constraint.
- world_validator.py: validate_program() for static pre-execution checks.
  Collects all step violations before returning (not just the first).
  validate_step() for single-step validation. Returns ValidationResult with
  StepViolation details.
- trace_storage.py: ProgramTraceStore — append-only JSONL store for
  ProgramTrace objects. Stores to_dict() + _stored_at ISO-8601 timestamp.
  list_recent() with ok/program_id filters; count(); creates parent dirs.

Modified:
- program_model.py: Add Step.description (Optional[str], excluded from
  equality/hash). Backward-compatible; default is None.
- __init__.py: Export SimpleTaskCompiler, validate_program, validate_step,
  ValidationResult, StepViolation, ProgramTraceStore. Update module docstring.
- docs/program_layer.md: Rewrite with Phase 1 executable programs section,
  full flow diagram, example ProgramExecutionPlan, example JSONL traces,
  validation explanation, sandbox enforcement table, limitation list.

Tests: 99 tests (was 54), all passing. New coverage:
- Step.description field (5 tests)
- SimpleTaskCompiler keyword matching, world filtering, fallback (17 tests)
- validate_program / validate_step, ValidationResult shape (10 tests)
- ProgramTraceStore append/read/filter/integration (13 tests)

https://claude.ai/code/session_01SKS9SPsEPuuHcaMkVYUi9U