### PR TITLE
Add SYS-2 light: program–world compatibility & replay under worlds

### DIFF
--- a/docs/program-lifecycle.md
+++ b/docs/program-lifecycle.md
@@ -215,6 +215,34 @@ trace = engine.replay(prog, context={"input": "hello world"})
 
 ---
 
+## CLI
+
+The same lifecycle is available as `awc program` subcommands (store defaults to `./programs/`):
+
+```bash
+# Propose from a JSON step list — prints the new program id
+awc program propose --steps-json steps.json --trace-id t-001 --world-version 1.0
+
+# Apply minimization and print the diff
+awc program minimize --id prog-<hex>
+
+# Advance lifecycle
+awc program review  --id prog-<hex> --notes "LGTM"
+awc program accept  --id prog-<hex>           # runs world validation first
+awc program reject  --id prog-<hex> --reason "not needed"
+
+# Replay the minimized program through the same enforcement pipeline
+awc program replay --id prog-<hex>
+
+# Inspect the store
+awc program list
+awc program show --id prog-<hex>
+```
+
+Exit codes: `0` success, `1` bad input / not found, `2` invalid lifecycle transition, `3` world validation failed on accept, `4` replay produced a failed trace.
+
+---
+
 ## Limitations
 
 1. **No data-flow analysis.** Minimization does not track which step's output feeds into the next step's input. A step that appears redundant structurally may carry output consumed by a later step — the minimizer only removes consecutive duplicates, not dead code.

--- a/docs/program-world-compatibility.md
+++ b/docs/program-world-compatibility.md
@@ -1,0 +1,138 @@
+# Program–World Compatibility (SYS-2 light)
+
+## 1. Why this phase exists
+
+A reviewed and accepted program is a **reusable structure** — the minimal set of steps that accomplished a task. But it is **not a reusable authority**. Worlds grant authority; programs do not carry it.
+
+Before SYS-2 light, a reviewed program could be replayed against the World it was accepted under. After SYS-2 light, the same program can be re-checked and replayed under **any** registered World — and the World's current rules always decide.
+
+> World = constitution
+> Program = reviewed procedure
+> Preview = constitutional review
+> Replay = lawful execution under current constitution
+>
+> A reviewed program is reusable. Its authority is not.
+
+This is the non-negotiable invariant: *historical acceptance does not override the currently active World.*
+
+---
+
+## 2. Active world vs selected world
+
+SYS-2 light distinguishes three ways a World can become a replay's authority boundary. The choice is recorded on every `ReplayTrace` via `world_source`:
+
+| `world_source` | Meaning |
+|---|---|
+| `active`   | Fetched from the registry's active-pointer (`.active.json`) — the ambient, globally-selected World. |
+| `explicit` | Passed by the caller for this one replay only. Does not change the active pointer. |
+| `default`  | No world context was provided; the default `SUPPORTED_WORKFLOWS` set was used. Useful for tests and for the legacy replay path. |
+
+Switching the active World is explicit: `WorldRegistry.set_active(world_id, version)` validates the target first and rolls back if loading fails, so a bad switch never corrupts the existing active pointer.
+
+---
+
+## 3. Compatibility preview
+
+`check_compatibility(program, world)` (and its registry-aware wrapper `preview_program_under_world(...)`) is a **pure deterministic validation pass**. It:
+
+- walks each `CandidateStep` in `program.minimized_steps`;
+- delegates per-step checking to `world_validator.validate_step` so the authority logic stays in one place;
+- returns a `ProgramWorldCompatibility` carrying `compatible`, per-step `StepCompatibility` verdicts, and a `CompatibilitySummary` with denied-action counts.
+
+Preview **does not execute**. Nothing runs. Nothing mutates. The same `(program, world)` pair always produces the same verdict — the byte-identical JSON from `to_dict()`.
+
+---
+
+## 4. Replay semantics
+
+`ReplayEngine.replay_under_world(program, world, ...)` replays a program under a specific World and returns a `ReplayTrace`. The trace records:
+
+- `replay_id`, `program_id`, `replayed_at`
+- `world_id`, `world_version`, `world_source`
+- the optional `preview_compatible` verdict if the caller ran a preview first
+- the underlying `ProgramTrace` (per-step verdicts)
+- `final_verdict` — one of:
+  - `allow` — every step succeeded;
+  - `deny` — the first step was denied (nothing executed);
+  - `partial_failure` — some steps executed before a later deny.
+
+The World's `allowed_actions` becomes the replay's authority boundary, regardless of which World the program was accepted against. Static world validation runs *before* execution — an incompatible step short-circuits the whole replay, so a `deny` verdict from `replay_under_world` means the runtime path was never entered.
+
+The legacy `ReplayEngine.replay(program)` is unchanged and still returns a bare `ProgramTrace`.
+
+---
+
+## 5. Cross-world divergence
+
+`compare_program_across_worlds(program_id, world_a_id, world_a_version, world_b_id, world_b_version, store, registry)` runs the compatibility check under both Worlds and returns a `ProgramWorldDiff`.
+
+A **divergence point** is a step where one World allows the action and the other denies it. Steps that agree — allowed by both, denied by both — are not emitted. `both_compatible` is True only when the program is fully compatible under both Worlds.
+
+Reading the diff:
+
+```
+step[1] 'normalize_text'
+  world_a: denied: action not in allowed set; allowed: ['count_lines', 'count_words']
+  world_b: allowed
+  reason : world_strict denies 'normalize_text' (...)
+```
+
+This is the minimal comparative surface SYS-2 light needs; it is not a full comparative playground.
+
+---
+
+## 6. CLI walk-through
+
+```bash
+# List the bundled example worlds (active world marked with ●)
+awc world list --worlds-dir src/agent_hypervisor/program_layer/worlds
+
+# Switch the ambient active World (validates first, rolls back on failure)
+awc world activate --id world_balanced --version 1.0 \
+    --worlds-dir src/agent_hypervisor/program_layer/worlds
+
+# Show the currently active World
+awc world show --worlds-dir src/agent_hypervisor/program_layer/worlds
+
+# Preview a reviewed program under a specific World (exit code 3 if incompatible)
+awc program preview --id prog-sys2-demo --world world_strict --version 1.0 \
+    --store ./programs --worlds-dir src/agent_hypervisor/program_layer/worlds
+
+# Compare across two Worlds
+awc program compare --id prog-sys2-demo \
+    --world-a world_strict --world-a-version 1.0 \
+    --world-b world_balanced --world-b-version 1.0 \
+    --store ./programs --worlds-dir src/agent_hypervisor/program_layer/worlds
+
+# Replay under a specific World (exit code 4 on deny, 5 on partial_failure).
+# --world is optional — omit it to fall back to the active World.
+awc program replay-under-world --id prog-sys2-demo \
+    --world world_balanced --version 1.0 \
+    --store ./programs --worlds-dir src/agent_hypervisor/program_layer/worlds
+```
+
+The full scripted flow is in `examples/program_world_compatibility_demo.py`.
+
+---
+
+## 7. Example divergence
+
+The bundled worlds differ by a single action:
+
+- `world_strict` allows `{count_lines, count_words}`.
+- `world_balanced` allows `{count_lines, count_words, normalize_text, word_frequency}`.
+
+A program with `count_words` + `normalize_text` is **compatible under `world_balanced`** (replay → `allow`) and **incompatible under `world_strict`** (replay → `deny`, nothing executes). Same bytes on disk, different Worlds, different verdicts — which is exactly the point.
+
+---
+
+## 8. Limitations (deliberate)
+
+SYS-2 light is a focused bridge phase, not a control plane:
+
+- World identity is a YAML file plus a set of action names. No CompiledPolicy, no schema validation beyond action membership, no provenance rules here.
+- No policy editor, no UI beyond the CLI, no diff UI.
+- No mutation of the existing enforcement path — `IRBuilder`, taint, executor, and proxy are untouched.
+- The "latest version" fallback in `WorldRegistry.get` is lexicographic; semantic versioning is a future concern.
+
+What SYS-2 light *does* establish: a reviewed program is re-validated against a World on every replay, the choice of World is explicit and auditable, and the current World always wins.

--- a/examples/program_world_compatibility_demo.py
+++ b/examples/program_world_compatibility_demo.py
@@ -1,0 +1,246 @@
+"""
+program_world_compatibility_demo.py — SYS-2 light end-to-end demonstration.
+
+Same program, different World, different verdict.
+
+Flow:
+    1. Create an empty ProgramStore and a WorldRegistry seeded with two
+       worlds (world_strict, world_balanced).
+    2. Propose → minimize → review → accept a program that uses
+       count_words + normalize_text.
+    3. List the registered worlds.
+    4. Preview the accepted program under world_strict  → expect incompatible
+       (world_strict does NOT allow normalize_text).
+    5. Preview the accepted program under world_balanced → expect compatible.
+    6. compare_program_across_worlds → print the divergence point.
+    7. Replay under world_balanced  → allow.
+    8. Replay under world_strict    → deny before execution.
+
+The takeaway: historical acceptance does not grant ongoing authority.
+The current World always decides.
+
+Run:
+    python examples/program_world_compatibility_demo.py
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import sys
+import tempfile
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+from agent_hypervisor.program_layer import (
+    CandidateStep,
+    ProgramStore,
+    ReplayEngine,
+    WorldRegistry,
+    accept_program,
+    check_compatibility,
+    compare_program_across_worlds,
+    minimize_program,
+    preview_program_under_world,
+    propose_program,
+    review_program,
+)
+from agent_hypervisor.program_layer.task_compiler import DeterministicTaskCompiler
+
+
+BUNDLED_WORLDS_DIR = (
+    Path(__file__).parent.parent
+    / "src" / "agent_hypervisor" / "program_layer" / "worlds"
+)
+
+
+def _sep(title: str) -> None:
+    print(f"\n{'─' * 64}")
+    print(f"  {title}")
+    print("─" * 64)
+
+
+def _print_compat(compat) -> None:
+    verdict = "COMPATIBLE" if compat.compatible else "INCOMPATIBLE"
+    print(
+        f"\n  program={compat.program_id}  world={compat.world_id}@{compat.world_version}  "
+        f"→ {verdict}"
+    )
+    for sr in compat.step_results:
+        mark = "✓" if sr.allowed else "✗"
+        print(f"    {mark} step[{sr.step_index}] {sr.action!r}  {sr.reason}")
+    s = compat.summary
+    print(f"  summary: allowed={s.allowed_steps}  denied={s.denied_steps}  "
+          f"restricted={list(s.restricted_actions)}")
+
+
+def _print_diff(diff) -> None:
+    print(f"\n  program={diff.program_id}")
+    print(f"  world_a={diff.world_a['id']}@{diff.world_a['version']}  "
+          f"world_b={diff.world_b['id']}@{diff.world_b['version']}")
+    print(f"  both_compatible={diff.both_compatible}")
+    if not diff.divergence_points:
+        print("  (no divergence points — worlds agree on every step)")
+        return
+    print("  divergence_points:")
+    for d in diff.divergence_points:
+        print(f"    step[{d.step_index}] {d.action!r}")
+        print(f"      world_a: {d.world_a}")
+        print(f"      world_b: {d.world_b}")
+        print(f"      reason : {d.reason}")
+
+
+def _print_replay(rt) -> None:
+    print(
+        f"\n  replay={rt.replay_id}  program={rt.program_id}  "
+        f"world={rt.world_id}@{rt.world_version} (source={rt.world_source})"
+    )
+    print(f"  preview_compatible={rt.preview_compatible}  final_verdict={rt.final_verdict}")
+    for st in rt.program_trace.step_traces:
+        mark = "✓" if st.verdict == "allow" else "✗"
+        print(f"    {mark} step[{st.step_index}] {st.action!r}  "
+              f"verdict={st.verdict}  error={st.error}")
+
+
+def run_demo() -> None:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+
+        # ----------------------------------------------------------------
+        # Step 1: Set up store + registry (copy bundled worlds in)
+        # ----------------------------------------------------------------
+        _sep("STEP 1 — Set up ProgramStore and WorldRegistry")
+        store = ProgramStore(tmp / "programs")
+        worlds_dir = tmp / "worlds"
+        worlds_dir.mkdir()
+        for yaml in BUNDLED_WORLDS_DIR.glob("*.yaml"):
+            shutil.copy(yaml, worlds_dir / yaml.name)
+        registry = WorldRegistry(worlds_dir=worlds_dir, active_file=tmp / "active.json")
+        print(f"\n  programs dir: {tmp / 'programs'}")
+        print(f"  worlds dir:   {worlds_dir}")
+
+        # ----------------------------------------------------------------
+        # Step 2: Propose → minimize → review → accept
+        # ----------------------------------------------------------------
+        _sep("STEP 2 — Accept a program via PL-3 lifecycle")
+        steps = [
+            CandidateStep(tool="count_words", params={"input": "the quick brown fox"}),
+            CandidateStep(tool="normalize_text", params={"input": "HELLO WORLD"}),
+        ]
+        prog = propose_program(
+            steps=steps,
+            trace_id="demo-trace-001",
+            world_version="1.0",
+            store=store,
+            program_id="prog-sys2-demo",
+        )
+        minimize_program(prog.id, store)
+        review_program(prog.id, store, notes="Demo program for SYS-2 light.")
+        accept_program(
+            prog.id,
+            store,
+            allowed_actions=DeterministicTaskCompiler.SUPPORTED_WORKFLOWS,
+        )
+        accepted = store.load(prog.id)
+        print(f"\n  id={accepted.id}  status={accepted.status.value}  "
+              f"steps={len(accepted.minimized_steps)}")
+
+        # ----------------------------------------------------------------
+        # Step 3: List worlds
+        # ----------------------------------------------------------------
+        _sep("STEP 3 — List available worlds")
+        for w in registry.list_worlds():
+            print(f"  {w.world_id}@{w.version}  actions={sorted(w.allowed_actions)}")
+
+        # ----------------------------------------------------------------
+        # Step 4: Preview under world_strict (expect incompatible)
+        # ----------------------------------------------------------------
+        _sep("STEP 4 — Preview under world_strict")
+        strict = registry.get("world_strict", "1.0")
+        compat_strict = check_compatibility(accepted, strict)
+        _print_compat(compat_strict)
+
+        # ----------------------------------------------------------------
+        # Step 5: Preview under world_balanced (expect compatible)
+        # ----------------------------------------------------------------
+        _sep("STEP 5 — Preview under world_balanced")
+        balanced = registry.get("world_balanced", "1.0")
+        compat_balanced = preview_program_under_world(
+            program_id=accepted.id,
+            world_id="world_balanced",
+            version="1.0",
+            store=store,
+            registry=registry,
+        )
+        _print_compat(compat_balanced)
+
+        # ----------------------------------------------------------------
+        # Step 6: Compare across worlds
+        # ----------------------------------------------------------------
+        _sep("STEP 6 — Compare across worlds")
+        diff = compare_program_across_worlds(
+            program_id=accepted.id,
+            world_a_id="world_strict",
+            world_a_version="1.0",
+            world_b_id="world_balanced",
+            world_b_version="1.0",
+            store=store,
+            registry=registry,
+        )
+        _print_diff(diff)
+
+        # ----------------------------------------------------------------
+        # Step 7: Replay under world_balanced (allow)
+        # ----------------------------------------------------------------
+        _sep("STEP 7 — Replay under world_balanced")
+        engine = ReplayEngine()
+        rt_balanced = engine.replay_under_world(
+            accepted,
+            balanced,
+            preview_compatible=compat_balanced.compatible,
+        )
+        _print_replay(rt_balanced)
+
+        # ----------------------------------------------------------------
+        # Step 8: Replay under world_strict (deny before execution)
+        # ----------------------------------------------------------------
+        _sep("STEP 8 — Replay under world_strict")
+        rt_strict = engine.replay_under_world(
+            accepted,
+            strict,
+            preview_compatible=compat_strict.compatible,
+        )
+        _print_replay(rt_strict)
+
+        # ----------------------------------------------------------------
+        # Summary
+        # ----------------------------------------------------------------
+        _sep("SUMMARY")
+        print(f"""
+  Program                : {accepted.id}  ({len(accepted.minimized_steps)} step(s))
+  world_strict  preview  : {'compatible' if compat_strict.compatible else 'INCOMPATIBLE'}
+  world_balanced preview : {'compatible' if compat_balanced.compatible else 'INCOMPATIBLE'}
+  Divergence points      : {len(diff.divergence_points)}
+  Replay in balanced     : {rt_balanced.final_verdict}
+  Replay in strict       : {rt_strict.final_verdict}
+
+  Moral: the program is the same. The World is what decides.
+""")
+
+        # Emit a single JSON blob with all the artifacts for audit/offline use.
+        artifacts = {
+            "program_id": accepted.id,
+            "preview_strict": compat_strict.to_dict(),
+            "preview_balanced": compat_balanced.to_dict(),
+            "diff": diff.to_dict(),
+            "replay_balanced": rt_balanced.to_dict(),
+            "replay_strict": rt_strict.to_dict(),
+        }
+        print("  JSON artifacts (first 400 chars):")
+        blob = json.dumps(artifacts, default=str)
+        print("  " + blob[:400] + ("…" if len(blob) > 400 else ""))
+
+
+if __name__ == "__main__":
+    run_demo()

--- a/src/agent_hypervisor/compiler/cli.py
+++ b/src/agent_hypervisor/compiler/cli.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import json
+import sys
 from pathlib import Path
 
 import click
@@ -491,3 +493,192 @@ def cmd_run(scenario: str, rendered: bool, manifest_path: str | None, compare: b
     click.echo()
     click.echo(_col("=" * 62, _BOLD))
     click.echo()
+
+
+# ── program lifecycle (PL-3) ─────────────────────────────────────────────────
+#
+# Thin CLI wrapper over program_layer.review_lifecycle and ReplayEngine.
+# No enforcement logic lives here — every command delegates to the Python API.
+
+
+_DEFAULT_PROGRAM_STORE = "./programs"
+
+
+def _program_store(directory: str):
+    from agent_hypervisor.program_layer import ProgramStore
+    return ProgramStore(directory)
+
+
+def _fail(msg: str, code: int = 1) -> None:
+    click.echo(_col(msg, _RED), err=True)
+    raise SystemExit(code)
+
+
+@cli.group("program")
+def cmd_program():
+    """Manage reviewed programs (PL-3: propose, minimize, review, accept, replay)."""
+
+
+@cmd_program.command("propose")
+@click.option("--steps-json", "steps_json", required=True, type=click.Path(exists=True),
+              help="JSON file: a list of {tool, params, provenance?, capabilities_used?} entries.")
+@click.option("--trace-id", "trace_id", default=None, help="Trace id this program was extracted from.")
+@click.option("--world-version", "world_version", required=True, help="World manifest version at creation time.")
+@click.option("--store", "store_dir", default=_DEFAULT_PROGRAM_STORE, show_default=True,
+              help="Directory holding program JSON files.")
+def cmd_program_propose(steps_json: str, trace_id: str | None, world_version: str, store_dir: str):
+    """Create a PROPOSED ReviewedProgram from a JSON step list."""
+    from agent_hypervisor.program_layer import CandidateStep, propose_program
+
+    raw = json.loads(Path(steps_json).read_text(encoding="utf-8"))
+    if not isinstance(raw, list) or not raw:
+        _fail("--steps-json must contain a non-empty JSON array of step objects.")
+    try:
+        steps = [CandidateStep.from_dict(s) for s in raw]
+    except (KeyError, TypeError, ValueError) as exc:
+        _fail(f"Invalid step in --steps-json: {exc}")
+
+    prog = propose_program(
+        steps=steps,
+        trace_id=trace_id,
+        world_version=world_version,
+        store=_program_store(store_dir),
+    )
+    click.echo(prog.id)
+
+
+@cmd_program.command("minimize")
+@click.option("--id", "program_id", required=True, help="Program id to minimize.")
+@click.option("--store", "store_dir", default=_DEFAULT_PROGRAM_STORE, show_default=True)
+def cmd_program_minimize(program_id: str, store_dir: str):
+    """Apply deterministic minimization and print the resulting diff."""
+    from agent_hypervisor.program_layer import minimize_program
+
+    try:
+        prog = minimize_program(program_id, _program_store(store_dir))
+    except KeyError as exc:
+        _fail(f"Program not found: {exc}")
+    _print_program_diff(prog.diff)
+
+
+@cmd_program.command("review")
+@click.option("--id", "program_id", required=True)
+@click.option("--notes", default=None, help="Optional reviewer notes.")
+@click.option("--store", "store_dir", default=_DEFAULT_PROGRAM_STORE, show_default=True)
+def cmd_program_review(program_id: str, notes: str | None, store_dir: str):
+    """Transition PROPOSED → REVIEWED."""
+    from agent_hypervisor.program_layer import InvalidTransitionError, review_program
+
+    try:
+        prog = review_program(program_id, _program_store(store_dir), notes=notes)
+    except KeyError as exc:
+        _fail(f"Program not found: {exc}")
+    except InvalidTransitionError as exc:
+        _fail(str(exc), code=2)
+    click.echo(f"{prog.id}: {prog.status.value}")
+
+
+@cmd_program.command("accept")
+@click.option("--id", "program_id", required=True)
+@click.option("--store", "store_dir", default=_DEFAULT_PROGRAM_STORE, show_default=True)
+def cmd_program_accept(program_id: str, store_dir: str):
+    """Transition REVIEWED → ACCEPTED (runs world validation first)."""
+    from agent_hypervisor.program_layer import (
+        InvalidTransitionError,
+        WorldValidationError,
+        accept_program,
+    )
+
+    try:
+        prog = accept_program(program_id, _program_store(store_dir))
+    except KeyError as exc:
+        _fail(f"Program not found: {exc}")
+    except InvalidTransitionError as exc:
+        _fail(str(exc), code=2)
+    except WorldValidationError as exc:
+        _fail(str(exc), code=3)
+    click.echo(f"{prog.id}: {prog.status.value}")
+
+
+@cmd_program.command("reject")
+@click.option("--id", "program_id", required=True)
+@click.option("--reason", default=None, help="Optional rejection reason, appended to reviewer_notes.")
+@click.option("--store", "store_dir", default=_DEFAULT_PROGRAM_STORE, show_default=True)
+def cmd_program_reject(program_id: str, reason: str | None, store_dir: str):
+    """Transition REVIEWED → REJECTED."""
+    from agent_hypervisor.program_layer import InvalidTransitionError, reject_program
+
+    try:
+        prog = reject_program(program_id, _program_store(store_dir), reason=reason)
+    except KeyError as exc:
+        _fail(f"Program not found: {exc}")
+    except InvalidTransitionError as exc:
+        _fail(str(exc), code=2)
+    click.echo(f"{prog.id}: {prog.status.value}")
+
+
+@cmd_program.command("replay")
+@click.option("--id", "program_id", required=True)
+@click.option("--store", "store_dir", default=_DEFAULT_PROGRAM_STORE, show_default=True)
+def cmd_program_replay(program_id: str, store_dir: str):
+    """Replay the minimized program through the same enforcement pipeline as live execution."""
+    from agent_hypervisor.program_layer import ReplayEngine
+
+    try:
+        prog = _program_store(store_dir).load(program_id)
+    except KeyError as exc:
+        _fail(f"Program not found: {exc}")
+    trace = ReplayEngine().replay(prog)
+    json.dump(trace.to_dict(), sys.stdout, indent=2, default=str)
+    click.echo()
+    if not trace.ok:
+        raise SystemExit(4)
+
+
+@cmd_program.command("list")
+@click.option("--store", "store_dir", default=_DEFAULT_PROGRAM_STORE, show_default=True)
+def cmd_program_list(store_dir: str):
+    """List stored programs (id, status, step counts, created_at)."""
+    summaries = _program_store(store_dir).list_all()
+    if not summaries:
+        click.echo(_col("(no programs)", _DIM))
+        return
+    click.echo(f"{'id':<22} {'status':<10} {'orig':>5} {'min':>5}  created_at")
+    click.echo(_col("─" * 72, _DIM))
+    for s in summaries:
+        click.echo(
+            f"{s['id']:<22} {s['status']:<10} "
+            f"{s['step_count_original']:>5} {s['step_count_minimized']:>5}  "
+            f"{s['created_at']}"
+        )
+
+
+@cmd_program.command("show")
+@click.option("--id", "program_id", required=True)
+@click.option("--store", "store_dir", default=_DEFAULT_PROGRAM_STORE, show_default=True)
+def cmd_program_show(program_id: str, store_dir: str):
+    """Print a stored program as JSON."""
+    try:
+        prog = _program_store(store_dir).load(program_id)
+    except KeyError as exc:
+        _fail(f"Program not found: {exc}")
+    json.dump(prog.to_dict(), sys.stdout, indent=2, default=str)
+    click.echo()
+
+
+def _print_program_diff(diff) -> None:
+    if diff.is_empty:
+        click.echo(_col("(no changes — program was already minimal)", _DIM))
+        return
+    for r in diff.removed_steps:
+        click.echo(f"  {_col('REMOVED', _RED)}  step[{r.index}] {r.tool!r}  — {r.reason}")
+    for c in diff.param_changes:
+        click.echo(
+            f"  {_col('PARAM  ', _YELLOW)}  step[{c.step_index}] {c.field!r}: "
+            f"{c.before!r}  →  {c.after!r}  — {c.reason}"
+        )
+    for c in diff.capability_reduction:
+        click.echo(
+            f"  {_col('CAP    ', _YELLOW)}  step[{c.step_index}] "
+            f"{c.before!r}  →  {c.after!r}  — {c.reason}"
+        )

--- a/src/agent_hypervisor/compiler/cli.py
+++ b/src/agent_hypervisor/compiler/cli.py
@@ -682,3 +682,247 @@ def _print_program_diff(diff) -> None:
             f"  {_col('CAP    ', _YELLOW)}  step[{c.step_index}] "
             f"{c.before!r}  →  {c.after!r}  — {c.reason}"
         )
+
+
+# ── world registry (SYS-2 light) ─────────────────────────────────────────────
+#
+# Thin CLI wrapper over program_layer.world_registry.  Worlds live in a
+# directory of YAML manifests; --worlds-dir selects the directory.  The
+# registry owns a small .active.json pointer; set_active/clear commands
+# manage it.  No enforcement logic lives here.
+
+
+def _default_worlds_dir() -> str:
+    from pathlib import Path as _P
+    return str(_P(__file__).parent.parent / "program_layer" / "worlds")
+
+
+def _world_registry(worlds_dir: str):
+    from agent_hypervisor.program_layer import WorldRegistry
+    return WorldRegistry(worlds_dir)
+
+
+@cli.group("world")
+def cmd_world():
+    """Manage world registry (SYS-2 light: list / activate / show)."""
+
+
+@cmd_world.command("list")
+@click.option("--worlds-dir", "worlds_dir", default=_default_worlds_dir,
+              show_default=True, help="Directory of world YAML manifests.")
+def cmd_world_list(worlds_dir: str):
+    """List all worlds under --worlds-dir with their allowed_actions counts."""
+    registry = _world_registry(worlds_dir)
+    worlds = registry.list_worlds()
+    active = registry.get_active()
+    active_key = active.key if active else None
+    if not worlds:
+        click.echo(_col("(no worlds)", _DIM))
+        return
+    click.echo(f"{'world_id':<18} {'version':<8} {'actions':>7}  description")
+    click.echo(_col("─" * 72, _DIM))
+    for w in worlds:
+        marker = _col("●", _GREEN) if w.key == active_key else " "
+        click.echo(
+            f"{marker} {w.world_id:<16} {w.version:<8} "
+            f"{len(w.allowed_actions):>7}  {w.description.strip().splitlines()[0] if w.description.strip() else ''}"
+        )
+
+
+@cmd_world.command("show")
+@click.option("--worlds-dir", "worlds_dir", default=_default_worlds_dir, show_default=True)
+def cmd_world_show(worlds_dir: str):
+    """Show the currently active world (id, version, allowed_actions)."""
+    registry = _world_registry(worlds_dir)
+    active = registry.get_active()
+    if active is None:
+        click.echo(_col("(no active world)", _DIM))
+        raise SystemExit(1)
+    click.echo(json.dumps(active.to_dict(), indent=2))
+
+
+@cmd_world.command("activate")
+@click.option("--id", "world_id", required=True, help="World id to activate.")
+@click.option("--version", default=None, help="World version. Defaults to latest.")
+@click.option("--worlds-dir", "worlds_dir", default=_default_worlds_dir, show_default=True)
+def cmd_world_activate(world_id: str, version: str | None, worlds_dir: str):
+    """Mark a world as active.  Validates the target before writing."""
+    from agent_hypervisor.program_layer import WorldNotFoundError
+
+    registry = _world_registry(worlds_dir)
+    # If version is None, resolve the latest first so the echoed version is concrete.
+    try:
+        resolved = registry.get(world_id, version)
+        active = registry.set_active(resolved.world_id, resolved.version)
+    except WorldNotFoundError as exc:
+        _fail(str(exc))
+    click.echo(f"active: {active.world_id} {active.version}")
+
+
+@cmd_world.command("deactivate")
+@click.option("--worlds-dir", "worlds_dir", default=_default_worlds_dir, show_default=True)
+def cmd_world_deactivate(worlds_dir: str):
+    """Clear the active-world pointer."""
+    _world_registry(worlds_dir).clear_active()
+    click.echo("active: (none)")
+
+
+# ── program × world (SYS-2 light) ────────────────────────────────────────────
+
+
+def _resolve_world(registry, world_id: str | None, version: str | None,
+                   required: bool = False):
+    """
+    Resolve a WorldDescriptor from --world/--world-version, falling back to
+    the registry's active pointer.  Returns (world, source) where source is
+    'explicit', 'active', or 'default' (when world is None).
+    """
+    from agent_hypervisor.program_layer import WorldNotFoundError
+
+    if world_id:
+        try:
+            return registry.get(world_id, version), "explicit"
+        except WorldNotFoundError as exc:
+            _fail(str(exc))
+    active = registry.get_active()
+    if active is not None:
+        return active, "active"
+    if required:
+        _fail("No world specified and no active world set. "
+              "Pass --world <id> or run `awc world activate --id <id>`.")
+    return None, "default"
+
+
+@cmd_program.command("preview")
+@click.option("--id", "program_id", required=True, help="Program id to preview.")
+@click.option("--world", "world_id", required=True, help="World id to preview against.")
+@click.option("--version", default=None, help="World version (defaults to latest).")
+@click.option("--store", "store_dir", default=_DEFAULT_PROGRAM_STORE, show_default=True)
+@click.option("--worlds-dir", "worlds_dir", default=_default_worlds_dir, show_default=True)
+def cmd_program_preview(program_id: str, world_id: str, version: str | None,
+                        store_dir: str, worlds_dir: str):
+    """Preview a program's compatibility under a world (no execution)."""
+    from agent_hypervisor.program_layer import preview_program_under_world
+
+    try:
+        verdict = preview_program_under_world(
+            program_id=program_id,
+            world_id=world_id,
+            version=version,
+            store=_program_store(store_dir),
+            registry=_world_registry(worlds_dir),
+        )
+    except KeyError as exc:
+        _fail(f"Not found: {exc}")
+    _print_compatibility(verdict)
+    if not verdict.compatible:
+        raise SystemExit(3)
+
+
+@cmd_program.command("compare")
+@click.option("--id", "program_id", required=True)
+@click.option("--world-a", "world_a_id", required=True, help="First world id.")
+@click.option("--world-a-version", "world_a_version", default=None)
+@click.option("--world-b", "world_b_id", required=True, help="Second world id.")
+@click.option("--world-b-version", "world_b_version", default=None)
+@click.option("--store", "store_dir", default=_DEFAULT_PROGRAM_STORE, show_default=True)
+@click.option("--worlds-dir", "worlds_dir", default=_default_worlds_dir, show_default=True)
+def cmd_program_compare(program_id: str, world_a_id: str, world_a_version: str | None,
+                        world_b_id: str, world_b_version: str | None,
+                        store_dir: str, worlds_dir: str):
+    """Compare a program's compatibility across two worlds."""
+    from agent_hypervisor.program_layer import compare_program_across_worlds
+
+    try:
+        diff = compare_program_across_worlds(
+            program_id=program_id,
+            world_a_id=world_a_id,
+            world_a_version=world_a_version,
+            world_b_id=world_b_id,
+            world_b_version=world_b_version,
+            store=_program_store(store_dir),
+            registry=_world_registry(worlds_dir),
+        )
+    except KeyError as exc:
+        _fail(f"Not found: {exc}")
+    _print_program_world_diff(diff)
+
+
+@cmd_program.command("replay-under-world")
+@click.option("--id", "program_id", required=True)
+@click.option("--world", "world_id", default=None, help="World id. Defaults to active.")
+@click.option("--version", default=None, help="World version. Defaults to latest.")
+@click.option("--no-preview", is_flag=True, default=False,
+              help="Skip the compatibility preview pass before replay.")
+@click.option("--store", "store_dir", default=_DEFAULT_PROGRAM_STORE, show_default=True)
+@click.option("--worlds-dir", "worlds_dir", default=_default_worlds_dir, show_default=True)
+def cmd_program_replay_under_world(program_id: str, world_id: str | None,
+                                   version: str | None, no_preview: bool,
+                                   store_dir: str, worlds_dir: str):
+    """Replay a program under a specific world, recording world context in the trace."""
+    from agent_hypervisor.program_layer import (
+        ReplayEngine,
+        check_compatibility,
+    )
+
+    store = _program_store(store_dir)
+    registry = _world_registry(worlds_dir)
+
+    try:
+        prog = store.load(program_id)
+    except KeyError as exc:
+        _fail(f"Program not found: {exc}")
+
+    world, source = _resolve_world(registry, world_id, version, required=False)
+
+    preview = None
+    if world is not None and not no_preview:
+        preview = check_compatibility(prog, world).compatible
+
+    trace = ReplayEngine().replay_under_world(
+        program=prog,
+        world=world,
+        world_source=source,
+        preview_compatible=preview,
+    )
+
+    json.dump(trace.to_dict(), sys.stdout, indent=2, default=str)
+    click.echo()
+    if trace.final_verdict == "deny":
+        raise SystemExit(4)
+    if trace.final_verdict == "partial_failure":
+        raise SystemExit(5)
+
+
+def _print_compatibility(verdict) -> None:
+    tag = _col("COMPATIBLE", _GREEN) if verdict.compatible else _col("INCOMPATIBLE", _RED)
+    click.echo(f"{tag}  program={verdict.program_id}  "
+               f"world={verdict.world_id} {verdict.world_version}")
+    click.echo(_col("─" * 62, _DIM))
+    for sr in verdict.step_results:
+        mark = _col("✓", _GREEN) if sr.allowed else _col("✗", _RED)
+        click.echo(f"  {mark} step[{sr.step_index}] {sr.action:<18}  {sr.reason}")
+    s = verdict.summary
+    click.echo(_col("─" * 62, _DIM))
+    click.echo(f"Summary: {s.allowed_steps} allowed, {s.denied_steps} denied"
+               + (f"; restricted: {', '.join(s.restricted_actions)}"
+                  if s.restricted_actions else ""))
+
+
+def _print_program_world_diff(diff) -> None:
+    wa = f"{diff.world_a['id']} {diff.world_a['version']}"
+    wb = f"{diff.world_b['id']} {diff.world_b['version']}"
+    click.echo(f"program={diff.program_id}  A={wa}  B={wb}")
+    click.echo(_col("─" * 62, _DIM))
+    if not diff.divergence_points:
+        both = _col("COMPATIBLE IN BOTH", _GREEN) if diff.both_compatible \
+               else _col("INCOMPATIBLE IN BOTH", _RED)
+        click.echo(f"no divergence.  {both}")
+        return
+    for d in diff.divergence_points:
+        click.echo(
+            f"  step[{d.step_index}] {d.action:<18}  "
+            f"A={_col(d.world_a, _GREEN if d.world_a == 'allowed' else _RED)}  "
+            f"B={_col(d.world_b, _GREEN if d.world_b == 'allowed' else _RED)}"
+        )
+        click.echo(f"      reason: {d.reason}")

--- a/src/agent_hypervisor/program_layer/__init__.py
+++ b/src/agent_hypervisor/program_layer/__init__.py
@@ -63,6 +63,16 @@ Public surface:
     SandboxError hierarchy is exported for callers handling specific failures.
 """
 
+from .compatibility import (
+    CompatibilitySummary,
+    DivergencePoint,
+    ProgramWorldCompatibility,
+    ProgramWorldDiff,
+    StepCompatibility,
+    check_compatibility,
+    compare_program_across_worlds,
+    preview_program_under_world,
+)
 from .config import ENABLE_PROGRAM_LAYER
 from .execution_plan import DirectExecutionPlan, ExecutionPlan, ProgramExecutionPlan
 from .interfaces import Executor, ProgramRegistry, TaskCompiler
@@ -72,7 +82,15 @@ from .program_model import MAX_STEPS, Program, Step
 from .program_runner import ProgramRunner
 from .program_store import ProgramStore
 from .program_trace import ProgramTrace, StepTrace
-from .replay_engine import ReplayEngine
+from .replay_engine import ReplayEngine, ReplayTrace
+from .world_registry import (
+    WorldDescriptor,
+    WorldLoadError,
+    WorldNotFoundError,
+    WorldRegistry,
+    default_registry,
+    load_world_from_yaml,
+)
 from .review_lifecycle import (
     InvalidTransitionError,
     WorldValidationError,
@@ -173,4 +191,22 @@ __all__ = [
     # PL-3: Errors
     "InvalidTransitionError",
     "WorldValidationError",
+    # SYS-2 light: World registry
+    "WorldDescriptor",
+    "WorldRegistry",
+    "WorldLoadError",
+    "WorldNotFoundError",
+    "load_world_from_yaml",
+    "default_registry",
+    # SYS-2 light: Compatibility
+    "StepCompatibility",
+    "CompatibilitySummary",
+    "ProgramWorldCompatibility",
+    "DivergencePoint",
+    "ProgramWorldDiff",
+    "check_compatibility",
+    "preview_program_under_world",
+    "compare_program_across_worlds",
+    # SYS-2 light: Replay-under-world
+    "ReplayTrace",
 ]

--- a/src/agent_hypervisor/program_layer/compatibility.py
+++ b/src/agent_hypervisor/program_layer/compatibility.py
@@ -1,0 +1,347 @@
+"""
+compatibility.py — Deterministic program/world compatibility checks.
+
+The authority check: given a ReviewedProgram's minimized_steps and a
+WorldDescriptor, decide whether the program could lawfully replay under
+that world.  This is a pure validation pass — no execution, no side
+effects, no mutation.
+
+Output contracts:
+
+    ProgramWorldCompatibility — per-step verdicts for a single (program, world)
+    ProgramWorldDiff          — side-by-side verdicts for (program, world_a, world_b)
+
+Both shapes are JSON-serializable and stable within SYS-2 light.
+
+Why this module exists separately from world_validator.py:
+    - world_validator returns violations about a ``Program`` with ``Step``s.
+    - compatibility works directly on a ReviewedProgram's ``CandidateStep``s
+      (the shape stored in ProgramStore), and attaches world identity so a
+      single verdict carries the full "who, what, which world" triple.
+
+    compatibility still delegates the per-step check to validate_step to keep
+    the authority logic in one place.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Optional
+
+from .program_model import Step
+from .program_store import ProgramStore
+from .review_models import CandidateStep, ReviewedProgram
+from .world_registry import WorldDescriptor, WorldRegistry
+from .world_validator import validate_step
+
+
+# ---------------------------------------------------------------------------
+# Per-step and summary models
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class StepCompatibility:
+    """
+    Verdict for a single step against a world.
+
+    Fields:
+        step_index          — 0-based index in minimized_steps
+        action              — the step's tool/action name
+        allowed             — True if the world permits this action
+        reason              — short human-readable explanation
+        missing_capability  — action name that is absent from the world, if any
+
+    The ``schema_issue`` slot reserved in the spec is not emitted by this
+    module (schema-level validation is the compiler's job, not SYS-2's).
+    """
+
+    step_index: int
+    action: str
+    allowed: bool
+    reason: str
+    missing_capability: Optional[str] = field(default=None)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "step_index": self.step_index,
+            "action": self.action,
+            "allowed": self.allowed,
+            "reason": self.reason,
+            "missing_capability": self.missing_capability,
+        }
+
+
+@dataclass(frozen=True)
+class CompatibilitySummary:
+    """Aggregate counts derived from a list of StepCompatibility."""
+
+    allowed_steps: int
+    denied_steps: int
+    restricted_actions: tuple[str, ...]  # unique actions that were denied
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "allowed_steps": self.allowed_steps,
+            "denied_steps": self.denied_steps,
+            "restricted_actions": list(self.restricted_actions),
+        }
+
+
+@dataclass(frozen=True)
+class ProgramWorldCompatibility:
+    """
+    Full compatibility verdict for a program under one world.
+
+    ``compatible`` is True iff every step is allowed.  Callers that want to
+    allow partial replay should inspect ``step_results`` directly.
+    """
+
+    program_id: str
+    world_id: str
+    world_version: str
+    compatible: bool
+    step_results: tuple[StepCompatibility, ...]
+    summary: CompatibilitySummary
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "program_id": self.program_id,
+            "world_id": self.world_id,
+            "world_version": self.world_version,
+            "compatible": self.compatible,
+            "step_results": [s.to_dict() for s in self.step_results],
+            "summary": self.summary.to_dict(),
+        }
+
+
+# ---------------------------------------------------------------------------
+# Divergence model
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class DivergencePoint:
+    """A single step where two worlds give different verdicts."""
+
+    step_index: int
+    action: str
+    world_a: str  # "allowed" or "denied: <reason>"
+    world_b: str
+    reason: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "step_index": self.step_index,
+            "action": self.action,
+            "world_a": self.world_a,
+            "world_b": self.world_b,
+            "reason": self.reason,
+        }
+
+
+@dataclass(frozen=True)
+class ProgramWorldDiff:
+    """
+    Side-by-side compatibility verdict for one program across two worlds.
+
+    Fields:
+        program_id        — the program being compared
+        world_a, world_b  — {id, version} pairs for each world
+        both_compatible   — True iff compatibility holds under BOTH worlds
+        divergence_points — steps where the two worlds disagree
+    """
+
+    program_id: str
+    world_a: dict[str, str]
+    world_b: dict[str, str]
+    both_compatible: bool
+    divergence_points: tuple[DivergencePoint, ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "program_id": self.program_id,
+            "world_a": dict(self.world_a),
+            "world_b": dict(self.world_b),
+            "both_compatible": self.both_compatible,
+            "divergence_points": [d.to_dict() for d in self.divergence_points],
+        }
+
+
+# ---------------------------------------------------------------------------
+# Core checker
+# ---------------------------------------------------------------------------
+
+
+def check_compatibility(
+    program: ReviewedProgram,
+    world: WorldDescriptor,
+) -> ProgramWorldCompatibility:
+    """
+    Check every minimized step against the world's allowed_actions.
+
+    Deterministic: same program + same world always produces the same
+    verdict.  No side effects.
+
+    Args:
+        program: the ReviewedProgram whose minimized_steps will be checked.
+        world:   the WorldDescriptor defining allowed_actions.
+
+    Returns:
+        A ProgramWorldCompatibility with per-step results and summary.
+
+    Notes:
+        - An empty minimized_steps list is reported as compatible=True (a
+          program with no steps cannot violate any world).
+        - The action and its validate_step violation message are surfaced
+          verbatim in ``StepCompatibility.reason`` for auditability.
+    """
+    if not isinstance(program, ReviewedProgram):
+        raise TypeError(
+            f"check_compatibility() requires a ReviewedProgram, "
+            f"got {type(program).__name__!r}"
+        )
+    if not isinstance(world, WorldDescriptor):
+        raise TypeError(
+            f"check_compatibility() requires a WorldDescriptor, "
+            f"got {type(world).__name__!r}"
+        )
+
+    step_results: list[StepCompatibility] = []
+    restricted: list[str] = []
+
+    for i, cs in enumerate(program.minimized_steps):
+        violation = validate_step(
+            Step(action=cs.tool, params=cs.params),
+            world.allowed_actions,
+            step_index=i,
+        )
+        if violation is None:
+            step_results.append(
+                StepCompatibility(
+                    step_index=i,
+                    action=cs.tool,
+                    allowed=True,
+                    reason="action present in world",
+                )
+            )
+        else:
+            if cs.tool not in restricted:
+                restricted.append(cs.tool)
+            step_results.append(
+                StepCompatibility(
+                    step_index=i,
+                    action=cs.tool,
+                    allowed=False,
+                    reason=violation.reason,
+                    missing_capability=cs.tool,
+                )
+            )
+
+    allowed = sum(1 for s in step_results if s.allowed)
+    denied = len(step_results) - allowed
+    summary = CompatibilitySummary(
+        allowed_steps=allowed,
+        denied_steps=denied,
+        restricted_actions=tuple(restricted),
+    )
+
+    return ProgramWorldCompatibility(
+        program_id=program.id,
+        world_id=world.world_id,
+        world_version=world.version,
+        compatible=(denied == 0),
+        step_results=tuple(step_results),
+        summary=summary,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Preview (registry-aware wrapper)
+# ---------------------------------------------------------------------------
+
+
+def preview_program_under_world(
+    program_id: str,
+    world_id: str,
+    version: Optional[str],
+    store: ProgramStore,
+    registry: WorldRegistry,
+) -> ProgramWorldCompatibility:
+    """
+    Load a stored program and preview its compatibility under a world.
+
+    Looks up the world via ``registry.get(world_id, version)`` and the
+    program via ``store.load(program_id)``.  Preview does not execute and
+    does not mutate either side.
+
+    Raises:
+        KeyError:             program or world does not exist.
+        WorldNotFoundError:   world_id/version is unknown to the registry.
+    """
+    program = store.load(program_id)
+    world = registry.get(world_id, version)
+    return check_compatibility(program, world)
+
+
+# ---------------------------------------------------------------------------
+# Cross-world divergence
+# ---------------------------------------------------------------------------
+
+
+def compare_program_across_worlds(
+    program_id: str,
+    world_a_id: str,
+    world_a_version: Optional[str],
+    world_b_id: str,
+    world_b_version: Optional[str],
+    store: ProgramStore,
+    registry: WorldRegistry,
+) -> ProgramWorldDiff:
+    """
+    Run compatibility under two worlds and return the divergence points.
+
+    A "divergence point" is a step where one world allows the action and the
+    other denies it.  Steps that are allowed or denied in both worlds are
+    not emitted.
+
+    ``both_compatible`` is True only when the program is fully compatible
+    under both worlds.
+    """
+    program = store.load(program_id)
+    world_a = registry.get(world_a_id, world_a_version)
+    world_b = registry.get(world_b_id, world_b_version)
+
+    compat_a = check_compatibility(program, world_a)
+    compat_b = check_compatibility(program, world_b)
+
+    divergences: list[DivergencePoint] = []
+    for sa, sb in zip(compat_a.step_results, compat_b.step_results):
+        if sa.allowed == sb.allowed:
+            continue
+        reason = (
+            f"{world_b.world_id} denies {sa.action!r} ({sb.reason})"
+            if sa.allowed
+            else f"{world_a.world_id} denies {sa.action!r} ({sa.reason})"
+        )
+        divergences.append(
+            DivergencePoint(
+                step_index=sa.step_index,
+                action=sa.action,
+                world_a=_verdict_label(sa),
+                world_b=_verdict_label(sb),
+                reason=reason,
+            )
+        )
+
+    return ProgramWorldDiff(
+        program_id=program.id,
+        world_a={"id": world_a.world_id, "version": world_a.version},
+        world_b={"id": world_b.world_id, "version": world_b.version},
+        both_compatible=(compat_a.compatible and compat_b.compatible),
+        divergence_points=tuple(divergences),
+    )
+
+
+def _verdict_label(step: StepCompatibility) -> str:
+    return "allowed" if step.allowed else f"denied: {step.reason}"

--- a/src/agent_hypervisor/program_layer/replay_engine.py
+++ b/src/agent_hypervisor/program_layer/replay_engine.py
@@ -39,14 +39,99 @@ Usage::
 
 from __future__ import annotations
 
-from typing import Any, Collection, Optional
+import uuid
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Collection, Literal, Optional
 
 from .program_model import Program, Step
 from .program_runner import ProgramRunner
 from .program_trace import ProgramTrace, StepTrace
 from .review_models import ReviewedProgram
 from .task_compiler import DeterministicTaskCompiler
+from .world_registry import WorldDescriptor
 from .world_validator import validate_program
+
+
+# ---------------------------------------------------------------------------
+# Replay trace — enriches ProgramTrace with world context (SYS-2 light step 8)
+# ---------------------------------------------------------------------------
+
+
+ReplayWorldSource = Literal["active", "explicit", "default"]
+ReplayVerdict = Literal["allow", "deny", "partial_failure"]
+
+
+@dataclass(frozen=True)
+class ReplayTrace:
+    """
+    Wraps a ProgramTrace with the World context under which replay occurred.
+
+    Fields:
+        replay_id            — unique per-replay identifier ("replay-<hex>")
+        program_id           — the replayed program's id
+        world_id             — world used for this replay
+        world_version        — the world's version
+        world_source         — how the world was selected: "active" (fetched
+                               from the registry's active pointer), "explicit"
+                               (passed by the caller), or "default"
+                               (no world context; SUPPORTED_WORKFLOWS)
+        preview_compatible   — prior preview verdict if run; None if skipped
+        program_trace        — the underlying execution trace (step verdicts)
+        final_verdict        — 'allow' if every step allowed, 'deny' if the
+                               first step was denied, 'partial_failure' if
+                               some steps ran before a later step was denied
+        replayed_at          — ISO-8601 wall clock of the replay call
+
+    The `program_trace` field carries the full step-by-step outcome; this
+    wrapper exists only to bind world identity to that outcome so downstream
+    audit can reconstruct "who replayed, what program, under which world".
+    """
+
+    replay_id: str
+    program_id: str
+    world_id: str
+    world_version: str
+    world_source: ReplayWorldSource
+    program_trace: ProgramTrace
+    final_verdict: ReplayVerdict
+    preview_compatible: Optional[bool] = field(default=None)
+    replayed_at: str = field(default="")
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "replay_id": self.replay_id,
+            "program_id": self.program_id,
+            "world_id": self.world_id,
+            "world_version": self.world_version,
+            "world_source": self.world_source,
+            "preview_compatible": self.preview_compatible,
+            "final_verdict": self.final_verdict,
+            "replayed_at": self.replayed_at,
+            "program_trace": self.program_trace.to_dict(),
+        }
+
+
+def _make_replay_id() -> str:
+    return f"replay-{uuid.uuid4().hex[:12]}"
+
+
+def _classify_verdict(trace: ProgramTrace) -> ReplayVerdict:
+    """
+    Map a ProgramTrace to the three-valued replay verdict.
+
+    - allow            — every step.verdict == 'allow'
+    - deny             — first step was denied (nothing executed)
+    - partial_failure  — at least one step executed before a later deny
+    """
+    if trace.ok:
+        return "allow"
+    if not trace.step_traces:
+        return "deny"
+    allowed_prefix = any(st.allowed for st in trace.step_traces)
+    if allowed_prefix:
+        return "partial_failure"
+    return "deny"
 
 
 class ReplayEngine:
@@ -142,3 +227,80 @@ class ReplayEngine:
             runner = ProgramRunner(allowed_actions=allowed_actions)
 
         return runner.run(prog, context=context)
+
+    # ------------------------------------------------------------------
+    # SYS-2 light: replay targeting a specific World
+    # ------------------------------------------------------------------
+
+    def replay_under_world(
+        self,
+        program: ReviewedProgram,
+        world: Optional[WorldDescriptor] = None,
+        world_source: ReplayWorldSource = "explicit",
+        preview_compatible: Optional[bool] = None,
+        runner: Optional[ProgramRunner] = None,
+        context: Optional[dict[str, Any]] = None,
+    ) -> ReplayTrace:
+        """
+        Replay ``program`` under a specific ``world`` and return a ReplayTrace.
+
+        The world's ``allowed_actions`` becomes the replay's authority
+        boundary — no matter what world the program was originally accepted
+        against.  This enforces the SYS-2 light invariant: "a reviewed
+        program does not carry authority; authority lives in the World."
+
+        Args:
+            program:             the ReviewedProgram to replay.
+            world:               WorldDescriptor defining allowed_actions.
+                                 When None, falls back to the default
+                                 SUPPORTED_WORKFLOWS set and the returned
+                                 ReplayTrace marks world_source='default'.
+            world_source:        how the caller chose this world — used by
+                                 audit so a trace records 'active' vs
+                                 'explicit' vs 'default' selection.  Ignored
+                                 when world is None (forced to 'default').
+            preview_compatible:  optional verdict from a prior compatibility
+                                 preview; stored on the trace for audit.  No
+                                 effect on execution.
+            runner:              optional ProgramRunner to reuse.  If None,
+                                 a fresh runner is built from the world's
+                                 allowed_actions.
+            context:             execution context passed through to runner.
+
+        Returns:
+            A ReplayTrace carrying the world identity, source, preview
+            verdict, and the underlying ProgramTrace.
+        """
+        if world is None:
+            allowed_actions: Collection[str] = DeterministicTaskCompiler.SUPPORTED_WORKFLOWS
+            world_id = "default"
+            world_version = "unspecified"
+            world_source = "default"
+        else:
+            if not isinstance(world, WorldDescriptor):
+                raise TypeError(
+                    f"replay_under_world() requires a WorldDescriptor, "
+                    f"got {type(world).__name__!r}"
+                )
+            allowed_actions = world.allowed_actions
+            world_id = world.world_id
+            world_version = world.version
+
+        program_trace = self.replay(
+            program,
+            runner=runner,
+            context=context,
+            allowed_actions=allowed_actions,
+        )
+
+        return ReplayTrace(
+            replay_id=_make_replay_id(),
+            program_id=program.id,
+            world_id=world_id,
+            world_version=world_version,
+            world_source=world_source,
+            preview_compatible=preview_compatible,
+            program_trace=program_trace,
+            final_verdict=_classify_verdict(program_trace),
+            replayed_at=datetime.now(tz=timezone.utc).isoformat(),
+        )

--- a/src/agent_hypervisor/program_layer/world_registry.py
+++ b/src/agent_hypervisor/program_layer/world_registry.py
@@ -1,0 +1,385 @@
+"""
+world_registry.py — Lightweight world registry for SYS-2 light.
+
+A **World** here is the set of actions a reviewed program is permitted to use.
+It is deliberately narrower than the full CompiledPolicy — just enough to
+demonstrate that "a reviewed program does not carry authority; authority
+lives in the currently active World."
+
+Each world is declared in a YAML file:
+
+    world_id: world_strict
+    version: "1.0"
+    description: "Basic measurement only"
+    allowed_actions:
+      - count_words
+      - count_lines
+
+The registry loads worlds from a directory and tracks exactly one "active"
+world via a small JSON file.  Switching worlds is atomic: the new world is
+loaded and validated before the active pointer is updated, so a failed load
+never corrupts state.
+
+Design notes:
+    - WorldDescriptor is frozen and carries allowed_actions as a frozenset.
+    - The registry does NOT execute anything.  It only loads and indexes.
+    - "Active world" is advisory metadata, not an authority boost — every
+      replay/preview still validates independently.
+
+Usage::
+
+    registry = WorldRegistry(worlds_dir="src/agent_hypervisor/program_layer/worlds/")
+    worlds = registry.list_worlds()
+    registry.set_active("world_strict", "1.0")
+    active = registry.get_active()
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Optional
+
+import yaml
+
+
+# ---------------------------------------------------------------------------
+# Errors
+# ---------------------------------------------------------------------------
+
+
+class WorldNotFoundError(KeyError):
+    """Raised when a requested world_id/version does not exist in the registry."""
+
+
+class WorldLoadError(ValueError):
+    """Raised when a world YAML file is malformed or fails schema validation."""
+
+
+# ---------------------------------------------------------------------------
+# WorldDescriptor
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class WorldDescriptor:
+    """
+    Immutable description of a World.
+
+    Fields:
+        world_id         — stable identifier (e.g. "world_strict")
+        version          — semver-ish string (e.g. "1.0")
+        allowed_actions  — frozenset of action names the world permits
+        manifest_path    — filesystem path the descriptor was loaded from
+        description      — human-readable summary
+        created_at       — ISO-8601 timestamp (from YAML or load time)
+
+    ``allowed_actions`` is the authoritative boundary.  Any reviewed
+    program whose minimized_steps reference an action outside this set is
+    incompatible with this world.
+    """
+
+    world_id: str
+    version: str
+    allowed_actions: frozenset[str]
+    manifest_path: Optional[str] = field(default=None)
+    description: str = field(default="")
+    created_at: str = field(default="")
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.world_id, str) or not self.world_id.strip():
+            raise ValueError(
+                f"WorldDescriptor.world_id must be a non-empty string, "
+                f"got {self.world_id!r}"
+            )
+        if not isinstance(self.version, str) or not self.version.strip():
+            raise ValueError(
+                f"WorldDescriptor.version must be a non-empty string, "
+                f"got {self.version!r}"
+            )
+        if not isinstance(self.allowed_actions, frozenset):
+            raise TypeError(
+                f"WorldDescriptor.allowed_actions must be a frozenset, "
+                f"got {type(self.allowed_actions).__name__!r}"
+            )
+
+    @property
+    def key(self) -> tuple[str, str]:
+        """(world_id, version) — the lookup key used inside the registry."""
+        return (self.world_id, self.version)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "world_id": self.world_id,
+            "version": self.version,
+            "allowed_actions": sorted(self.allowed_actions),
+            "manifest_path": self.manifest_path,
+            "description": self.description,
+            "created_at": self.created_at,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "WorldDescriptor":
+        return cls(
+            world_id=data["world_id"],
+            version=str(data["version"]),
+            allowed_actions=frozenset(data.get("allowed_actions", ())),
+            manifest_path=data.get("manifest_path"),
+            description=data.get("description", ""),
+            created_at=data.get("created_at", ""),
+        )
+
+
+# ---------------------------------------------------------------------------
+# YAML loader
+# ---------------------------------------------------------------------------
+
+
+def load_world_from_yaml(path: str | Path) -> WorldDescriptor:
+    """
+    Load a single WorldDescriptor from a YAML manifest file.
+
+    Required fields in the YAML:
+        world_id         — string
+        version          — string (or number, coerced to string)
+        allowed_actions  — list of string action names
+
+    Optional:
+        description      — human-readable summary
+        created_at       — ISO-8601 timestamp (defaults to file mtime)
+
+    Raises:
+        WorldLoadError: file missing, unparseable, or schema-invalid.
+    """
+    p = Path(path)
+    if not p.exists():
+        raise WorldLoadError(f"World manifest not found: {path}")
+
+    try:
+        raw = yaml.safe_load(p.read_text(encoding="utf-8"))
+    except yaml.YAMLError as exc:
+        raise WorldLoadError(f"Invalid YAML in {path}: {exc}") from exc
+
+    if not isinstance(raw, dict):
+        raise WorldLoadError(f"World manifest at {path} must be a mapping")
+
+    for required in ("world_id", "version", "allowed_actions"):
+        if required not in raw:
+            raise WorldLoadError(f"{path}: missing required field {required!r}")
+
+    actions = raw["allowed_actions"]
+    if not isinstance(actions, list) or not all(isinstance(a, str) for a in actions):
+        raise WorldLoadError(
+            f"{path}: allowed_actions must be a list of strings"
+        )
+
+    created_at = raw.get("created_at") or datetime.fromtimestamp(
+        p.stat().st_mtime, tz=timezone.utc
+    ).isoformat()
+
+    try:
+        return WorldDescriptor(
+            world_id=str(raw["world_id"]),
+            version=str(raw["version"]),
+            allowed_actions=frozenset(actions),
+            manifest_path=str(p.resolve()),
+            description=raw.get("description", ""),
+            created_at=created_at,
+        )
+    except (TypeError, ValueError) as exc:
+        raise WorldLoadError(f"{path}: {exc}") from exc
+
+
+# ---------------------------------------------------------------------------
+# Registry
+# ---------------------------------------------------------------------------
+
+
+class WorldRegistry:
+    """
+    Directory-backed registry of WorldDescriptor objects.
+
+    Lookup layout:
+        {worlds_dir}/
+            world_strict.yaml
+            world_balanced.yaml
+            .active.json   # written by set_active()
+
+    A single YAML file describes one (world_id, version) pair.  Multiple
+    versions of the same world_id are supported by adding more YAML files.
+
+    Args:
+        worlds_dir:  directory containing world YAML manifests.
+        active_file: optional custom path for the active-world pointer.
+                     Defaults to ``{worlds_dir}/.active.json``.
+
+    Thread safety:
+        Not thread-safe.  Use one instance per process or synchronise externally.
+    """
+
+    _ACTIVE_FILENAME = ".active.json"
+
+    def __init__(
+        self,
+        worlds_dir: str | Path,
+        active_file: Optional[str | Path] = None,
+    ) -> None:
+        self._worlds_dir = Path(worlds_dir)
+        self._active_file = (
+            Path(active_file) if active_file is not None
+            else self._worlds_dir / self._ACTIVE_FILENAME
+        )
+
+    @property
+    def worlds_dir(self) -> Path:
+        return self._worlds_dir
+
+    # ------------------------------------------------------------------
+    # List / load
+    # ------------------------------------------------------------------
+
+    def list_worlds(self) -> list[WorldDescriptor]:
+        """
+        Return all worlds defined under ``worlds_dir``, sorted by (id, version).
+
+        Files that fail to parse are skipped silently so a corrupt file does
+        not break the whole registry — but ``get()`` will still raise for
+        that specific world.
+        """
+        if not self._worlds_dir.exists():
+            return []
+
+        out: list[WorldDescriptor] = []
+        for path in sorted(self._worlds_dir.iterdir()):
+            if path.name.startswith("."):
+                continue
+            if path.suffix not in (".yaml", ".yml"):
+                continue
+            try:
+                out.append(load_world_from_yaml(path))
+            except WorldLoadError:
+                continue
+        out.sort(key=lambda w: w.key)
+        return out
+
+    def get(
+        self,
+        world_id: str,
+        version: Optional[str] = None,
+    ) -> WorldDescriptor:
+        """
+        Load a world by id (and optionally version).
+
+        If ``version`` is None, the most recent version found (lexicographic
+        last) is returned.  Raises WorldNotFoundError if no match exists.
+        """
+        candidates = [w for w in self.list_worlds() if w.world_id == world_id]
+        if not candidates:
+            raise WorldNotFoundError(
+                f"No world with id {world_id!r} under {self._worlds_dir}"
+            )
+        if version is None:
+            return candidates[-1]  # lexicographic latest
+        for w in candidates:
+            if w.version == version:
+                return w
+        versions = sorted(w.version for w in candidates)
+        raise WorldNotFoundError(
+            f"World {world_id!r} has no version {version!r}. "
+            f"Available: {versions}"
+        )
+
+    # ------------------------------------------------------------------
+    # Active-world pointer
+    # ------------------------------------------------------------------
+
+    def get_active(self) -> Optional[WorldDescriptor]:
+        """
+        Return the currently active world, or None if none is set.
+
+        If the active pointer references a world that no longer exists,
+        returns None (stale pointers do not raise).
+        """
+        if not self._active_file.exists():
+            return None
+        try:
+            data = json.loads(self._active_file.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError):
+            return None
+
+        world_id = data.get("world_id")
+        version = data.get("version")
+        if not world_id or not version:
+            return None
+        try:
+            return self.get(world_id, version)
+        except WorldNotFoundError:
+            return None
+
+    def set_active(self, world_id: str, version: str) -> WorldDescriptor:
+        """
+        Mark ``(world_id, version)`` as the active world.
+
+        Loads and validates the target world first.  If loading fails, the
+        active pointer is left unchanged.  On success, the pointer file is
+        rewritten atomically.
+
+        Returns the newly active WorldDescriptor.
+        """
+        # Validate by loading before writing — this is the rollback guarantee.
+        target = self.get(world_id, version)
+
+        payload = {
+            "world_id": target.world_id,
+            "version": target.version,
+            "activated_at": datetime.now(tz=timezone.utc).isoformat(),
+        }
+
+        self._worlds_dir.mkdir(parents=True, exist_ok=True)
+        fd, tmp = tempfile.mkstemp(
+            dir=self._worlds_dir, prefix=".tmp_active_", suffix=".json"
+        )
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as f:
+                json.dump(payload, f, indent=2)
+                f.write("\n")
+            os.replace(tmp, self._active_file)
+        except Exception:
+            try:
+                os.unlink(tmp)
+            except OSError:
+                pass
+            raise
+
+        return target
+
+    def clear_active(self) -> None:
+        """Remove the active-world pointer if present."""
+        try:
+            self._active_file.unlink()
+        except FileNotFoundError:
+            pass
+
+
+# ---------------------------------------------------------------------------
+# Convenience: default bundled-worlds registry
+# ---------------------------------------------------------------------------
+
+
+def _bundled_worlds_dir() -> Path:
+    """Return the directory holding worlds shipped with the package."""
+    return Path(__file__).parent / "worlds"
+
+
+def default_registry(active_file: Optional[str | Path] = None) -> WorldRegistry:
+    """
+    Registry over the bundled example worlds (program_layer/worlds/).
+
+    Useful for demos and tests.  For real usage the caller should construct
+    WorldRegistry with its own directory.
+    """
+    return WorldRegistry(_bundled_worlds_dir(), active_file=active_file)

--- a/src/agent_hypervisor/program_layer/worlds/world_balanced.yaml
+++ b/src/agent_hypervisor/program_layer/worlds/world_balanced.yaml
@@ -1,0 +1,10 @@
+world_id: world_balanced
+version: "1.0"
+description: >
+  Balanced world: every deterministic text workflow is permitted.  Programs
+  accepted under this world exercise the full supported workflow set.
+allowed_actions:
+  - count_lines
+  - count_words
+  - normalize_text
+  - word_frequency

--- a/src/agent_hypervisor/program_layer/worlds/world_strict.yaml
+++ b/src/agent_hypervisor/program_layer/worlds/world_strict.yaml
@@ -1,0 +1,9 @@
+world_id: world_strict
+version: "1.0"
+description: >
+  Strict world: only basic measurement workflows are permitted.  No text
+  transformations, no ranked outputs.  Programs that rely on normalization
+  or frequency analysis are incompatible.
+allowed_actions:
+  - count_lines
+  - count_words

--- a/tests/program_layer/test_cli_program.py
+++ b/tests/program_layer/test_cli_program.py
@@ -1,0 +1,287 @@
+"""
+test_cli_program.py — CLI wrapper tests for PL-3.
+
+Exercises the `awc program ...` subcommands defined in
+``agent_hypervisor.compiler.cli``.  Each test invokes the CLI via
+``click.testing.CliRunner`` and inspects the exit code and stdout.
+
+The underlying Python API (review_lifecycle, ReplayEngine, ProgramStore)
+is covered exhaustively by ``test_review_minimization.py``.  These tests
+only verify the thin CLI surface: argument parsing, JSON input handling,
+error exit codes, and happy-path end-to-end wiring.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from agent_hypervisor.compiler.cli import cli
+
+
+def _write_steps_json(path: Path, steps: list[dict]) -> Path:
+    path.write_text(json.dumps(steps), encoding="utf-8")
+    return path
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+@pytest.fixture
+def store_dir(tmp_path: Path) -> Path:
+    d = tmp_path / "programs"
+    d.mkdir()
+    return d
+
+
+@pytest.fixture
+def steps_file(tmp_path: Path) -> Path:
+    # Two identical consecutive steps (dedup target) + a URL-with-query step
+    # (param reduction target).  "count_words" is in SUPPORTED_WORKFLOWS so
+    # world validation on accept passes.
+    steps = [
+        {"tool": "count_words", "params": {"input": "hello world"}},
+        {"tool": "count_words", "params": {"input": "hello world"}},  # duplicate
+        {
+            "tool": "normalize_text",
+            "params": {"input": "HELLO", "url": "https://api.example.com/v1?x=1"},
+        },
+    ]
+    return _write_steps_json(tmp_path / "steps.json", steps)
+
+
+# ---------------------------------------------------------------------------
+# propose
+# ---------------------------------------------------------------------------
+
+
+def test_propose_creates_program_and_prints_id(runner, store_dir, steps_file):
+    result = runner.invoke(
+        cli,
+        [
+            "program", "propose",
+            "--steps-json", str(steps_file),
+            "--trace-id", "trace-1",
+            "--world-version", "1.0",
+            "--store", str(store_dir),
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    prog_id = result.output.strip()
+    assert prog_id.startswith("prog-")
+    assert (store_dir / f"program_{prog_id}.json").exists()
+
+
+def test_propose_rejects_empty_array(runner, store_dir, tmp_path):
+    empty = _write_steps_json(tmp_path / "empty.json", [])
+    result = runner.invoke(
+        cli,
+        [
+            "program", "propose",
+            "--steps-json", str(empty),
+            "--world-version", "1.0",
+            "--store", str(store_dir),
+        ],
+    )
+    assert result.exit_code == 1
+    assert "non-empty" in result.output.lower()
+
+
+def test_propose_rejects_invalid_step_schema(runner, store_dir, tmp_path):
+    bad = _write_steps_json(tmp_path / "bad.json", [{"not_a_tool": "x"}])
+    result = runner.invoke(
+        cli,
+        [
+            "program", "propose",
+            "--steps-json", str(bad),
+            "--world-version", "1.0",
+            "--store", str(store_dir),
+        ],
+    )
+    assert result.exit_code == 1
+    assert "invalid step" in result.output.lower()
+
+
+# ---------------------------------------------------------------------------
+# Lifecycle happy path: propose → minimize → review → accept → replay
+# ---------------------------------------------------------------------------
+
+
+def _propose(runner, store_dir, steps_file) -> str:
+    result = runner.invoke(
+        cli,
+        [
+            "program", "propose",
+            "--steps-json", str(steps_file),
+            "--trace-id", "trace-1",
+            "--world-version", "1.0",
+            "--store", str(store_dir),
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    return result.output.strip()
+
+
+def test_minimize_prints_diff(runner, store_dir, steps_file):
+    prog_id = _propose(runner, store_dir, steps_file)
+    result = runner.invoke(
+        cli,
+        ["program", "minimize", "--id", prog_id, "--store", str(store_dir)],
+    )
+    assert result.exit_code == 0, result.output
+    # The duplicate should show up in the diff output
+    assert "REMOVED" in result.output
+    assert "consecutive duplicate" in result.output
+
+
+def test_minimize_empty_diff_is_reported(runner, store_dir, tmp_path):
+    steps = [{"tool": "count_words", "params": {"input": "hi"}}]
+    steps_file = _write_steps_json(tmp_path / "one.json", steps)
+    prog_id = _propose(runner, store_dir, steps_file)
+    result = runner.invoke(
+        cli,
+        ["program", "minimize", "--id", prog_id, "--store", str(store_dir)],
+    )
+    assert result.exit_code == 0, result.output
+    assert "no changes" in result.output.lower()
+
+
+def test_review_transitions_proposed_to_reviewed(runner, store_dir, steps_file):
+    prog_id = _propose(runner, store_dir, steps_file)
+    runner.invoke(cli, ["program", "minimize", "--id", prog_id, "--store", str(store_dir)])
+
+    result = runner.invoke(
+        cli,
+        [
+            "program", "review", "--id", prog_id,
+            "--notes", "looks fine",
+            "--store", str(store_dir),
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert "reviewed" in result.output
+
+
+def test_accept_requires_reviewed_status(runner, store_dir, steps_file):
+    """accept on a PROPOSED program should fail with invalid-transition exit code."""
+    prog_id = _propose(runner, store_dir, steps_file)
+    result = runner.invoke(
+        cli,
+        ["program", "accept", "--id", prog_id, "--store", str(store_dir)],
+    )
+    assert result.exit_code == 2, result.output
+    assert "cannot transition" in result.output.lower()
+
+
+def test_end_to_end_propose_minimize_review_accept_replay(runner, store_dir, steps_file):
+    prog_id = _propose(runner, store_dir, steps_file)
+
+    assert runner.invoke(
+        cli, ["program", "minimize", "--id", prog_id, "--store", str(store_dir)]
+    ).exit_code == 0
+
+    assert runner.invoke(
+        cli, ["program", "review", "--id", prog_id, "--store", str(store_dir)]
+    ).exit_code == 0
+
+    accept_result = runner.invoke(
+        cli, ["program", "accept", "--id", prog_id, "--store", str(store_dir)]
+    )
+    assert accept_result.exit_code == 0, accept_result.output
+    assert "accepted" in accept_result.output
+
+    replay_result = runner.invoke(
+        cli, ["program", "replay", "--id", prog_id, "--store", str(store_dir)]
+    )
+    # Replay may succeed (exit 0) or fail deterministically (exit 4) depending
+    # on whether the sandboxed workflow handler produces a usable result in
+    # this test environment.  Either way the command must print a valid
+    # ProgramTrace dict and never crash.
+    assert replay_result.exit_code in (0, 4), replay_result.output
+    parsed = json.loads(replay_result.output.splitlines()[-1]) if False else None
+    # Stdout contains JSON followed by a trailing newline — parse the whole lot
+    # up to the newline-only tail.
+    json_text = replay_result.output.strip()
+    trace = json.loads(json_text)
+    assert trace["program_id"] == prog_id
+    assert "step_traces" in trace
+    assert "ok" in trace
+
+
+# ---------------------------------------------------------------------------
+# reject
+# ---------------------------------------------------------------------------
+
+
+def test_reject_transitions_reviewed_to_rejected(runner, store_dir, steps_file):
+    prog_id = _propose(runner, store_dir, steps_file)
+    runner.invoke(cli, ["program", "minimize", "--id", prog_id, "--store", str(store_dir)])
+    runner.invoke(cli, ["program", "review", "--id", prog_id, "--store", str(store_dir)])
+
+    result = runner.invoke(
+        cli,
+        [
+            "program", "reject", "--id", prog_id,
+            "--reason", "not needed",
+            "--store", str(store_dir),
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert "rejected" in result.output
+
+
+# ---------------------------------------------------------------------------
+# list / show / unknown-id
+# ---------------------------------------------------------------------------
+
+
+def test_list_empty_store(runner, store_dir):
+    result = runner.invoke(cli, ["program", "list", "--store", str(store_dir)])
+    assert result.exit_code == 0
+    assert "no programs" in result.output.lower()
+
+
+def test_list_shows_saved_programs(runner, store_dir, steps_file):
+    prog_id = _propose(runner, store_dir, steps_file)
+    result = runner.invoke(cli, ["program", "list", "--store", str(store_dir)])
+    assert result.exit_code == 0, result.output
+    assert prog_id in result.output
+    assert "proposed" in result.output
+
+
+def test_show_prints_valid_json(runner, store_dir, steps_file):
+    prog_id = _propose(runner, store_dir, steps_file)
+    result = runner.invoke(
+        cli, ["program", "show", "--id", prog_id, "--store", str(store_dir)]
+    )
+    assert result.exit_code == 0, result.output
+    data = json.loads(result.output.strip())
+    assert data["id"] == prog_id
+    assert data["status"] == "proposed"
+    assert len(data["original_steps"]) == 3
+
+
+@pytest.mark.parametrize(
+    "subcommand, extra_args",
+    [
+        ("minimize", []),
+        ("review", []),
+        ("accept", []),
+        ("reject", []),
+        ("replay", []),
+        ("show", []),
+    ],
+)
+def test_unknown_id_exits_with_error(runner, store_dir, subcommand, extra_args):
+    result = runner.invoke(
+        cli,
+        ["program", subcommand, "--id", "prog-doesnotexist", "--store", str(store_dir)]
+        + extra_args,
+    )
+    assert result.exit_code != 0
+    assert "not found" in result.output.lower()

--- a/tests/program_layer/test_compatibility.py
+++ b/tests/program_layer/test_compatibility.py
@@ -1,0 +1,348 @@
+"""
+test_compatibility.py — Compatibility / preview / cross-world diff tests.
+
+Covers:
+    - check_compatibility: fully allowed, fully denied, mixed
+    - preview_program_under_world: happy path, unknown program, unknown world
+    - compare_program_across_worlds: identical verdicts, real divergence,
+      divergence_points carry the denying world's reason
+    - Empty minimized_steps is compatible under any world
+    - Compatibility summary counts match step_results
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from agent_hypervisor.program_layer import (
+    CandidateStep,
+    ProgramStore,
+    WorldDescriptor,
+    WorldRegistry,
+    check_compatibility,
+    compare_program_across_worlds,
+    preview_program_under_world,
+    propose_program,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def world_strict() -> WorldDescriptor:
+    return WorldDescriptor(
+        world_id="world_strict",
+        version="1.0",
+        allowed_actions=frozenset({"count_words", "count_lines"}),
+        description="strict",
+    )
+
+
+@pytest.fixture
+def world_balanced() -> WorldDescriptor:
+    return WorldDescriptor(
+        world_id="world_balanced",
+        version="1.0",
+        allowed_actions=frozenset(
+            {"count_words", "count_lines", "normalize_text", "word_frequency"}
+        ),
+        description="balanced",
+    )
+
+
+@pytest.fixture
+def store(tmp_path: Path) -> ProgramStore:
+    return ProgramStore(tmp_path / "programs")
+
+
+def _propose(store: ProgramStore, steps: list[CandidateStep]) -> str:
+    return propose_program(
+        steps=steps,
+        trace_id="trace-1",
+        world_version="1.0",
+        store=store,
+    ).id
+
+
+# ---------------------------------------------------------------------------
+# Per-program-world registry setup
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def registry_with_both(tmp_path: Path) -> WorldRegistry:
+    worlds_dir = tmp_path / "worlds"
+    worlds_dir.mkdir()
+    (worlds_dir / "world_strict.yaml").write_text(
+        "world_id: world_strict\n"
+        "version: \"1.0\"\n"
+        "allowed_actions: [count_words, count_lines]\n",
+        encoding="utf-8",
+    )
+    (worlds_dir / "world_balanced.yaml").write_text(
+        "world_id: world_balanced\n"
+        "version: \"1.0\"\n"
+        "allowed_actions: [count_words, count_lines, normalize_text, word_frequency]\n",
+        encoding="utf-8",
+    )
+    return WorldRegistry(worlds_dir)
+
+
+# ---------------------------------------------------------------------------
+# check_compatibility — basic verdicts
+# ---------------------------------------------------------------------------
+
+
+def test_fully_compatible_program(store: ProgramStore, world_strict: WorldDescriptor):
+    pid = _propose(store, [CandidateStep(tool="count_words", params={"input": "hi"})])
+    prog = store.load(pid)
+    verdict = check_compatibility(prog, world_strict)
+    assert verdict.compatible
+    assert verdict.summary.allowed_steps == 1
+    assert verdict.summary.denied_steps == 0
+    assert verdict.summary.restricted_actions == ()
+
+
+def test_fully_incompatible_program(store: ProgramStore, world_strict: WorldDescriptor):
+    pid = _propose(
+        store,
+        [
+            CandidateStep(tool="normalize_text", params={"input": "HELLO"}),
+            CandidateStep(tool="word_frequency", params={"input": "a b a"}),
+        ],
+    )
+    prog = store.load(pid)
+    verdict = check_compatibility(prog, world_strict)
+    assert not verdict.compatible
+    assert verdict.summary.denied_steps == 2
+    assert verdict.summary.allowed_steps == 0
+    assert set(verdict.summary.restricted_actions) == {"normalize_text", "word_frequency"}
+    for sr in verdict.step_results:
+        assert not sr.allowed
+        assert sr.missing_capability == sr.action
+
+
+def test_mixed_compatibility(store: ProgramStore, world_strict: WorldDescriptor):
+    pid = _propose(
+        store,
+        [
+            CandidateStep(tool="count_words", params={"input": "hi"}),
+            CandidateStep(tool="normalize_text", params={"input": "HELLO"}),
+            CandidateStep(tool="count_lines", params={"input": "a\nb"}),
+        ],
+    )
+    prog = store.load(pid)
+    verdict = check_compatibility(prog, world_strict)
+    assert not verdict.compatible
+    assert verdict.summary.allowed_steps == 2
+    assert verdict.summary.denied_steps == 1
+    assert verdict.summary.restricted_actions == ("normalize_text",)
+    assert [sr.allowed for sr in verdict.step_results] == [True, False, True]
+
+
+def test_empty_minimized_steps_is_compatible(
+    store: ProgramStore, world_strict: WorldDescriptor
+):
+    # A program whose minimizer reduced everything away is still valid.
+    # Propose a 1-step program, then synthesize an "empty minimized_steps"
+    # ReviewedProgram by serializing/overriding via from_dict.
+    import dataclasses
+
+    pid = _propose(store, [CandidateStep(tool="count_words", params={"input": "hi"})])
+    prog = store.load(pid)
+    empty = dataclasses.replace(prog, minimized_steps=())
+    store.save(empty)
+    verdict = check_compatibility(store.load(pid), world_strict)
+    assert verdict.compatible
+    assert verdict.step_results == ()
+    assert verdict.summary.allowed_steps == 0
+    assert verdict.summary.denied_steps == 0
+
+
+def test_check_compatibility_rejects_wrong_types(
+    store: ProgramStore, world_strict: WorldDescriptor
+):
+    with pytest.raises(TypeError):
+        check_compatibility("not a program", world_strict)  # type: ignore
+    pid = _propose(store, [CandidateStep(tool="count_words", params={"input": "hi"})])
+    prog = store.load(pid)
+    with pytest.raises(TypeError):
+        check_compatibility(prog, {"allowed_actions": {"count_words"}})  # type: ignore
+
+
+def test_compatibility_to_dict_is_json_safe(
+    store: ProgramStore, world_strict: WorldDescriptor
+):
+    import json
+
+    pid = _propose(
+        store,
+        [
+            CandidateStep(tool="count_words", params={}),
+            CandidateStep(tool="normalize_text", params={}),
+        ],
+    )
+    prog = store.load(pid)
+    verdict = check_compatibility(prog, world_strict)
+    json.dumps(verdict.to_dict())  # must not raise
+
+
+def test_preview_same_result_as_check(
+    store: ProgramStore, registry_with_both: WorldRegistry
+):
+    """preview_program_under_world is just a store+registry-aware wrapper."""
+    pid = _propose(
+        store,
+        [
+            CandidateStep(tool="count_words", params={}),
+            CandidateStep(tool="normalize_text", params={}),
+        ],
+    )
+    strict = registry_with_both.get("world_strict", "1.0")
+    from_direct = check_compatibility(store.load(pid), strict)
+    from_preview = preview_program_under_world(
+        program_id=pid,
+        world_id="world_strict",
+        version="1.0",
+        store=store,
+        registry=registry_with_both,
+    )
+    assert from_direct == from_preview
+
+
+def test_preview_unknown_program_raises(
+    store: ProgramStore, registry_with_both: WorldRegistry
+):
+    with pytest.raises(KeyError):
+        preview_program_under_world(
+            program_id="prog-doesnotexist",
+            world_id="world_strict",
+            version="1.0",
+            store=store,
+            registry=registry_with_both,
+        )
+
+
+def test_preview_unknown_world_raises(
+    store: ProgramStore, registry_with_both: WorldRegistry
+):
+    from agent_hypervisor.program_layer import WorldNotFoundError
+
+    pid = _propose(store, [CandidateStep(tool="count_words", params={})])
+    with pytest.raises(WorldNotFoundError):
+        preview_program_under_world(
+            program_id=pid,
+            world_id="world_nonexistent",
+            version=None,
+            store=store,
+            registry=registry_with_both,
+        )
+
+
+# ---------------------------------------------------------------------------
+# compare_program_across_worlds
+# ---------------------------------------------------------------------------
+
+
+def test_compare_finds_divergence_strict_vs_balanced(
+    store: ProgramStore, registry_with_both: WorldRegistry
+):
+    pid = _propose(
+        store,
+        [
+            CandidateStep(tool="count_words", params={"input": "a b c"}),
+            CandidateStep(tool="normalize_text", params={"input": "HELLO"}),
+        ],
+    )
+    diff = compare_program_across_worlds(
+        program_id=pid,
+        world_a_id="world_strict",
+        world_a_version="1.0",
+        world_b_id="world_balanced",
+        world_b_version="1.0",
+        store=store,
+        registry=registry_with_both,
+    )
+    assert not diff.both_compatible  # strict denies normalize_text
+    assert len(diff.divergence_points) == 1
+    point = diff.divergence_points[0]
+    assert point.step_index == 1
+    assert point.action == "normalize_text"
+    assert point.world_a.startswith("denied")
+    assert point.world_b == "allowed"
+
+
+def test_compare_same_world_reports_no_divergence(
+    store: ProgramStore, registry_with_both: WorldRegistry
+):
+    pid = _propose(
+        store,
+        [
+            CandidateStep(tool="count_words", params={}),
+            CandidateStep(tool="normalize_text", params={}),
+        ],
+    )
+    diff = compare_program_across_worlds(
+        program_id=pid,
+        world_a_id="world_balanced",
+        world_a_version="1.0",
+        world_b_id="world_balanced",
+        world_b_version="1.0",
+        store=store,
+        registry=registry_with_both,
+    )
+    assert diff.divergence_points == ()
+    assert diff.both_compatible
+
+
+def test_compare_both_incompatible_no_divergence(
+    store: ProgramStore, registry_with_both: WorldRegistry
+):
+    pid = _propose(
+        store,
+        [CandidateStep(tool="normalize_text", params={})],  # denied by strict
+    )
+    # Swap balanced for a second strict world so BOTH deny
+    worlds_dir = registry_with_both.worlds_dir
+    (worlds_dir / "world_strict_2.yaml").write_text(
+        "world_id: world_strict_2\n"
+        "version: \"1.0\"\n"
+        "allowed_actions: [count_words, count_lines]\n",
+        encoding="utf-8",
+    )
+    diff = compare_program_across_worlds(
+        program_id=pid,
+        world_a_id="world_strict",
+        world_a_version="1.0",
+        world_b_id="world_strict_2",
+        world_b_version="1.0",
+        store=store,
+        registry=registry_with_both,
+    )
+    assert diff.divergence_points == ()
+    assert not diff.both_compatible
+
+
+def test_compare_diff_to_dict_is_json_safe(
+    store: ProgramStore, registry_with_both: WorldRegistry
+):
+    import json
+
+    pid = _propose(
+        store, [CandidateStep(tool="normalize_text", params={})]
+    )
+    diff = compare_program_across_worlds(
+        program_id=pid,
+        world_a_id="world_strict",
+        world_a_version="1.0",
+        world_b_id="world_balanced",
+        world_b_version="1.0",
+        store=store,
+        registry=registry_with_both,
+    )
+    json.dumps(diff.to_dict())  # must not raise

--- a/tests/program_layer/test_replay_under_world.py
+++ b/tests/program_layer/test_replay_under_world.py
@@ -1,0 +1,332 @@
+"""
+test_replay_under_world.py — ReplayEngine.replay_under_world + ReplayTrace.
+
+Covers:
+    - Replay under a compatible world yields final_verdict='allow' and the
+      trace records world_id, world_version, world_source='explicit'.
+    - Replay under an incompatible world yields final_verdict='deny',
+      ProgramTrace.ok is False, and the failing step's error mentions
+      "world validation failed".
+    - Replay without a world falls back to SUPPORTED_WORKFLOWS and records
+      world_source='default' + world_id='default'.
+    - preview_compatible annotation is stored verbatim on the trace.
+    - final_verdict classification: allow / deny / partial_failure.
+    - ReplayTrace.to_dict() is JSON-safe and stable.
+    - ReplayEngine.replay() (the legacy method) is untouched: returns a bare
+      ProgramTrace and is unaffected by the SYS-2 additions.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from agent_hypervisor.program_layer import (
+    CandidateStep,
+    ProgramStore,
+    ProgramTrace,
+    ReplayEngine,
+    ReplayTrace,
+    WorldDescriptor,
+    accept_program,
+    check_compatibility,
+    minimize_program,
+    propose_program,
+    review_program,
+)
+from agent_hypervisor.program_layer.program_trace import StepTrace
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def store(tmp_path: Path) -> ProgramStore:
+    return ProgramStore(tmp_path / "programs")
+
+
+@pytest.fixture
+def world_strict() -> WorldDescriptor:
+    return WorldDescriptor(
+        world_id="world_strict",
+        version="1.0",
+        allowed_actions=frozenset({"count_words", "count_lines"}),
+    )
+
+
+@pytest.fixture
+def world_balanced() -> WorldDescriptor:
+    return WorldDescriptor(
+        world_id="world_balanced",
+        version="1.0",
+        allowed_actions=frozenset(
+            {"count_words", "count_lines", "normalize_text", "word_frequency"}
+        ),
+    )
+
+
+def _accept_program(store: ProgramStore, steps: list[CandidateStep]) -> str:
+    """Propose → minimize → review → accept, return program id."""
+    prog = propose_program(
+        steps=steps,
+        trace_id="trace-1",
+        world_version="1.0",
+        store=store,
+    )
+    minimize_program(prog.id, store)
+    review_program(prog.id, store)
+    accept_program(
+        prog.id,
+        store,
+        allowed_actions={"count_words", "count_lines", "normalize_text", "word_frequency"},
+    )
+    return prog.id
+
+
+# ---------------------------------------------------------------------------
+# Replay under a compatible world
+# ---------------------------------------------------------------------------
+
+
+def test_replay_under_compatible_world_allows(
+    store: ProgramStore, world_balanced: WorldDescriptor
+):
+    pid = _accept_program(
+        store, [CandidateStep(tool="count_words", params={"input": "a b c"})]
+    )
+    prog = store.load(pid)
+    trace = ReplayEngine().replay_under_world(prog, world_balanced)
+    assert isinstance(trace, ReplayTrace)
+    assert trace.world_id == "world_balanced"
+    assert trace.world_version == "1.0"
+    assert trace.world_source == "explicit"
+    assert trace.final_verdict == "allow"
+    assert trace.program_trace.ok is True
+    assert all(st.allowed for st in trace.program_trace.step_traces)
+
+
+# ---------------------------------------------------------------------------
+# Replay under an incompatible world
+# ---------------------------------------------------------------------------
+
+
+def test_replay_under_incompatible_world_denies_before_execution(
+    store: ProgramStore, world_strict: WorldDescriptor
+):
+    # normalize_text is absent from world_strict
+    pid = _accept_program(
+        store, [CandidateStep(tool="normalize_text", params={"input": "HELLO"})]
+    )
+    prog = store.load(pid)
+    trace = ReplayEngine().replay_under_world(prog, world_strict)
+    assert trace.world_id == "world_strict"
+    assert trace.final_verdict == "deny"
+    assert trace.program_trace.ok is False
+    assert trace.program_trace.step_traces[0].denied
+    assert "world validation failed" in (
+        trace.program_trace.step_traces[0].error or ""
+    )
+
+
+def test_replay_under_incompatible_world_does_not_execute_later_steps(
+    store: ProgramStore, world_strict: WorldDescriptor
+):
+    pid = _accept_program(
+        store,
+        [
+            CandidateStep(tool="normalize_text", params={"input": "HI"}),  # denied
+            CandidateStep(tool="count_words", params={"input": "a b"}),   # would be ok
+        ],
+    )
+    prog = store.load(pid)
+    trace = ReplayEngine().replay_under_world(prog, world_strict)
+    # Pre-execution validation rejects the whole program — second step never runs.
+    assert trace.final_verdict == "deny"
+    # No 'allow' step trace should exist
+    assert not any(st.allowed for st in trace.program_trace.step_traces)
+
+
+# ---------------------------------------------------------------------------
+# No-world (default) fallback
+# ---------------------------------------------------------------------------
+
+
+def test_replay_without_world_uses_default_set(store: ProgramStore):
+    pid = _accept_program(
+        store, [CandidateStep(tool="count_words", params={"input": "hi"})]
+    )
+    prog = store.load(pid)
+    trace = ReplayEngine().replay_under_world(prog, world=None)
+    assert trace.world_source == "default"
+    assert trace.world_id == "default"
+    assert trace.world_version == "unspecified"
+    assert trace.final_verdict == "allow"
+
+
+def test_replay_under_world_rejects_non_descriptor(store: ProgramStore):
+    pid = _accept_program(
+        store, [CandidateStep(tool="count_words", params={})]
+    )
+    prog = store.load(pid)
+    with pytest.raises(TypeError):
+        ReplayEngine().replay_under_world(prog, world="not_a_descriptor")  # type: ignore
+
+
+# ---------------------------------------------------------------------------
+# Preview-compatible annotation
+# ---------------------------------------------------------------------------
+
+
+def test_preview_flag_is_recorded_on_replay_trace(
+    store: ProgramStore, world_balanced: WorldDescriptor
+):
+    pid = _accept_program(
+        store, [CandidateStep(tool="count_words", params={"input": "hi"})]
+    )
+    prog = store.load(pid)
+    preview = check_compatibility(prog, world_balanced)
+    trace = ReplayEngine().replay_under_world(
+        prog, world_balanced, preview_compatible=preview.compatible
+    )
+    assert trace.preview_compatible is True
+
+
+def test_preview_flag_defaults_to_none(
+    store: ProgramStore, world_balanced: WorldDescriptor
+):
+    pid = _accept_program(
+        store, [CandidateStep(tool="count_words", params={"input": "hi"})]
+    )
+    prog = store.load(pid)
+    trace = ReplayEngine().replay_under_world(prog, world_balanced)
+    assert trace.preview_compatible is None
+
+
+# ---------------------------------------------------------------------------
+# world_source: active vs explicit
+# ---------------------------------------------------------------------------
+
+
+def test_world_source_is_propagated(
+    store: ProgramStore, world_balanced: WorldDescriptor
+):
+    pid = _accept_program(
+        store, [CandidateStep(tool="count_words", params={})]
+    )
+    prog = store.load(pid)
+    t_explicit = ReplayEngine().replay_under_world(
+        prog, world_balanced, world_source="explicit"
+    )
+    t_active = ReplayEngine().replay_under_world(
+        prog, world_balanced, world_source="active"
+    )
+    assert t_explicit.world_source == "explicit"
+    assert t_active.world_source == "active"
+
+
+# ---------------------------------------------------------------------------
+# final_verdict classification helper
+# ---------------------------------------------------------------------------
+
+
+def _manual_verdict(steps_data):
+    """Synthesize a ProgramTrace with arbitrary step outcomes for classifier testing."""
+    pt = ProgramTrace(program_id="prog-x")
+    pt.step_traces = [
+        StepTrace(
+            step_index=i, action=s["action"], verdict=s["verdict"],
+            result=None, error=s.get("error"), duration_seconds=0.0,
+        )
+        for i, s in enumerate(steps_data)
+    ]
+    pt.ok = all(s["verdict"] == "allow" for s in steps_data)
+    if not pt.ok:
+        pt.aborted_at_step = next(
+            (i for i, s in enumerate(steps_data) if s["verdict"] == "deny"), None
+        )
+    return pt
+
+
+def test_classify_verdict_allow():
+    from agent_hypervisor.program_layer.replay_engine import _classify_verdict
+
+    t = _manual_verdict([{"action": "a", "verdict": "allow"}])
+    assert _classify_verdict(t) == "allow"
+
+
+def test_classify_verdict_deny_when_first_step_denied():
+    from agent_hypervisor.program_layer.replay_engine import _classify_verdict
+
+    t = _manual_verdict(
+        [
+            {"action": "a", "verdict": "deny", "error": "x"},
+            {"action": "b", "verdict": "skip"},
+        ]
+    )
+    assert _classify_verdict(t) == "deny"
+
+
+def test_classify_verdict_partial_failure():
+    from agent_hypervisor.program_layer.replay_engine import _classify_verdict
+
+    t = _manual_verdict(
+        [
+            {"action": "a", "verdict": "allow"},
+            {"action": "b", "verdict": "deny", "error": "x"},
+        ]
+    )
+    assert _classify_verdict(t) == "partial_failure"
+
+
+def test_classify_verdict_empty_trace_is_deny():
+    from agent_hypervisor.program_layer.replay_engine import _classify_verdict
+
+    t = ProgramTrace(program_id="prog-empty")
+    t.ok = False
+    assert _classify_verdict(t) == "deny"
+
+
+# ---------------------------------------------------------------------------
+# Serialization
+# ---------------------------------------------------------------------------
+
+
+def test_replay_trace_to_dict_is_json_safe(
+    store: ProgramStore, world_balanced: WorldDescriptor
+):
+    pid = _accept_program(
+        store, [CandidateStep(tool="count_words", params={"input": "hi"})]
+    )
+    prog = store.load(pid)
+    trace = ReplayEngine().replay_under_world(prog, world_balanced)
+    data = trace.to_dict()
+    # All SYS-2 fields must be present
+    for k in (
+        "replay_id", "program_id", "world_id", "world_version",
+        "world_source", "preview_compatible", "final_verdict",
+        "replayed_at", "program_trace",
+    ):
+        assert k in data
+    json.dumps(data, default=str)  # must not raise
+
+
+# ---------------------------------------------------------------------------
+# Legacy replay() is still a plain ProgramTrace (non-breaking)
+# ---------------------------------------------------------------------------
+
+
+def test_legacy_replay_is_untouched(
+    store: ProgramStore, world_balanced: WorldDescriptor
+):
+    pid = _accept_program(
+        store, [CandidateStep(tool="count_words", params={"input": "hi"})]
+    )
+    prog = store.load(pid)
+    trace = ReplayEngine().replay(prog)
+    assert isinstance(trace, ProgramTrace)
+    # The new wrapper type must not leak into the legacy method.
+    assert not isinstance(trace, ReplayTrace)

--- a/tests/program_layer/test_world_registry.py
+++ b/tests/program_layer/test_world_registry.py
@@ -1,0 +1,314 @@
+"""
+test_world_registry.py — WorldRegistry + WorldDescriptor tests (SYS-2 light).
+
+Covers:
+    - WorldDescriptor construction and validation
+    - YAML manifest loading (happy path, missing fields, malformed YAML)
+    - WorldRegistry.list_worlds() sorting and filtering
+    - WorldRegistry.get() with and without explicit version
+    - Active-world pointer: set / get / clear / rollback on bad target
+    - Stale active pointer returns None (does not raise)
+    - default_registry() loads the bundled example worlds
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from agent_hypervisor.program_layer import (
+    WorldDescriptor,
+    WorldLoadError,
+    WorldNotFoundError,
+    WorldRegistry,
+    default_registry,
+    load_world_from_yaml,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _write(path: Path, text: str) -> Path:
+    path.write_text(text, encoding="utf-8")
+    return path
+
+
+@pytest.fixture
+def strict_yaml(tmp_path: Path) -> Path:
+    return _write(
+        tmp_path / "world_strict.yaml",
+        """
+world_id: world_strict
+version: "1.0"
+description: strict
+allowed_actions:
+  - count_words
+  - count_lines
+""".strip(),
+    )
+
+
+@pytest.fixture
+def balanced_yaml(tmp_path: Path) -> Path:
+    return _write(
+        tmp_path / "world_balanced.yaml",
+        """
+world_id: world_balanced
+version: "1.0"
+description: balanced
+allowed_actions:
+  - count_words
+  - count_lines
+  - normalize_text
+  - word_frequency
+""".strip(),
+    )
+
+
+@pytest.fixture
+def registry(tmp_path: Path, strict_yaml: Path, balanced_yaml: Path) -> WorldRegistry:
+    return WorldRegistry(worlds_dir=tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# WorldDescriptor
+# ---------------------------------------------------------------------------
+
+
+def test_world_descriptor_roundtrip():
+    w = WorldDescriptor(
+        world_id="w1",
+        version="1.0",
+        allowed_actions=frozenset({"a", "b"}),
+        description="desc",
+    )
+    data = w.to_dict()
+    assert data["allowed_actions"] == ["a", "b"]  # sorted
+    round = WorldDescriptor.from_dict(data)
+    assert round.world_id == "w1"
+    assert round.version == "1.0"
+    assert round.allowed_actions == frozenset({"a", "b"})
+
+
+def test_world_descriptor_rejects_empty_id():
+    with pytest.raises(ValueError):
+        WorldDescriptor(world_id="", version="1.0", allowed_actions=frozenset())
+
+
+def test_world_descriptor_rejects_empty_version():
+    with pytest.raises(ValueError):
+        WorldDescriptor(world_id="w1", version="", allowed_actions=frozenset())
+
+
+def test_world_descriptor_rejects_non_frozenset_actions():
+    with pytest.raises(TypeError):
+        WorldDescriptor(
+            world_id="w1", version="1.0", allowed_actions={"a"}  # set, not frozenset
+        )
+
+
+# ---------------------------------------------------------------------------
+# YAML loader
+# ---------------------------------------------------------------------------
+
+
+def test_load_world_from_yaml_happy_path(strict_yaml: Path):
+    w = load_world_from_yaml(strict_yaml)
+    assert w.world_id == "world_strict"
+    assert w.version == "1.0"
+    assert w.allowed_actions == frozenset({"count_words", "count_lines"})
+    assert w.description == "strict"
+    assert w.manifest_path is not None
+    assert w.created_at  # populated from file mtime
+
+
+def test_load_world_missing_file(tmp_path: Path):
+    with pytest.raises(WorldLoadError):
+        load_world_from_yaml(tmp_path / "nope.yaml")
+
+
+def test_load_world_missing_required_field(tmp_path: Path):
+    bad = _write(tmp_path / "bad.yaml", "world_id: only_id\n")
+    with pytest.raises(WorldLoadError):
+        load_world_from_yaml(bad)
+
+
+def test_load_world_bad_actions_type(tmp_path: Path):
+    bad = _write(
+        tmp_path / "bad.yaml",
+        "world_id: x\nversion: 1.0\nallowed_actions: not_a_list\n",
+    )
+    with pytest.raises(WorldLoadError):
+        load_world_from_yaml(bad)
+
+
+def test_load_world_non_mapping(tmp_path: Path):
+    bad = _write(tmp_path / "bad.yaml", "- just a list\n- not a mapping\n")
+    with pytest.raises(WorldLoadError):
+        load_world_from_yaml(bad)
+
+
+def test_load_world_malformed_yaml(tmp_path: Path):
+    bad = _write(tmp_path / "bad.yaml", "world_id: [unclosed\n")
+    with pytest.raises(WorldLoadError):
+        load_world_from_yaml(bad)
+
+
+# ---------------------------------------------------------------------------
+# Registry listing
+# ---------------------------------------------------------------------------
+
+
+def test_list_worlds_returns_sorted(registry: WorldRegistry):
+    worlds = registry.list_worlds()
+    keys = [w.key for w in worlds]
+    assert keys == sorted(keys)
+    ids = {w.world_id for w in worlds}
+    assert ids == {"world_strict", "world_balanced"}
+
+
+def test_list_worlds_skips_hidden_and_non_yaml(
+    tmp_path: Path, strict_yaml: Path
+):
+    # Dotfile + non-YAML should not appear
+    _write(tmp_path / ".hidden.yaml", "ignored: true\n")
+    _write(tmp_path / "notes.txt", "not yaml")
+    worlds = WorldRegistry(tmp_path).list_worlds()
+    assert [w.world_id for w in worlds] == ["world_strict"]
+
+
+def test_list_worlds_skips_corrupt_files(tmp_path: Path, strict_yaml: Path):
+    _write(tmp_path / "broken.yaml", "world_id: missing_version\n")
+    worlds = WorldRegistry(tmp_path).list_worlds()
+    assert [w.world_id for w in worlds] == ["world_strict"]
+
+
+def test_list_worlds_empty_dir(tmp_path: Path):
+    empty = tmp_path / "empty"
+    empty.mkdir()
+    assert WorldRegistry(empty).list_worlds() == []
+
+
+def test_list_worlds_missing_dir(tmp_path: Path):
+    assert WorldRegistry(tmp_path / "does_not_exist").list_worlds() == []
+
+
+# ---------------------------------------------------------------------------
+# Registry.get
+# ---------------------------------------------------------------------------
+
+
+def test_get_by_id_and_version(registry: WorldRegistry):
+    w = registry.get("world_strict", "1.0")
+    assert w.world_id == "world_strict"
+    assert w.version == "1.0"
+
+
+def test_get_latest_when_version_omitted(registry: WorldRegistry):
+    w = registry.get("world_balanced")  # only one version → returns it
+    assert w.world_id == "world_balanced"
+
+
+def test_get_unknown_id_raises(registry: WorldRegistry):
+    with pytest.raises(WorldNotFoundError):
+        registry.get("does_not_exist")
+
+
+def test_get_unknown_version_raises(registry: WorldRegistry):
+    with pytest.raises(WorldNotFoundError):
+        registry.get("world_strict", "99.0")
+
+
+def test_get_latest_version_picks_lexicographic_last(tmp_path: Path):
+    _write(
+        tmp_path / "w_a.yaml",
+        "world_id: w\nversion: \"1.0\"\nallowed_actions: [a]\n",
+    )
+    _write(
+        tmp_path / "w_b.yaml",
+        "world_id: w\nversion: \"2.0\"\nallowed_actions: [a, b]\n",
+    )
+    w = WorldRegistry(tmp_path).get("w")
+    assert w.version == "2.0"
+
+
+# ---------------------------------------------------------------------------
+# Active-world pointer
+# ---------------------------------------------------------------------------
+
+
+def test_get_active_returns_none_initially(registry: WorldRegistry):
+    assert registry.get_active() is None
+
+
+def test_set_and_get_active(registry: WorldRegistry):
+    registry.set_active("world_strict", "1.0")
+    active = registry.get_active()
+    assert active is not None
+    assert active.world_id == "world_strict"
+    assert active.version == "1.0"
+
+
+def test_set_active_fails_on_unknown_target_and_leaves_state_intact(
+    registry: WorldRegistry,
+):
+    registry.set_active("world_strict", "1.0")
+    with pytest.raises(WorldNotFoundError):
+        registry.set_active("does_not_exist", "1.0")
+    # Previous active pointer must still be valid
+    active = registry.get_active()
+    assert active is not None
+    assert active.world_id == "world_strict"
+
+
+def test_clear_active_removes_pointer(registry: WorldRegistry):
+    registry.set_active("world_strict", "1.0")
+    registry.clear_active()
+    assert registry.get_active() is None
+
+
+def test_clear_active_when_nothing_set_is_safe(registry: WorldRegistry):
+    # must not raise
+    registry.clear_active()
+    assert registry.get_active() is None
+
+
+def test_stale_active_pointer_returns_none(
+    tmp_path: Path, strict_yaml: Path, balanced_yaml: Path
+):
+    registry = WorldRegistry(tmp_path)
+    registry.set_active("world_strict", "1.0")
+    # Delete the world file out from under the pointer
+    strict_yaml.unlink()
+    # Re-list so the in-memory state reflects the deletion
+    assert registry.get_active() is None
+
+
+def test_corrupt_active_file_returns_none(tmp_path: Path, strict_yaml: Path):
+    registry = WorldRegistry(tmp_path)
+    (tmp_path / ".active.json").write_text("{not valid json", encoding="utf-8")
+    assert registry.get_active() is None
+
+
+def test_custom_active_file_location(tmp_path: Path, strict_yaml: Path):
+    pointer = tmp_path / "pointer.json"
+    registry = WorldRegistry(worlds_dir=tmp_path, active_file=pointer)
+    registry.set_active("world_strict", "1.0")
+    assert pointer.exists()
+    assert not (tmp_path / ".active.json").exists()
+
+
+# ---------------------------------------------------------------------------
+# Bundled default registry
+# ---------------------------------------------------------------------------
+
+
+def test_default_registry_exposes_bundled_worlds(tmp_path: Path):
+    # Redirect the active-pointer file so tests can't pollute the package dir.
+    registry = default_registry(active_file=tmp_path / "active.json")
+    ids = {w.world_id for w in registry.list_worlds()}
+    assert {"world_strict", "world_balanced"} <= ids


### PR DESCRIPTION
## Summary

Implements SYS-2 light, a system for validating and replaying reviewed programs under different registered Worlds. A World defines the set of actions a program is permitted to use; this change adds the infrastructure to preview program compatibility against any World and replay programs with world-based authority enforcement.

The core principle: **historical acceptance does not grant ongoing authority**. A program accepted under one World can be re-checked and replayed under any registered World, and the current World's rules always decide.

## Key Changes

### New Modules

- **`world_registry.py`** — Lightweight registry for loading and managing Worlds from YAML manifests. Tracks an "active" World via atomic pointer updates. Each World declares `world_id`, `version`, and `allowed_actions` (frozenset).

- **`compatibility.py`** — Deterministic program–world compatibility checking. Provides:
  - `check_compatibility(program, world)` → `ProgramWorldCompatibility` with per-step verdicts
  - `preview_program_under_world(...)` — registry-aware wrapper
  - `compare_program_across_worlds(...)` → `ProgramWorldDiff` showing divergence points

- **`world_registry.py` + `compatibility.py`** — Pure validation passes with no side effects; delegate per-step authority checks to existing `world_validator.validate_step`.

### Enhanced Modules

- **`replay_engine.py`** — Added `ReplayTrace` dataclass wrapping `ProgramTrace` with world context:
  - `replay_under_world(program, world)` — replay with explicit world enforcement
  - `replay_under_active_world(program)` — use registry's active pointer
  - Records `world_source` ("active", "explicit", or "default"), `final_verdict` ("allow", "deny", "partial_failure"), and `preview_compatible` annotation
  - Legacy `replay()` method unchanged

- **`cli.py`** — New `awc program` command group with subcommands:
  - `propose` — create PROPOSED program from JSON step list
  - `minimize` — apply deterministic minimization, print diff
  - `review` — transition PROPOSED → REVIEWED
  - `accept` — transition REVIEWED → ACCEPTED (with world validation)
  - `reject` — transition REVIEWED → REJECTED
  - `replay` — replay under default/active world, output JSON trace
  - `list` — list stored programs with status and step counts
  - `show` — display full program JSON
  - `preview` — check compatibility under a specific world
  - `compare` — compare program across two worlds

- **`__init__.py`** — Export new compatibility types and functions

### Example & Documentation

- **`examples/program_world_compatibility_demo.py`** — End-to-end demonstration: propose → minimize → review → accept a program, then preview and replay under different Worlds to show divergent verdicts.

- **`docs/program-world-compatibility.md`** — Conceptual guide explaining the three world sources, preview semantics, and the invariant that current World authority overrides historical acceptance.

- **`docs/program-lifecycle.md`** — Updated with CLI usage examples.

### Test Coverage

- **`test_world_registry.py`** — WorldDescriptor construction, YAML loading, registry operations, active-pointer management
- **`test_compatibility.py`** — Per-step verdicts, summary counts, mixed compatibility, empty minimized_steps edge case
- **`test_replay_under_world.py`** — Replay under compatible/incompatible worlds, pre-execution denial, fallback to default world, ReplayTrace JSON serialization
- **`test_cli_program.py`** — CLI argument parsing, JSON input validation, lifecycle happy path, error exit codes

### Bundled Worlds

- **`worlds/world_strict.yaml`** — Permits only `count_words`, `count_lines` (basic measurement)
- **`worlds/world_balanced.yaml`** — Permits all deterministic text workflows (measurement + transformation)

## Notable Implementation Details

- **Atomic world switching**: `WorldRegistry.set_active()` validates the target before updating the pointer

https://claude.ai/code/session_018TYpWmkWkAd1Czwqvvon7w