### PR TITLE
feat(program-layer): SYS-3 — comparative playground (scenario runner)

### DIFF
--- a/docs/comparative-playground.md
+++ b/docs/comparative-playground.md
@@ -1,0 +1,200 @@
+# Comparative Playground (SYS-3)
+
+The Comparative Playground is the first **visible proof layer** of the Agent
+Hypervisor.  It is not a UI polish layer.  It is a differential execution
+analyzer that makes a single claim legible:
+
+> **The same program produces different outcomes under different worlds.
+> `program ≠ authority`; `world = authority`.**
+
+Security is a property of the World, not of the agent.  SYS-3 lets you see
+that in one command.
+
+---
+
+## What this shows
+
+A **Scenario** binds ONE reviewed program to N worlds.  `run_scenario(...)`
+does this, per world, without touching the sealed runtime:
+
+1. **Preview** — `check_compatibility(program, world)` decides whether the
+   program is admissible under the world's allowed-action set.
+2. **Replay** — if preview passes, `ReplayEngine.replay_under_world(...)` runs
+   the same enforcement path live execution uses and records a per-step
+   verdict trace.
+3. **Outcome matrix** — one `StepOutcome` row per `(step, world)`, carrying
+   `stage`, `verdict`, and a deterministic `rule_kind`
+   (`capability`, `schema`, `taint`, `policy`, `execution`).
+4. **Divergence** — a step is divergent iff two worlds produced different
+   verdicts at the same index.  `DivergenceReport.all_agree` is a single-bit
+   summary for CI pipelines.
+
+Typical run of the bundled `memory_write_test` scenario:
+
+```
+World: world_strict@1.0
+  preview: incompatible
+  step[0] count_words        ALLOW  (preview/capability: action present in world)
+  step[1] normalize_text     DENY   (preview/capability: action not in allowed set)
+  replay:  denied_at_preview
+
+World: world_balanced@1.0
+  preview: compatible
+  step[0] count_words        ALLOW  (replay/execution: executed successfully)
+  step[1] normalize_text     ALLOW  (replay/execution: executed successfully)
+  replay:  allow
+
+Divergence:
+  step[1] normalize_text
+    world_strict@1.0       DENY   action not in allowed set
+    world_balanced@1.0     ALLOW  executed successfully
+```
+
+---
+
+## Why it matters
+
+Agent security frameworks tend to treat "what the agent can do" as a property
+of the agent.  SYS-3 demonstrates the opposite by construction:
+
+- The program is **immutable** across the run (the ReviewedProgram loaded
+  once, reused for every world).
+- No LLM call, no heuristic, no monitoring exists on the verdict path.  Every
+  verdict is a deterministic consequence of the world's rules evaluated over
+  the program's steps.
+- The explanation for every outcome is a fixed rule class, not a generated
+  sentence.  Re-running the same scenario with identical inputs produces a
+  byte-identical result after scrubbing `run_id`/`ran_at`.
+
+That makes the World a first-class, swappable authority surface.  You can
+tighten or relax enforcement by changing the World, not the agent; and you
+can prove the change is real by comparing two scenario runs.
+
+---
+
+## How to use
+
+### CLI
+
+```bash
+# List the bundled scenarios.
+awc scenario list
+
+# Inspect a specific scenario as JSON.
+awc scenario show memory_write_test
+
+# Run it across all its worlds.
+awc scenario run memory_write_test
+
+# Same, but emit machine-readable ScenarioResult JSON.
+awc scenario run memory_write_test --json
+
+# Append every run to a persistent JSONL trace file.
+awc scenario run memory_write_test --trace-file .ah/scenario_traces.jsonl
+```
+
+Exit codes:
+
+| Code | Meaning |
+|------|---------|
+| 0    | Scenario ran; all worlds agreed on every step. |
+| 1    | Scenario not found, malformed YAML, or unknown world. |
+| 6    | Scenario ran; at least one step diverged across worlds. |
+
+### Python
+
+```python
+from pathlib import Path
+from agent_hypervisor.program_layer import (
+    ScenarioRegistry,
+    WorldRegistry,
+    run_scenario,
+)
+
+registry = WorldRegistry(
+    worlds_dir=Path("src/agent_hypervisor/program_layer/worlds"),
+    active_file=Path(".ah/active_world.json"),
+)
+scen_reg = ScenarioRegistry(
+    Path("src/agent_hypervisor/program_layer/scenarios")
+)
+scenario = scen_reg.get("memory_write_test")
+
+result = run_scenario(scenario, registry=registry)
+
+print(f"divergence points: {len(result.divergence.divergence_points)}")
+for wr in result.world_results:
+    print(f"{wr.key}: preview={wr.preview_compatible} replay={wr.replay_verdict}")
+```
+
+A fully runnable end-to-end script lives at
+[`examples/comparative_playground_demo.py`](../examples/comparative_playground_demo.py).
+
+### Bundled scenarios
+
+Under `src/agent_hypervisor/program_layer/scenarios/`:
+
+| File | Program | Worlds | Narrative |
+|------|---------|--------|-----------|
+| `scenario_memory_write.yaml`  | `count_words` → `normalize_text` | strict, balanced | Writing a derived value "to memory" (stand-in: `normalize_text`) is denied under strict; allowed under balanced. |
+| `scenario_external_call.yaml` | `count_lines` → `word_frequency` | strict, balanced | Producing a ranked external-facing output is denied under strict; allowed under balanced. |
+
+### Authoring a scenario
+
+A scenario YAML pins a program (inline steps **or** a `program_id` reference)
+to two or more `(world_id, version)` pairs:
+
+```yaml
+scenario_id: my_scenario
+name: "Short human-readable name"
+description: "What this scenario demonstrates."
+program_steps:
+  - tool: count_words
+    params: {input: "hello world"}
+  - tool: normalize_text
+    params: {input: "HELLO WORLD"}
+worlds:
+  - world_id: world_strict
+    version: "1.0"
+  - world_id: world_balanced
+    version: "1.0"
+```
+
+Invariants enforced at load time:
+
+- `worlds` must contain **at least two distinct** `(id, version)` pairs.
+- `version` must be concrete — `"latest"` is rejected so scenario runs stay
+  deterministic.
+- Exactly one of `program_id` or `program_steps` must be set.
+
+---
+
+## Limitations
+
+- **Narrative vs wired actions.**  The bundled scenarios describe "memory
+  write" and "external call" in their `description` fields, but the program
+  steps reuse the four real `SUPPORTED_WORKFLOWS`
+  (`count_words`, `count_lines`, `normalize_text`, `word_frequency`) so the
+  demos stay executable without adding stub tool handlers.  Narrative labels
+  are documentation, not tool bindings.
+- **Per-step-index comparison.**  Divergence is measured by step index, not
+  by semantic step identity.  Inserting a step in one program but not another
+  is out of scope — scenarios bind one program to many worlds, not many
+  programs to many worlds.
+- **`input` is opaque.**  `Scenario.input` is forwarded to the replay engine
+  as `context` but is not schema-validated.  Callers treat it as free-form.
+- **Timestamps are non-deterministic.**  `run_id` and `ran_at` differ across
+  runs; use `ScenarioResult.scrub_run_metadata()` before byte-comparing two
+  runs.
+- **No HTTP surface yet.**  The CLI is the only user-facing entry point.
+  Downstream systems consume `scenario run --json` or the append-only
+  `ScenarioTraceStore`.
+
+---
+
+## Related
+
+- World registry & activation — [SYS-2 light](../src/agent_hypervisor/program_layer/world_registry.py)
+- Program review lifecycle — [PL-3](../src/agent_hypervisor/program_layer/review_lifecycle.py)
+- Compatibility preview — [`compatibility.py`](../src/agent_hypervisor/program_layer/compatibility.py)
+- Replay engine — [`replay_engine.py`](../src/agent_hypervisor/program_layer/replay_engine.py)

--- a/examples/comparative_playground_demo.py
+++ b/examples/comparative_playground_demo.py
@@ -1,0 +1,163 @@
+"""
+comparative_playground_demo.py — SYS-3 end-to-end demonstration.
+
+ONE program, multiple worlds, divergent outcomes.  The program is loaded
+via a Scenario; each world is evaluated via ``run_scenario`` which composes
+``check_compatibility`` (preview) and ``ReplayEngine.replay_under_world``
+(execution) without modifying the sealed runtime.
+
+Flow:
+    1. Build a ProgramStore and a WorldRegistry in a tempdir, seeded with
+       the bundled strict/balanced worlds.
+    2. Load the bundled ``memory_write_test`` scenario (program_steps:
+       ``[count_words, normalize_text]``; worlds: ``world_strict``,
+       ``world_balanced``).
+    3. Call ``run_scenario`` — preview + replay runs under each world.
+    4. Pretty-print per-world outcomes and the divergence report.
+
+Expected outcome:
+    world_strict  @1.0: preview=incompatible, replay=denied_at_preview,
+                        step[1] normalize_text DENY (capability).
+    world_balanced@1.0: preview=compatible,   replay=allow,
+                        all steps ALLOW.
+    Divergence points: [step[1] normalize_text].
+
+Run:
+    python examples/comparative_playground_demo.py
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import sys
+import tempfile
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+from agent_hypervisor.program_layer import (
+    ProgramStore,
+    ScenarioRegistry,
+    WorldRegistry,
+    run_scenario,
+)
+
+
+BUNDLED_WORLDS_DIR = (
+    Path(__file__).parent.parent
+    / "src" / "agent_hypervisor" / "program_layer" / "worlds"
+)
+BUNDLED_SCENARIOS_DIR = (
+    Path(__file__).parent.parent
+    / "src" / "agent_hypervisor" / "program_layer" / "scenarios"
+)
+
+
+def _sep(title: str) -> None:
+    print(f"\n{'─' * 64}")
+    print(f"  {title}")
+    print("─" * 64)
+
+
+def _print_world_result(wr) -> None:
+    preview = "compatible" if wr.preview_compatible else "INCOMPATIBLE"
+    print(f"\n  World: {wr.key}")
+    print(f"    preview: {preview}")
+    for o in wr.step_outcomes:
+        mark = "✓" if o.verdict == "allow" else ("✗" if o.verdict == "deny" else "·")
+        print(
+            f"    {mark} step[{o.step_index}] {o.action:<18} "
+            f"{o.verdict.upper():<5} ({o.stage}/{o.rule_kind}: {o.reason})"
+        )
+    print(f"    replay:  {wr.replay_verdict}")
+
+
+def _print_divergence(report) -> None:
+    print(f"\n  Divergence ({len(report.divergence_points)} point(s)):")
+    if report.all_agree:
+        print("    (worlds agreed on every step)")
+        return
+    for d in report.divergence_points:
+        print(f"    step[{d.step_index}] {d.action}")
+        for wk, v in d.verdicts_by_world.items():
+            print(f"      {wk:<22} {v.upper():<5}  "
+                  f"{d.reasons_by_world.get(wk, '')}")
+
+
+def run_demo() -> None:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+
+        # Step 1 — stores + registries
+        _sep("STEP 1 — Set up ProgramStore, WorldRegistry, ScenarioRegistry")
+        store = ProgramStore(tmp / "programs")
+        worlds_dir = tmp / "worlds"
+        worlds_dir.mkdir()
+        for yaml in BUNDLED_WORLDS_DIR.glob("*.yaml"):
+            shutil.copy(yaml, worlds_dir / yaml.name)
+        registry = WorldRegistry(worlds_dir=worlds_dir, active_file=tmp / "active.json")
+        scen_reg = ScenarioRegistry(BUNDLED_SCENARIOS_DIR)
+
+        print(f"\n  programs dir:  {tmp / 'programs'}")
+        print(f"  worlds dir:    {worlds_dir}")
+        print(f"  scenarios dir: {BUNDLED_SCENARIOS_DIR}")
+        print("\n  Registered worlds:")
+        for w in registry.list_worlds():
+            print(f"    {w.world_id}@{w.version}  "
+                  f"actions={sorted(w.allowed_actions)}")
+        print("\n  Bundled scenarios:")
+        for s in scen_reg.list_scenarios():
+            print(f"    {s.scenario_id:<24} ({len(s.worlds)} worlds)  {s.name}")
+
+        # Step 2 — pick a scenario
+        _sep("STEP 2 — Load scenario 'memory_write_test'")
+        scenario = scen_reg.get("memory_write_test")
+        print(f"\n  scenario_id: {scenario.scenario_id}")
+        print(f"  name:        {scenario.name}")
+        print(f"  description: {scenario.description.strip()}")
+        if scenario.program_steps:
+            print("  program_steps (inline):")
+            for i, st in enumerate(scenario.program_steps):
+                print(f"    [{i}] {st.tool}  params={st.params}")
+        print("  worlds:")
+        for w in scenario.worlds:
+            print(f"    {w.world_id}@{w.version}")
+
+        # Step 3 — run the scenario
+        _sep("STEP 3 — run_scenario(...) across all worlds")
+        result = run_scenario(
+            scenario,
+            registry=registry,
+            store=store if scenario.program_id else None,
+        )
+
+        # Step 4 — report
+        _sep("STEP 4 — Per-world results")
+        for wr in result.world_results:
+            _print_world_result(wr)
+
+        _sep("STEP 5 — Divergence report")
+        _print_divergence(result.divergence)
+
+        # Summary
+        _sep("SUMMARY")
+        print(f"""
+  Scenario           : {result.scenario_id}
+  Program            : {result.program_id}
+  Worlds compared    : {len(result.world_results)}
+  Divergence points  : {len(result.divergence.divergence_points)}
+  All worlds agree   : {result.divergence.all_agree}
+  run_id             : {result.run_id}
+  ran_at             : {result.ran_at}
+
+  Moral: the program is the same.  The world is what decides.
+""")
+
+        blob = json.dumps(result.to_dict(), default=str)
+        print("  JSON artifact (first 400 chars):")
+        print("  " + blob[:400] + ("…" if len(blob) > 400 else ""))
+
+
+if __name__ == "__main__":
+    run_demo()

--- a/src/agent_hypervisor/compiler/cli.py
+++ b/src/agent_hypervisor/compiler/cli.py
@@ -926,3 +926,188 @@ def _print_program_world_diff(diff) -> None:
             f"B={_col(d.world_b, _GREEN if d.world_b == 'allowed' else _RED)}"
         )
         click.echo(f"      reason: {d.reason}")
+
+
+# ── scenario (SYS-3 Comparative Playground) ──────────────────────────────────
+#
+# Thin CLI wrapper over program_layer.scenario_runner.  A scenario pins ONE
+# program to N worlds; `awc scenario run` orchestrates preview + replay for
+# each world and prints a side-by-side divergence view.
+
+
+def _default_scenarios_dir() -> str:
+    from pathlib import Path as _P
+    return str(_P(__file__).parent.parent / "program_layer" / "scenarios")
+
+
+def _scenario_registry(scenarios_dir: str):
+    from agent_hypervisor.program_layer import ScenarioRegistry
+    return ScenarioRegistry(scenarios_dir)
+
+
+@cli.group("scenario")
+def cmd_scenario():
+    """Run comparative scenarios (SYS-3: one program, many worlds)."""
+
+
+@cmd_scenario.command("list")
+@click.option("--scenarios-dir", "scenarios_dir", default=_default_scenarios_dir,
+              show_default=True, help="Directory of scenario YAML manifests.")
+def cmd_scenario_list(scenarios_dir: str):
+    """List all scenarios under --scenarios-dir."""
+    scenarios = _scenario_registry(scenarios_dir).list_scenarios()
+    if not scenarios:
+        click.echo(_col("(no scenarios)", _DIM))
+        return
+    click.echo(f"{'scenario_id':<28} {'worlds':>6}  name")
+    click.echo(_col("─" * 72, _DIM))
+    for s in scenarios:
+        click.echo(f"{s.scenario_id:<28} {len(s.worlds):>6}  {s.name}")
+
+
+@cmd_scenario.command("show")
+@click.argument("scenario_id")
+@click.option("--scenarios-dir", "scenarios_dir", default=_default_scenarios_dir,
+              show_default=True)
+def cmd_scenario_show(scenario_id: str, scenarios_dir: str):
+    """Print a scenario's YAML contents as JSON."""
+    from agent_hypervisor.program_layer import ScenarioNotFoundError
+    try:
+        s = _scenario_registry(scenarios_dir).get(scenario_id)
+    except ScenarioNotFoundError as exc:
+        _fail(str(exc))
+    json.dump(s.to_dict(), sys.stdout, indent=2, default=str)
+    click.echo()
+
+
+@cmd_scenario.command("run")
+@click.argument("scenario_id")
+@click.option("--scenarios-dir", "scenarios_dir", default=_default_scenarios_dir,
+              show_default=True)
+@click.option("--worlds-dir", "worlds_dir", default=_default_worlds_dir, show_default=True)
+@click.option("--store", "store_dir", default=_DEFAULT_PROGRAM_STORE, show_default=True,
+              help="ProgramStore directory (only used when the scenario references "
+                   "an existing program by id).")
+@click.option("--trace-file", "trace_file", default=None, type=click.Path(),
+              help="Append the ScenarioResult to this JSONL file.")
+@click.option("--json", "json_out", is_flag=True, default=False,
+              help="Emit ScenarioResult as JSON instead of the human view.")
+def cmd_scenario_run(scenario_id: str, scenarios_dir: str, worlds_dir: str,
+                     store_dir: str, trace_file: str | None, json_out: bool):
+    """Run SCENARIO_ID across its worlds and print the comparative output."""
+    from agent_hypervisor.program_layer import (
+        ScenarioNotFoundError,
+        ScenarioTraceStore,
+        WorldNotFoundError,
+        run_scenario,
+    )
+
+    scen_reg = _scenario_registry(scenarios_dir)
+    worlds = _world_registry(worlds_dir)
+    program_store = _program_store(store_dir)
+
+    try:
+        scenario = scen_reg.get(scenario_id)
+    except ScenarioNotFoundError as exc:
+        _fail(str(exc))
+
+    try:
+        result = run_scenario(
+            scenario,
+            registry=worlds,
+            store=program_store if scenario.program_id else None,
+        )
+    except (KeyError, ValueError, WorldNotFoundError) as exc:
+        _fail(str(exc))
+
+    if trace_file:
+        ScenarioTraceStore(trace_file).append(result)
+
+    if json_out:
+        json.dump(result.to_dict(), sys.stdout, indent=2, default=str)
+        click.echo()
+    else:
+        _print_scenario_result(scenario, result)
+
+    if not result.divergence.all_agree:
+        # Exit code 6 signals "worlds disagreed" — distinct from the other
+        # program_layer CLI codes (3 preview-incompat, 4 replay-deny,
+        # 5 partial-failure).
+        raise SystemExit(6)
+
+
+@cmd_scenario.command("compare")
+@click.argument("scenario_id")
+@click.option("--scenarios-dir", "scenarios_dir", default=_default_scenarios_dir,
+              show_default=True)
+@click.option("--worlds-dir", "worlds_dir", default=_default_worlds_dir, show_default=True)
+@click.option("--store", "store_dir", default=_DEFAULT_PROGRAM_STORE, show_default=True)
+@click.pass_context
+def cmd_scenario_compare(ctx, scenario_id: str, scenarios_dir: str,
+                         worlds_dir: str, store_dir: str):
+    """Alias for ``scenario run`` that emphasises the divergence view."""
+    ctx.invoke(
+        cmd_scenario_run,
+        scenario_id=scenario_id,
+        scenarios_dir=scenarios_dir,
+        worlds_dir=worlds_dir,
+        store_dir=store_dir,
+        trace_file=None,
+        json_out=False,
+    )
+
+
+def _verdict_col(verdict: str) -> str:
+    if verdict == "allow":
+        return _col("ALLOW", _GREEN)
+    if verdict == "deny":
+        return _col("DENY ", _RED)
+    return _col("SKIP ", _YELLOW)
+
+
+def _replay_col(replay_verdict: str) -> str:
+    if replay_verdict == "allow":
+        return _col(replay_verdict, _GREEN)
+    if replay_verdict in ("deny", "denied_at_preview"):
+        return _col(replay_verdict, _RED)
+    return _col(replay_verdict, _YELLOW)
+
+
+def _print_scenario_result(scenario, result) -> None:
+    click.echo()
+    click.echo(_col(f"Scenario: {scenario.scenario_id}", _BOLD))
+    click.echo(f"  Name:     {scenario.name}")
+    click.echo(f"  Program:  {result.program_id}")
+    click.echo(f"  Worlds:   {len(result.world_results)}")
+    if scenario.description.strip():
+        click.echo(_col(f"  {scenario.description.strip()}", _DIM))
+    click.echo()
+
+    for wr in result.world_results:
+        preview_tag = (
+            _col("compatible", _GREEN) if wr.preview_compatible
+            else _col("incompatible", _RED)
+        )
+        click.echo(_col(f"World: {wr.key}", _BOLD))
+        click.echo(f"  preview: {preview_tag}")
+        for o in wr.step_outcomes:
+            verdict = _verdict_col(o.verdict)
+            action = f"{o.action:<18}"
+            click.echo(
+                f"  step[{o.step_index}] {action} {verdict}  "
+                f"{_col(f'({o.rule_kind}: {o.reason})', _DIM)}"
+            )
+        click.echo(f"  replay:  {_replay_col(wr.replay_verdict)}")
+        click.echo()
+
+    click.echo(_col("Divergence:", _BOLD))
+    if result.divergence.all_agree:
+        click.echo(_col("  (worlds agreed on every step)", _DIM))
+        return
+
+    for d in result.divergence.divergence_points:
+        click.echo(f"  step[{d.step_index}] {d.action}")
+        for world_key in d.verdicts_by_world:
+            verdict = _verdict_col(d.verdicts_by_world[world_key])
+            reason = d.reasons_by_world.get(world_key, "")
+            click.echo(f"    {world_key:<22} {verdict}  {_col(reason, _DIM)}")

--- a/src/agent_hypervisor/program_layer/__init__.py
+++ b/src/agent_hypervisor/program_layer/__init__.py
@@ -111,6 +111,28 @@ from .review_models import (
     ReviewedProgram,
     make_program_id,
 )
+from .scenario_model import (
+    DivergenceReport,
+    Scenario,
+    ScenarioDivergencePoint,
+    ScenarioResult,
+    StepOutcome,
+    WorldRef,
+    WorldResult,
+    make_scenario_run_id,
+)
+from .scenario_registry import (
+    ScenarioLoadError,
+    ScenarioNotFoundError,
+    ScenarioRegistry,
+    default_scenario_registry,
+    load_scenario_from_yaml,
+)
+from .scenario_runner import (
+    detect_divergence,
+    run_scenario,
+)
+from .scenario_trace_store import ScenarioTraceStore
 from .sandbox_runtime import (
     SandboxError,
     SandboxRuntime,
@@ -209,4 +231,23 @@ __all__ = [
     "compare_program_across_worlds",
     # SYS-2 light: Replay-under-world
     "ReplayTrace",
+    # SYS-3: Comparative Playground — scenario model
+    "Scenario",
+    "WorldRef",
+    "StepOutcome",
+    "WorldResult",
+    "ScenarioDivergencePoint",
+    "DivergenceReport",
+    "ScenarioResult",
+    "make_scenario_run_id",
+    # SYS-3: Comparative Playground — orchestration
+    "run_scenario",
+    "detect_divergence",
+    # SYS-3: Comparative Playground — registry and trace store
+    "ScenarioRegistry",
+    "ScenarioNotFoundError",
+    "ScenarioLoadError",
+    "load_scenario_from_yaml",
+    "default_scenario_registry",
+    "ScenarioTraceStore",
 ]

--- a/src/agent_hypervisor/program_layer/scenario_model.py
+++ b/src/agent_hypervisor/program_layer/scenario_model.py
@@ -1,0 +1,477 @@
+"""
+scenario_model.py — SYS-3 Comparative Playground data models.
+
+A **Scenario** binds ONE program to MULTIPLE worlds.  The point of SYS-3 is
+to make visible a single deterministic claim:
+
+    The same program produces different outcomes under different worlds.
+    program ≠ authority; world = authority.
+
+Data model layering (all frozen dataclasses, all with stable ``to_dict`` /
+``from_dict`` matching the house style in ``review_models.py``):
+
+    WorldRef                 — (world_id, version) pair.
+    Scenario                 — one program bound to N worlds.  Program may be
+                               referenced by id (loaded from ProgramStore) or
+                               embedded as a list of steps (self-contained).
+    StepOutcome              — one row per (step, world): stage + verdict +
+                               reason + rule_kind.  The deterministic rule
+                               class surfaces WHY a step was allowed/denied.
+    WorldResult              — all step outcomes for a single world plus the
+                               preview verdict and replay verdict.
+    ScenarioDivergencePoint  — a step_index where at least two worlds produced
+                               different (verdict, rule_kind) values.
+    DivergenceReport         — the set of divergence points for a scenario
+                               run plus ``all_agree`` for quick checks.
+    ScenarioResult           — the full run: per-world results + divergence
+                               + a fresh ``run_id`` and ``ran_at`` timestamp.
+
+Nothing here executes.  These are pure value types.  The runner in
+``scenario_runner.py`` composes them from existing primitives
+(``check_compatibility``, ``ReplayEngine.replay_under_world``).
+"""
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Literal, Mapping, Optional
+
+from .review_models import CandidateStep
+
+
+# ---------------------------------------------------------------------------
+# Enums (as string Literals — keep serialisation trivial)
+# ---------------------------------------------------------------------------
+
+
+StepStage = Literal["preview", "replay", "skipped"]
+StepVerdict = Literal["allow", "deny", "skip"]
+RuleKind = Literal["capability", "schema", "taint", "policy", "execution"]
+ReplayVerdict = Literal[
+    "allow", "deny", "partial_failure", "denied_at_preview"
+]
+
+
+_VALID_STAGES = frozenset({"preview", "replay", "skipped"})
+_VALID_VERDICTS = frozenset({"allow", "deny", "skip"})
+_VALID_RULE_KINDS = frozenset(
+    {"capability", "schema", "taint", "policy", "execution"}
+)
+_VALID_REPLAY_VERDICTS = frozenset(
+    {"allow", "deny", "partial_failure", "denied_at_preview"}
+)
+
+
+# ---------------------------------------------------------------------------
+# WorldRef
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class WorldRef:
+    """A (world_id, version) pair used to pin a scenario to a concrete world.
+
+    version is required and must be non-empty.  "latest" is forbidden: a
+    scenario must be deterministic, and pinning to "latest" would let a new
+    world release silently change the result.
+    """
+
+    world_id: str
+    version: str
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.world_id, str) or not self.world_id.strip():
+            raise ValueError(
+                f"WorldRef.world_id must be a non-empty string, got {self.world_id!r}"
+            )
+        if not isinstance(self.version, str) or not self.version.strip():
+            raise ValueError(
+                f"WorldRef.version must be a non-empty string, got {self.version!r}"
+            )
+        if self.version.strip().lower() == "latest":
+            raise ValueError(
+                "WorldRef.version must be a concrete version; 'latest' is not "
+                "permitted because it defeats scenario determinism."
+            )
+
+    @property
+    def key(self) -> str:
+        """Stable flat key for cross-world comparison ("id@version")."""
+        return f"{self.world_id}@{self.version}"
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"world_id": self.world_id, "version": self.version}
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> "WorldRef":
+        return cls(world_id=str(data["world_id"]), version=str(data["version"]))
+
+
+# ---------------------------------------------------------------------------
+# Scenario
+# ---------------------------------------------------------------------------
+
+
+def make_scenario_run_id() -> str:
+    """Generate a stable, unique scenario-run identifier."""
+    return f"scn-{uuid.uuid4().hex[:12]}"
+
+
+@dataclass(frozen=True)
+class Scenario:
+    """One program bound to N worlds.
+
+    Exactly one of ``program_id`` or ``program_steps`` must be set.
+
+        program_id     — references a ReviewedProgram already in a ProgramStore.
+        program_steps  — inline tuple of CandidateStep that the runner will
+                         materialise into an ephemeral ReviewedProgram (useful
+                         for bundled scenarios that ship with the package).
+
+    worlds must contain at least two distinct WorldRefs — otherwise there is
+    nothing to compare and the "comparative" part of the playground is moot.
+    """
+
+    scenario_id: str
+    name: str
+    worlds: tuple[WorldRef, ...]
+    program_id: Optional[str] = field(default=None)
+    program_steps: Optional[tuple[CandidateStep, ...]] = field(default=None)
+    description: str = field(default="")
+    input: Optional[dict[str, Any]] = field(default=None, hash=False, compare=False)
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.scenario_id, str) or not self.scenario_id.strip():
+            raise ValueError(
+                f"Scenario.scenario_id must be a non-empty string, got {self.scenario_id!r}"
+            )
+        if not isinstance(self.name, str) or not self.name.strip():
+            raise ValueError(
+                f"Scenario.name must be a non-empty string, got {self.name!r}"
+            )
+        if not isinstance(self.worlds, tuple):
+            raise TypeError(
+                f"Scenario.worlds must be a tuple, got {type(self.worlds).__name__!r}"
+            )
+        if len(self.worlds) < 2:
+            raise ValueError(
+                "Scenario.worlds must contain at least two WorldRefs; "
+                f"got {len(self.worlds)}"
+            )
+        for i, w in enumerate(self.worlds):
+            if not isinstance(w, WorldRef):
+                raise TypeError(
+                    f"Scenario.worlds[{i}] must be a WorldRef, "
+                    f"got {type(w).__name__!r}"
+                )
+        keys = [w.key for w in self.worlds]
+        if len(set(keys)) != len(keys):
+            raise ValueError(
+                f"Scenario.worlds must not contain duplicate (id, version) "
+                f"pairs; got {keys}"
+            )
+
+        has_id = self.program_id is not None and str(self.program_id).strip() != ""
+        has_steps = self.program_steps is not None and len(self.program_steps) > 0
+        if has_id == has_steps:
+            raise ValueError(
+                "Scenario must specify exactly one of program_id or "
+                "program_steps (got both or neither)."
+            )
+        if has_steps:
+            if not isinstance(self.program_steps, tuple):
+                raise TypeError(
+                    "Scenario.program_steps must be a tuple, "
+                    f"got {type(self.program_steps).__name__!r}"
+                )
+            for i, s in enumerate(self.program_steps):
+                if not isinstance(s, CandidateStep):
+                    raise TypeError(
+                        f"Scenario.program_steps[{i}] must be a CandidateStep, "
+                        f"got {type(s).__name__!r}"
+                    )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "scenario_id": self.scenario_id,
+            "name": self.name,
+            "description": self.description,
+            "program_id": self.program_id,
+            "program_steps": (
+                [s.to_dict() for s in self.program_steps]
+                if self.program_steps is not None
+                else None
+            ),
+            "worlds": [w.to_dict() for w in self.worlds],
+            "input": self.input,
+        }
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> "Scenario":
+        raw_steps = data.get("program_steps")
+        steps: Optional[tuple[CandidateStep, ...]] = None
+        if raw_steps:
+            steps = tuple(CandidateStep.from_dict(s) for s in raw_steps)
+        return cls(
+            scenario_id=str(data["scenario_id"]),
+            name=str(data.get("name") or data["scenario_id"]),
+            description=str(data.get("description") or ""),
+            program_id=data.get("program_id"),
+            program_steps=steps,
+            worlds=tuple(WorldRef.from_dict(w) for w in data["worlds"]),
+            input=data.get("input"),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Per-step outcome
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class StepOutcome:
+    """One row per (step, world).
+
+    ``stage`` describes where the verdict was produced:
+        preview  — the compatibility pre-check decided this step's fate.
+        replay   — the replay engine executed (or attempted) this step.
+        skipped  — this step was never reached because a prior step denied.
+
+    ``rule_kind`` names the class of deterministic rule that produced the
+    verdict.  Every non-"allow" verdict carries a non-empty ``reason``.
+    """
+
+    step_index: int
+    action: str
+    stage: StepStage
+    verdict: StepVerdict
+    reason: str
+    rule_kind: RuleKind
+
+    def __post_init__(self) -> None:
+        if self.stage not in _VALID_STAGES:
+            raise ValueError(
+                f"StepOutcome.stage must be one of {sorted(_VALID_STAGES)}, "
+                f"got {self.stage!r}"
+            )
+        if self.verdict not in _VALID_VERDICTS:
+            raise ValueError(
+                f"StepOutcome.verdict must be one of {sorted(_VALID_VERDICTS)}, "
+                f"got {self.verdict!r}"
+            )
+        if self.rule_kind not in _VALID_RULE_KINDS:
+            raise ValueError(
+                f"StepOutcome.rule_kind must be one of "
+                f"{sorted(_VALID_RULE_KINDS)}, got {self.rule_kind!r}"
+            )
+        if not isinstance(self.reason, str) or not self.reason.strip():
+            raise ValueError(
+                "StepOutcome.reason must be a non-empty string (deterministic "
+                "explanation required for every outcome)."
+            )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "step_index": self.step_index,
+            "action": self.action,
+            "stage": self.stage,
+            "verdict": self.verdict,
+            "reason": self.reason,
+            "rule_kind": self.rule_kind,
+        }
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> "StepOutcome":
+        return cls(
+            step_index=int(data["step_index"]),
+            action=str(data["action"]),
+            stage=str(data["stage"]),  # type: ignore[arg-type]
+            verdict=str(data["verdict"]),  # type: ignore[arg-type]
+            reason=str(data["reason"]),
+            rule_kind=str(data["rule_kind"]),  # type: ignore[arg-type]
+        )
+
+
+# ---------------------------------------------------------------------------
+# Per-world result
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class WorldResult:
+    """Result for one world inside a scenario run."""
+
+    world_id: str
+    world_version: str
+    preview_compatible: bool
+    replay_verdict: ReplayVerdict
+    step_outcomes: tuple[StepOutcome, ...]
+
+    def __post_init__(self) -> None:
+        if self.replay_verdict not in _VALID_REPLAY_VERDICTS:
+            raise ValueError(
+                f"WorldResult.replay_verdict must be one of "
+                f"{sorted(_VALID_REPLAY_VERDICTS)}, got {self.replay_verdict!r}"
+            )
+        if not isinstance(self.step_outcomes, tuple):
+            raise TypeError(
+                "WorldResult.step_outcomes must be a tuple, "
+                f"got {type(self.step_outcomes).__name__!r}"
+            )
+        for i, o in enumerate(self.step_outcomes):
+            if not isinstance(o, StepOutcome):
+                raise TypeError(
+                    f"WorldResult.step_outcomes[{i}] must be a StepOutcome, "
+                    f"got {type(o).__name__!r}"
+                )
+
+    @property
+    def key(self) -> str:
+        return f"{self.world_id}@{self.world_version}"
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "world_id": self.world_id,
+            "world_version": self.world_version,
+            "preview_compatible": self.preview_compatible,
+            "replay_verdict": self.replay_verdict,
+            "step_outcomes": [o.to_dict() for o in self.step_outcomes],
+        }
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> "WorldResult":
+        return cls(
+            world_id=str(data["world_id"]),
+            world_version=str(data["world_version"]),
+            preview_compatible=bool(data["preview_compatible"]),
+            replay_verdict=str(data["replay_verdict"]),  # type: ignore[arg-type]
+            step_outcomes=tuple(
+                StepOutcome.from_dict(o) for o in data.get("step_outcomes", [])
+            ),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Divergence
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ScenarioDivergencePoint:
+    """A step index where at least two worlds disagreed.
+
+    ``verdicts_by_world`` and ``reasons_by_world`` are keyed by the world's
+    flat "id@version" key (matches ``WorldResult.key``).  Every world in the
+    scenario contributes exactly one entry.
+    """
+
+    step_index: int
+    action: str
+    verdicts_by_world: Mapping[str, str]
+    reasons_by_world: Mapping[str, str]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "step_index": self.step_index,
+            "action": self.action,
+            "verdicts_by_world": dict(self.verdicts_by_world),
+            "reasons_by_world": dict(self.reasons_by_world),
+        }
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> "ScenarioDivergencePoint":
+        return cls(
+            step_index=int(data["step_index"]),
+            action=str(data["action"]),
+            verdicts_by_world=dict(data.get("verdicts_by_world", {})),
+            reasons_by_world=dict(data.get("reasons_by_world", {})),
+        )
+
+
+@dataclass(frozen=True)
+class DivergenceReport:
+    """Summary of cross-world divergence for a scenario run."""
+
+    scenario_id: str
+    divergence_points: tuple[ScenarioDivergencePoint, ...]
+    all_agree: bool
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "scenario_id": self.scenario_id,
+            "all_agree": self.all_agree,
+            "divergence_points": [p.to_dict() for p in self.divergence_points],
+        }
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> "DivergenceReport":
+        return cls(
+            scenario_id=str(data["scenario_id"]),
+            all_agree=bool(data["all_agree"]),
+            divergence_points=tuple(
+                ScenarioDivergencePoint.from_dict(p)
+                for p in data.get("divergence_points", [])
+            ),
+        )
+
+
+# ---------------------------------------------------------------------------
+# ScenarioResult
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ScenarioResult:
+    """Full outcome of a single ``run_scenario`` call.
+
+    Only ``run_id`` and ``ran_at`` are non-deterministic across runs of the
+    same scenario; every other field is a deterministic function of the
+    program and the selected worlds.
+    """
+
+    scenario_id: str
+    program_id: str
+    world_results: tuple[WorldResult, ...]
+    divergence: DivergenceReport
+    run_id: str
+    ran_at: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "scenario_id": self.scenario_id,
+            "program_id": self.program_id,
+            "run_id": self.run_id,
+            "ran_at": self.ran_at,
+            "world_results": [w.to_dict() for w in self.world_results],
+            "divergence": self.divergence.to_dict(),
+        }
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> "ScenarioResult":
+        return cls(
+            scenario_id=str(data["scenario_id"]),
+            program_id=str(data["program_id"]),
+            world_results=tuple(
+                WorldResult.from_dict(w) for w in data.get("world_results", [])
+            ),
+            divergence=DivergenceReport.from_dict(data["divergence"]),
+            run_id=str(data["run_id"]),
+            ran_at=str(data["ran_at"]),
+        )
+
+    def scrub_run_metadata(self) -> dict[str, Any]:
+        """Return ``to_dict()`` with ``run_id`` and ``ran_at`` removed.
+
+        Useful for stability assertions: two runs of the same scenario on
+        identical inputs must produce identical scrubbed dicts.
+        """
+        d = self.to_dict()
+        d.pop("run_id", None)
+        d.pop("ran_at", None)
+        return d
+
+
+def _utcnow_iso() -> str:
+    return datetime.now(tz=timezone.utc).isoformat()

--- a/src/agent_hypervisor/program_layer/scenario_registry.py
+++ b/src/agent_hypervisor/program_layer/scenario_registry.py
@@ -1,0 +1,220 @@
+"""
+scenario_registry.py — YAML-backed registry for ``Scenario`` definitions.
+
+Mirrors the shape of ``world_registry.WorldRegistry``: a directory of YAML
+files, each describing exactly one ``Scenario``.  No active-pointer state is
+kept — scenarios are lookups by id, nothing more.
+
+Expected YAML shape::
+
+    scenario_id: memory_write_test
+    name: "Safe vs strict memory write"
+    description: "..."
+    program_steps:
+      - tool: count_words
+        params: {input: "hello world"}
+      - tool: normalize_text
+        params: {input: "HELLO WORLD"}
+    worlds:
+      - world_id: world_strict
+        version: "1.0"
+      - world_id: world_balanced
+        version: "1.0"
+
+Either ``program_steps`` (inline) or ``program_id`` (reference) must be
+present (but not both) — the same invariant enforced by ``Scenario``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Optional
+
+import yaml
+
+from .review_models import CandidateStep
+from .scenario_model import Scenario, WorldRef
+
+
+# ---------------------------------------------------------------------------
+# Errors
+# ---------------------------------------------------------------------------
+
+
+class ScenarioNotFoundError(KeyError):
+    """Raised when a requested scenario_id is not present in the registry."""
+
+
+class ScenarioLoadError(ValueError):
+    """Raised when a scenario YAML file is malformed or fails validation."""
+
+
+# ---------------------------------------------------------------------------
+# YAML loader
+# ---------------------------------------------------------------------------
+
+
+def load_scenario_from_yaml(path: str | Path) -> Scenario:
+    """Load a single ``Scenario`` from a YAML manifest file.
+
+    Raises:
+        ScenarioLoadError: file missing, unparseable, or schema-invalid.
+    """
+    p = Path(path)
+    if not p.exists():
+        raise ScenarioLoadError(f"Scenario manifest not found: {path}")
+
+    try:
+        raw = yaml.safe_load(p.read_text(encoding="utf-8"))
+    except yaml.YAMLError as exc:
+        raise ScenarioLoadError(f"Invalid YAML in {path}: {exc}") from exc
+
+    if not isinstance(raw, dict):
+        raise ScenarioLoadError(f"Scenario manifest at {path} must be a mapping")
+
+    for required in ("scenario_id", "worlds"):
+        if required not in raw:
+            raise ScenarioLoadError(f"{path}: missing required field {required!r}")
+
+    raw_worlds = raw["worlds"]
+    if not isinstance(raw_worlds, list) or not raw_worlds:
+        raise ScenarioLoadError(
+            f"{path}: 'worlds' must be a non-empty list of (world_id, version) mappings"
+        )
+    worlds: list[WorldRef] = []
+    for i, w in enumerate(raw_worlds):
+        if not isinstance(w, dict):
+            raise ScenarioLoadError(
+                f"{path}: worlds[{i}] must be a mapping with world_id and version"
+            )
+        try:
+            worlds.append(WorldRef.from_dict(w))
+        except (KeyError, TypeError, ValueError) as exc:
+            raise ScenarioLoadError(f"{path}: worlds[{i}]: {exc}") from exc
+
+    steps: Optional[tuple[CandidateStep, ...]] = None
+    raw_steps = raw.get("program_steps")
+    if raw_steps is not None:
+        if not isinstance(raw_steps, list) or not raw_steps:
+            raise ScenarioLoadError(
+                f"{path}: 'program_steps' must be a non-empty list of step mappings"
+            )
+        try:
+            steps = tuple(
+                CandidateStep.from_dict(_normalise_step(s, i, path))
+                for i, s in enumerate(raw_steps)
+            )
+        except (KeyError, TypeError, ValueError) as exc:
+            raise ScenarioLoadError(f"{path}: program_steps: {exc}") from exc
+
+    try:
+        return Scenario(
+            scenario_id=str(raw["scenario_id"]),
+            name=str(raw.get("name") or raw["scenario_id"]),
+            description=str(raw.get("description") or ""),
+            program_id=(
+                str(raw["program_id"]) if raw.get("program_id") is not None else None
+            ),
+            program_steps=steps,
+            worlds=tuple(worlds),
+            input=raw.get("input"),
+        )
+    except (TypeError, ValueError) as exc:
+        raise ScenarioLoadError(f"{path}: {exc}") from exc
+
+
+def _normalise_step(s: Any, i: int, path: Path) -> dict[str, Any]:
+    if not isinstance(s, dict):
+        raise ScenarioLoadError(
+            f"{path}: program_steps[{i}] must be a mapping, got {type(s).__name__!r}"
+        )
+    return s
+
+
+# ---------------------------------------------------------------------------
+# Registry
+# ---------------------------------------------------------------------------
+
+
+class ScenarioRegistry:
+    """Directory-backed registry of ``Scenario`` definitions.
+
+    Args:
+        scenarios_dir: directory containing one YAML file per scenario.
+
+    The registry is read-only.  There is no ``save``/``activate`` surface —
+    the scenario YAMLs are treated as the source of truth.
+    """
+
+    def __init__(self, scenarios_dir: str | Path) -> None:
+        self._scenarios_dir = Path(scenarios_dir)
+
+    @property
+    def scenarios_dir(self) -> Path:
+        return self._scenarios_dir
+
+    def list_scenarios(self) -> list[Scenario]:
+        """Return all scenarios under ``scenarios_dir``, sorted by id.
+
+        Files that fail to parse are skipped silently so a single corrupt
+        file does not poison the listing — a subsequent ``get()`` on that
+        specific id will raise the underlying ``ScenarioLoadError``.
+        """
+        if not self._scenarios_dir.exists():
+            return []
+
+        out: list[Scenario] = []
+        for p in sorted(self._scenarios_dir.iterdir()):
+            if p.name.startswith("."):
+                continue
+            if p.suffix not in (".yaml", ".yml"):
+                continue
+            try:
+                out.append(load_scenario_from_yaml(p))
+            except ScenarioLoadError:
+                continue
+        out.sort(key=lambda s: s.scenario_id)
+        return out
+
+    def get(self, scenario_id: str) -> Scenario:
+        """Load a scenario by id.
+
+        Raises:
+            ScenarioNotFoundError: no YAML file produced a scenario with that id.
+            ScenarioLoadError:     a file matched the id but failed to parse.
+        """
+        if not self._scenarios_dir.exists():
+            raise ScenarioNotFoundError(
+                f"Scenario {scenario_id!r}: directory does not exist: "
+                f"{self._scenarios_dir}"
+            )
+        last_load_error: Optional[ScenarioLoadError] = None
+        for p in sorted(self._scenarios_dir.iterdir()):
+            if p.suffix not in (".yaml", ".yml") or p.name.startswith("."):
+                continue
+            try:
+                s = load_scenario_from_yaml(p)
+            except ScenarioLoadError as exc:
+                last_load_error = exc
+                continue
+            if s.scenario_id == scenario_id:
+                return s
+        if last_load_error is not None:
+            raise last_load_error
+        raise ScenarioNotFoundError(
+            f"Scenario {scenario_id!r} not found under {self._scenarios_dir}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Convenience: bundled scenarios
+# ---------------------------------------------------------------------------
+
+
+def _bundled_scenarios_dir() -> Path:
+    return Path(__file__).parent / "scenarios"
+
+
+def default_scenario_registry() -> ScenarioRegistry:
+    """Registry over the bundled example scenarios (``program_layer/scenarios/``)."""
+    return ScenarioRegistry(_bundled_scenarios_dir())

--- a/src/agent_hypervisor/program_layer/scenario_runner.py
+++ b/src/agent_hypervisor/program_layer/scenario_runner.py
@@ -1,0 +1,405 @@
+"""
+scenario_runner.py — SYS-3 multi-world execution engine.
+
+Given a ``Scenario`` (one program + N worlds), this module:
+
+    1. Loads or materialises the ReviewedProgram exactly once.
+    2. For each world:
+         - Runs ``check_compatibility`` (the preview pass).
+         - If compatible, invokes ``ReplayEngine.replay_under_world`` to run
+           the same enforcement path used by live execution.
+         - Otherwise records ``denied_at_preview`` and skips replay.
+    3. Builds ``StepOutcome`` rows that carry a deterministic ``rule_kind``
+       explanation for every (step, world) pair.
+    4. Calls ``detect_divergence`` to find step indices where the worlds
+       disagreed.
+    5. Returns a frozen ``ScenarioResult``.
+
+Nothing in this module adds new policy logic — it composes existing
+primitives (``compatibility.py``, ``replay_engine.py``) so the authority
+boundary remains exactly what SYS-2 and PL-3 already define.
+
+The ``_classify_replay_reason`` helper maps the free-form error strings
+produced by ``ProgramRunner`` into one of five deterministic rule classes:
+
+    capability  — world validation said the action is not permitted
+    schema      — task compiler rejected the intent shape
+    taint       — (reserved) taint rule denial
+    policy      — security validation or timeout denial
+    execution   — a sandboxed runtime error surfaced from the handler
+"""
+
+from __future__ import annotations
+
+from typing import Optional, Sequence
+
+from .compatibility import check_compatibility
+from .program_store import ProgramStore
+from .replay_engine import ReplayEngine, ReplayTrace
+from .review_models import (
+    CandidateStep,
+    ProgramDiff,
+    ProgramMetadata,
+    ProgramStatus,
+    ReviewedProgram,
+)
+from .scenario_model import (
+    DivergenceReport,
+    RuleKind,
+    Scenario,
+    ScenarioDivergencePoint,
+    ScenarioResult,
+    StepOutcome,
+    WorldResult,
+    _utcnow_iso,
+    make_scenario_run_id,
+)
+from .world_registry import WorldDescriptor, WorldRegistry
+
+
+# ---------------------------------------------------------------------------
+# Rule classification
+# ---------------------------------------------------------------------------
+
+
+def _classify_replay_reason(error: Optional[str]) -> RuleKind:
+    """Map a ProgramRunner/ReplayEngine error string to a deterministic kind.
+
+    The prefixes here mirror the error strings produced in
+    ``replay_engine.py`` and ``program_runner.py``.  Any unrecognised error
+    falls back to ``execution`` so the taxonomy is closed but forgiving.
+    """
+    if error is None:
+        return "execution"
+    e = error.lower()
+    if e.startswith("world validation failed"):
+        return "capability"
+    if e.startswith("action ") and "is not a supported program workflow" in e:
+        return "schema"
+    if e.startswith("compile error"):
+        return "schema"
+    if e.startswith("security validation failed"):
+        return "policy"
+    if "exceeded timeout" in e:
+        return "policy"
+    return "execution"
+
+
+# ---------------------------------------------------------------------------
+# Program resolution
+# ---------------------------------------------------------------------------
+
+
+def _materialise_program(
+    scenario: Scenario,
+    store: Optional[ProgramStore],
+) -> ReviewedProgram:
+    """Return the ReviewedProgram the scenario should run.
+
+    - If ``scenario.program_id`` is set, load it via ``store.load``.  A store
+      is required in that case.
+    - Otherwise construct an ephemeral ACCEPTED program from
+      ``scenario.program_steps`` (never persisted).
+    """
+    if scenario.program_id is not None:
+        if store is None:
+            raise ValueError(
+                f"Scenario {scenario.scenario_id!r} references program_id "
+                f"{scenario.program_id!r} but no ProgramStore was provided."
+            )
+        try:
+            return store.load(scenario.program_id)
+        except KeyError as exc:
+            raise KeyError(
+                f"Scenario {scenario.scenario_id!r}: program "
+                f"{scenario.program_id!r} not found in store"
+            ) from exc
+
+    # Inline program_steps path — build an ephemeral ACCEPTED program.
+    steps: tuple[CandidateStep, ...] = scenario.program_steps or ()
+    prog_id = f"scn-inline-{scenario.scenario_id}"
+    metadata = ProgramMetadata(
+        created_from_trace=None,
+        world_version="scenario-inline",
+        created_at=_utcnow_iso(),
+        reviewer_notes=f"Inline program for scenario {scenario.scenario_id!r}.",
+    )
+    return ReviewedProgram(
+        id=prog_id,
+        status=ProgramStatus.ACCEPTED,
+        original_steps=steps,
+        minimized_steps=steps,
+        diff=ProgramDiff(),
+        metadata=metadata,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Per-world execution
+# ---------------------------------------------------------------------------
+
+
+def _outcomes_from_preview_only(
+    program: ReviewedProgram,
+    world: WorldDescriptor,
+) -> tuple[WorldResult, bool]:
+    """Run ``check_compatibility`` and synthesise StepOutcome rows.
+
+    Returns ``(world_result, compatible)``.  If incompatible, the caller
+    should NOT replay; this function builds a full row set already, marking
+    the first denied step as ``deny`` and every subsequent step as
+    ``skipped``.
+    """
+    compat = check_compatibility(program, world)
+    outcomes: list[StepOutcome] = []
+    denied_seen = False
+    for sr in compat.step_results:
+        if sr.allowed:
+            # Compatible step under an incompatible-overall program: still
+            # reported as ``preview/allow`` so the per-step matrix is complete.
+            outcomes.append(
+                StepOutcome(
+                    step_index=sr.step_index,
+                    action=sr.action,
+                    stage="preview",
+                    verdict="allow",
+                    reason=sr.reason or "action present in world",
+                    rule_kind="capability",
+                )
+            )
+        else:
+            if not denied_seen:
+                outcomes.append(
+                    StepOutcome(
+                        step_index=sr.step_index,
+                        action=sr.action,
+                        stage="preview",
+                        verdict="deny",
+                        reason=sr.reason or "capability absent from world",
+                        rule_kind="capability",
+                    )
+                )
+                denied_seen = True
+            else:
+                outcomes.append(
+                    StepOutcome(
+                        step_index=sr.step_index,
+                        action=sr.action,
+                        stage="skipped",
+                        verdict="skip",
+                        reason="skipped after earlier preview denial",
+                        rule_kind="capability",
+                    )
+                )
+
+    result = WorldResult(
+        world_id=world.world_id,
+        world_version=world.version,
+        preview_compatible=compat.compatible,
+        replay_verdict="allow" if compat.compatible else "denied_at_preview",
+        step_outcomes=tuple(outcomes),
+    )
+    return result, compat.compatible
+
+
+def _outcomes_from_replay(
+    program: ReviewedProgram,
+    world: WorldDescriptor,
+    preview_outcomes: Sequence[StepOutcome],
+    replay_trace: ReplayTrace,
+) -> WorldResult:
+    """Combine the preview pass (all ``allow``) with the replay trace.
+
+    After a successful preview, every ``preview_outcomes`` entry has
+    ``verdict="allow"`` and ``stage="preview"``.  Replay then produces a
+    ``StepTrace`` per step.  For any step that replay actually executed we
+    replace the preview row with a ``stage="replay"`` row that carries the
+    real verdict and a classified rule_kind.  Steps that replay marked as
+    ``skip`` keep their preview row but are reported as ``stage="skipped"``.
+    """
+    by_index = {o.step_index: o for o in preview_outcomes}
+    merged: list[StepOutcome] = []
+
+    for st in replay_trace.program_trace.step_traces:
+        if st.verdict == "allow":
+            reason = "executed successfully"
+            rule_kind: RuleKind = "execution"
+        elif st.verdict == "deny":
+            reason = st.error or "denied by replay engine"
+            rule_kind = _classify_replay_reason(st.error)
+        else:  # skip
+            reason = "skipped after earlier replay denial"
+            rule_kind = "capability"
+        merged.append(
+            StepOutcome(
+                step_index=st.step_index,
+                action=st.action,
+                stage="replay" if st.verdict != "skip" else "skipped",
+                verdict=st.verdict,
+                reason=reason,
+                rule_kind=rule_kind,
+            )
+        )
+
+    # Replay may return fewer step_traces than the program has (e.g. empty
+    # minimized_steps path).  Fill any gaps from the preview rows so the
+    # matrix is always complete.
+    seen = {o.step_index for o in merged}
+    for idx in sorted(by_index):
+        if idx not in seen:
+            merged.append(by_index[idx])
+    merged.sort(key=lambda o: o.step_index)
+
+    return WorldResult(
+        world_id=world.world_id,
+        world_version=world.version,
+        preview_compatible=True,
+        replay_verdict=replay_trace.final_verdict,
+        step_outcomes=tuple(merged),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Divergence detection
+# ---------------------------------------------------------------------------
+
+
+def detect_divergence(
+    scenario_id: str,
+    world_results: Sequence[WorldResult],
+) -> DivergenceReport:
+    """Identify step indices where worlds disagreed.
+
+    A divergence at step ``i`` means at least two worlds produced different
+    ``(verdict, rule_kind)`` tuples at that index.  Order is preserved from
+    the input ``world_results`` sequence so cross-run comparisons stay
+    stable (scenarios use tuples, so this is already deterministic).
+    """
+    if not world_results:
+        return DivergenceReport(
+            scenario_id=scenario_id,
+            divergence_points=(),
+            all_agree=True,
+        )
+
+    # Determine the union of step indices observed across worlds.
+    all_indices: set[int] = set()
+    for wr in world_results:
+        for o in wr.step_outcomes:
+            all_indices.add(o.step_index)
+
+    divergences: list[ScenarioDivergencePoint] = []
+    for idx in sorted(all_indices):
+        rows_by_world: dict[str, StepOutcome] = {}
+        action_seen: Optional[str] = None
+        for wr in world_results:
+            for o in wr.step_outcomes:
+                if o.step_index == idx:
+                    rows_by_world[wr.key] = o
+                    action_seen = action_seen or o.action
+                    break
+
+        verdicts = {k: o.verdict for k, o in rows_by_world.items()}
+        # Divergence is measured on verdict alone.  A step that every world
+        # allowed is not divergent, even if one world allowed it at preview
+        # (no replay) and another allowed it after running the handler.
+        if len(set(verdicts.values())) <= 1:
+            continue
+
+        reasons = {k: o.reason for k, o in rows_by_world.items()}
+        divergences.append(
+            ScenarioDivergencePoint(
+                step_index=idx,
+                action=action_seen or "",
+                verdicts_by_world=verdicts,
+                reasons_by_world=reasons,
+            )
+        )
+
+    return DivergenceReport(
+        scenario_id=scenario_id,
+        divergence_points=tuple(divergences),
+        all_agree=not divergences,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+
+def run_scenario(
+    scenario: Scenario,
+    *,
+    registry: WorldRegistry,
+    store: Optional[ProgramStore] = None,
+    replay_engine: Optional[ReplayEngine] = None,
+) -> ScenarioResult:
+    """Run a scenario across its worlds and return a frozen ``ScenarioResult``.
+
+    Execution is deterministic apart from ``run_id`` and ``ran_at``:
+
+        - the program is loaded once and reused across worlds (no mutation).
+        - each world is resolved via ``registry.get(world_id, version)``;
+          concrete versions are required (``WorldRef.__post_init__`` rejects
+          "latest").
+        - compatibility preview runs before replay; if preview denies,
+          ``replay_verdict`` is ``denied_at_preview`` and ``ReplayEngine`` is
+          NOT called for that world.
+        - replay is delegated to ``ReplayEngine.replay_under_world`` with
+          ``world_source="explicit"`` and ``preview_compatible=True`` so the
+          underlying ReplayTrace carries accurate audit metadata.
+
+    The ``input`` attribute on ``Scenario`` is forwarded to replay as the
+    ``context`` argument — useful when a scenario wants to seed shared state
+    across steps.  Its shape is not validated here.
+
+    Raises:
+        KeyError:            program_id unknown in store.
+        ValueError:          scenario references program_id but no store.
+        WorldNotFoundError:  a world_id/version pair is unknown.
+    """
+    if not isinstance(scenario, Scenario):
+        raise TypeError(
+            f"run_scenario() requires a Scenario, got {type(scenario).__name__!r}"
+        )
+    if not isinstance(registry, WorldRegistry):
+        raise TypeError(
+            f"run_scenario() requires a WorldRegistry, got {type(registry).__name__!r}"
+        )
+
+    program = _materialise_program(scenario, store)
+    engine = replay_engine if replay_engine is not None else ReplayEngine()
+
+    world_results: list[WorldResult] = []
+    for wref in scenario.worlds:
+        world = registry.get(wref.world_id, wref.version)
+
+        preview_result, compatible = _outcomes_from_preview_only(program, world)
+        if not compatible:
+            world_results.append(preview_result)
+            continue
+
+        replay_trace = engine.replay_under_world(
+            program=program,
+            world=world,
+            world_source="explicit",
+            preview_compatible=True,
+            context=scenario.input,
+        )
+        world_results.append(
+            _outcomes_from_replay(
+                program, world, preview_result.step_outcomes, replay_trace
+            )
+        )
+
+    divergence = detect_divergence(scenario.scenario_id, world_results)
+
+    return ScenarioResult(
+        scenario_id=scenario.scenario_id,
+        program_id=program.id,
+        world_results=tuple(world_results),
+        divergence=divergence,
+        run_id=make_scenario_run_id(),
+        ran_at=_utcnow_iso(),
+    )

--- a/src/agent_hypervisor/program_layer/scenario_trace_store.py
+++ b/src/agent_hypervisor/program_layer/scenario_trace_store.py
@@ -1,0 +1,87 @@
+"""
+scenario_trace_store.py — Append-only JSONL store for ``ScenarioResult``.
+
+Every call to ``run_scenario`` can append one line to a persistent trace
+file.  Lines are never modified after they are written (SYS-3 step 7:
+"append-only, comparable across worlds").
+
+Matches the existing ``ProgramTraceStore`` shape so downstream audit code
+can share reader patterns.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Optional
+
+from .scenario_model import ScenarioResult
+
+
+class ScenarioTraceStore:
+    """Append-only JSONL store for ``ScenarioResult`` records.
+
+    Each ``append`` writes one line: the result dict from
+    ``ScenarioResult.to_dict()`` plus a ``_stored_at`` ISO-8601 timestamp.
+
+    Args:
+        path: path to the .jsonl file.  Parent directories are created on
+              first write.  The file need not exist in advance.
+    """
+
+    def __init__(self, path: str | Path) -> None:
+        self._path = Path(path)
+
+    def append(self, result: ScenarioResult) -> None:
+        if not isinstance(result, ScenarioResult):
+            raise TypeError(
+                "ScenarioTraceStore.append() requires a ScenarioResult, "
+                f"got {type(result).__name__!r}"
+            )
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        entry = result.to_dict()
+        entry["_stored_at"] = datetime.now(tz=timezone.utc).isoformat()
+        with open(self._path, "a", encoding="utf-8") as f:
+            f.write(json.dumps(entry, default=str) + "\n")
+
+    def list_recent(
+        self,
+        limit: int = 50,
+        scenario_id: Optional[str] = None,
+    ) -> list[dict[str, Any]]:
+        """Return up to ``limit`` entries, newest first.
+
+        ``scenario_id`` filters by the ``scenario_id`` field when provided.
+        """
+        if not self._path.exists():
+            return []
+
+        entries: list[dict[str, Any]] = []
+        with open(self._path, encoding="utf-8") as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    entry = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if scenario_id is not None and entry.get("scenario_id") != scenario_id:
+                    continue
+                entries.append(entry)
+
+        return list(reversed(entries))[:limit]
+
+    def count(self) -> int:
+        if not self._path.exists():
+            return 0
+        n = 0
+        with open(self._path, encoding="utf-8") as f:
+            for line in f:
+                if line.strip():
+                    n += 1
+        return n
+
+    def path(self) -> Path:
+        return self._path

--- a/src/agent_hypervisor/program_layer/scenarios/scenario_external_call.yaml
+++ b/src/agent_hypervisor/program_layer/scenarios/scenario_external_call.yaml
@@ -1,0 +1,20 @@
+scenario_id: external_call_test
+name: "Internal-only vs external-allowed"
+description: >
+  A program that reads a local measurement and then produces a ranked
+  frequency report — the stand-in for an external side-effect surface.
+  World_strict (internal only) denies the ranked-output step at preview;
+  world_balanced permits it and the program runs to completion.
+program_steps:
+  - tool: count_lines
+    params:
+      input: "line one\nline two\nline three\nline four"
+  - tool: word_frequency
+    params:
+      input: "alpha beta alpha gamma beta alpha"
+      top_n: 3
+worlds:
+  - world_id: world_strict
+    version: "1.0"
+  - world_id: world_balanced
+    version: "1.0"

--- a/src/agent_hypervisor/program_layer/scenarios/scenario_memory_write.yaml
+++ b/src/agent_hypervisor/program_layer/scenarios/scenario_memory_write.yaml
@@ -1,0 +1,21 @@
+scenario_id: memory_write_test
+name: "Safe vs strict memory write"
+description: >
+  A program that extracts a measurement and then writes a derived, normalized
+  value to memory.  The narrative action names map onto existing deterministic
+  workflows: ``count_words`` stands in for the read/extract step, and
+  ``normalize_text`` stands in for the memory-write step.  World_strict denies
+  the write surface; world_balanced permits it.  Same program, different
+  world, different outcome.
+program_steps:
+  - tool: count_words
+    params:
+      input: "the quick brown fox jumps over the lazy dog"
+  - tool: normalize_text
+    params:
+      input: "The QUICK Brown Fox Jumps Over the Lazy Dog"
+worlds:
+  - world_id: world_strict
+    version: "1.0"
+  - world_id: world_balanced
+    version: "1.0"

--- a/tests/program_layer/test_scenario_cli.py
+++ b/tests/program_layer/test_scenario_cli.py
@@ -1,0 +1,264 @@
+"""
+test_scenario_cli.py — CLI tests for ``awc scenario ...``.
+
+Exercises the ``scenario`` click subgroup added in SYS-3.  Only the CLI
+surface is covered here; the underlying runner/registry/model logic is
+validated in dedicated test files.
+
+Covers:
+
+    - ``scenario list`` over a custom directory.
+    - ``scenario show`` prints a valid JSON dict.
+    - ``scenario run`` exits 6 when worlds diverge; exit 0 when all agree.
+    - ``scenario run --json`` emits the machine-readable ScenarioResult.
+    - ``scenario run --trace-file`` appends a JSONL entry.
+    - ``scenario run`` exits 1 when the scenario_id is unknown.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+from pathlib import Path
+
+import pytest
+import yaml
+from click.testing import CliRunner
+
+from agent_hypervisor.compiler.cli import cli
+
+
+BUNDLED_WORLDS_DIR = (
+    Path(__file__).resolve().parents[2]
+    / "src" / "agent_hypervisor" / "program_layer" / "worlds"
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+@pytest.fixture
+def worlds_dir(tmp_path: Path) -> Path:
+    d = tmp_path / "worlds"
+    d.mkdir()
+    for y in BUNDLED_WORLDS_DIR.glob("*.yaml"):
+        shutil.copy(y, d / y.name)
+    return d
+
+
+@pytest.fixture
+def diverging_scenarios_dir(tmp_path: Path) -> Path:
+    """A scenarios dir that contains one divergent memory-write scenario."""
+    d = tmp_path / "scenarios"
+    d.mkdir()
+    (d / "memory.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "scenario_id": "memory_write_test",
+                "name": "memory write",
+                "description": "divergent demo",
+                "program_steps": [
+                    {"tool": "count_words", "params": {"input": "alpha beta"}},
+                    {"tool": "normalize_text", "params": {"input": "HELLO"}},
+                ],
+                "worlds": [
+                    {"world_id": "world_strict", "version": "1.0"},
+                    {"world_id": "world_balanced", "version": "1.0"},
+                ],
+            },
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+    return d
+
+
+@pytest.fixture
+def agreeing_scenarios_dir(tmp_path: Path) -> Path:
+    """A scenarios dir where both worlds allow every step (no divergence)."""
+    d = tmp_path / "scenarios_agree"
+    d.mkdir()
+    (d / "agree.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "scenario_id": "both_allow",
+                "name": "both allow",
+                "program_steps": [
+                    {"tool": "count_words", "params": {"input": "alpha beta"}},
+                ],
+                "worlds": [
+                    {"world_id": "world_strict", "version": "1.0"},
+                    {"world_id": "world_balanced", "version": "1.0"},
+                ],
+            },
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+    return d
+
+
+# ---------------------------------------------------------------------------
+# scenario list / show
+# ---------------------------------------------------------------------------
+
+
+def test_scenario_list_empty_dir(runner, tmp_path: Path):
+    empty = tmp_path / "empty"
+    empty.mkdir()
+    result = runner.invoke(
+        cli, ["scenario", "list", "--scenarios-dir", str(empty)]
+    )
+    assert result.exit_code == 0, result.output
+    assert "(no scenarios)" in result.output
+
+
+def test_scenario_list_shows_scenarios(runner, diverging_scenarios_dir: Path):
+    result = runner.invoke(
+        cli, ["scenario", "list", "--scenarios-dir", str(diverging_scenarios_dir)]
+    )
+    assert result.exit_code == 0, result.output
+    assert "memory_write_test" in result.output
+
+
+def test_scenario_show_emits_valid_json(runner, diverging_scenarios_dir: Path):
+    result = runner.invoke(
+        cli,
+        [
+            "scenario", "show", "memory_write_test",
+            "--scenarios-dir", str(diverging_scenarios_dir),
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    data = json.loads(result.output.strip())
+    assert data["scenario_id"] == "memory_write_test"
+    assert len(data["worlds"]) == 2
+
+
+def test_scenario_show_unknown_id_exits_nonzero(runner, diverging_scenarios_dir):
+    result = runner.invoke(
+        cli,
+        [
+            "scenario", "show", "nope",
+            "--scenarios-dir", str(diverging_scenarios_dir),
+        ],
+    )
+    assert result.exit_code != 0
+    assert "not found" in result.output.lower()
+
+
+# ---------------------------------------------------------------------------
+# scenario run — divergence
+# ---------------------------------------------------------------------------
+
+
+def test_scenario_run_divergent_exits_six(
+    runner, diverging_scenarios_dir, worlds_dir
+):
+    result = runner.invoke(
+        cli,
+        [
+            "scenario", "run", "memory_write_test",
+            "--scenarios-dir", str(diverging_scenarios_dir),
+            "--worlds-dir", str(worlds_dir),
+        ],
+    )
+    # Exit code 6 == worlds disagreed (distinct from other program-layer codes).
+    assert result.exit_code == 6, result.output
+    # Both worlds and the divergence section must appear in stdout.
+    assert "world_strict@1.0" in result.output
+    assert "world_balanced@1.0" in result.output
+    assert "Divergence" in result.output
+    assert "normalize_text" in result.output
+
+
+def test_scenario_run_agreement_exits_zero(
+    runner, agreeing_scenarios_dir, worlds_dir
+):
+    result = runner.invoke(
+        cli,
+        [
+            "scenario", "run", "both_allow",
+            "--scenarios-dir", str(agreeing_scenarios_dir),
+            "--worlds-dir", str(worlds_dir),
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert "worlds agreed" in result.output.lower()
+
+
+# ---------------------------------------------------------------------------
+# scenario run — JSON and trace
+# ---------------------------------------------------------------------------
+
+
+def test_scenario_run_json_emits_result_dict(
+    runner, diverging_scenarios_dir, worlds_dir
+):
+    result = runner.invoke(
+        cli,
+        [
+            "scenario", "run", "memory_write_test",
+            "--scenarios-dir", str(diverging_scenarios_dir),
+            "--worlds-dir", str(worlds_dir),
+            "--json",
+        ],
+    )
+    # Worlds still diverge → exit 6, but JSON must have been emitted first.
+    assert result.exit_code == 6, result.output
+    data = json.loads(result.output.strip())
+    assert data["scenario_id"] == "memory_write_test"
+    assert len(data["world_results"]) == 2
+    assert data["divergence"]["all_agree"] is False
+    # run_id / ran_at present.
+    assert data["run_id"].startswith("scn-")
+    assert "ran_at" in data
+
+
+def test_scenario_run_appends_to_trace_file(
+    runner, diverging_scenarios_dir, worlds_dir, tmp_path: Path
+):
+    trace = tmp_path / "traces.jsonl"
+    result = runner.invoke(
+        cli,
+        [
+            "scenario", "run", "memory_write_test",
+            "--scenarios-dir", str(diverging_scenarios_dir),
+            "--worlds-dir", str(worlds_dir),
+            "--trace-file", str(trace),
+        ],
+    )
+    assert result.exit_code == 6, result.output
+    assert trace.exists()
+    lines = [l for l in trace.read_text(encoding="utf-8").splitlines() if l.strip()]
+    assert len(lines) == 1
+    entry = json.loads(lines[0])
+    assert entry["scenario_id"] == "memory_write_test"
+    assert "_stored_at" in entry
+
+
+# ---------------------------------------------------------------------------
+# Unknown scenario
+# ---------------------------------------------------------------------------
+
+
+def test_scenario_run_unknown_exits_nonzero(
+    runner, diverging_scenarios_dir, worlds_dir
+):
+    result = runner.invoke(
+        cli,
+        [
+            "scenario", "run", "does_not_exist",
+            "--scenarios-dir", str(diverging_scenarios_dir),
+            "--worlds-dir", str(worlds_dir),
+        ],
+    )
+    assert result.exit_code != 0
+    assert "not found" in result.output.lower()

--- a/tests/program_layer/test_scenario_model.py
+++ b/tests/program_layer/test_scenario_model.py
@@ -1,0 +1,257 @@
+"""
+test_scenario_model.py — SYS-3 dataclass invariants and serialisation.
+
+Validates that the frozen value types in ``scenario_model.py`` enforce the
+structural guarantees documented in ``docs/comparative-playground.md``:
+
+- ``WorldRef`` rejects empty ids/versions and the literal ``"latest"``.
+- ``Scenario`` requires ≥2 distinct worlds and exactly one of
+  ``program_id`` or ``program_steps``.
+- Every model round-trips through ``to_dict``/``from_dict`` byte-stably.
+- ``ScenarioResult.scrub_run_metadata`` strips only the non-deterministic
+  ``run_id`` / ``ran_at`` fields.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from agent_hypervisor.program_layer import (
+    DivergenceReport,
+    Scenario,
+    ScenarioDivergencePoint,
+    ScenarioResult,
+    StepOutcome,
+    WorldRef,
+    WorldResult,
+    make_scenario_run_id,
+)
+from agent_hypervisor.program_layer.review_models import CandidateStep
+
+
+# ---------------------------------------------------------------------------
+# WorldRef
+# ---------------------------------------------------------------------------
+
+
+def test_world_ref_requires_non_empty_fields():
+    with pytest.raises(ValueError):
+        WorldRef(world_id="", version="1.0")
+    with pytest.raises(ValueError):
+        WorldRef(world_id="world_a", version="")
+
+
+@pytest.mark.parametrize("bad", ["latest", "LATEST", "  latest  "])
+def test_world_ref_rejects_latest_version(bad: str):
+    with pytest.raises(ValueError):
+        WorldRef(world_id="world_a", version=bad)
+
+
+def test_world_ref_round_trip():
+    w = WorldRef(world_id="world_a", version="1.2")
+    assert w.key == "world_a@1.2"
+    assert WorldRef.from_dict(w.to_dict()) == w
+
+
+# ---------------------------------------------------------------------------
+# Scenario
+# ---------------------------------------------------------------------------
+
+
+def _two_worlds() -> tuple[WorldRef, WorldRef]:
+    return (
+        WorldRef(world_id="world_strict", version="1.0"),
+        WorldRef(world_id="world_balanced", version="1.0"),
+    )
+
+
+def _two_steps() -> tuple[CandidateStep, CandidateStep]:
+    return (
+        CandidateStep(tool="count_words", params={"input": "hi"}),
+        CandidateStep(tool="normalize_text", params={"input": "HI"}),
+    )
+
+
+def test_scenario_rejects_single_world():
+    with pytest.raises(ValueError, match="at least two"):
+        Scenario(
+            scenario_id="s",
+            name="s",
+            worlds=(WorldRef("w", "1.0"),),
+            program_steps=_two_steps(),
+        )
+
+
+def test_scenario_rejects_duplicate_worlds():
+    w = WorldRef("world_a", "1.0")
+    with pytest.raises(ValueError, match="duplicate"):
+        Scenario(
+            scenario_id="s",
+            name="s",
+            worlds=(w, w),
+            program_steps=_two_steps(),
+        )
+
+
+def test_scenario_rejects_neither_program_form():
+    with pytest.raises(ValueError, match="exactly one"):
+        Scenario(
+            scenario_id="s",
+            name="s",
+            worlds=_two_worlds(),
+        )
+
+
+def test_scenario_rejects_both_program_forms():
+    with pytest.raises(ValueError, match="exactly one"):
+        Scenario(
+            scenario_id="s",
+            name="s",
+            worlds=_two_worlds(),
+            program_id="prog-1",
+            program_steps=_two_steps(),
+        )
+
+
+def test_scenario_round_trip_inline_steps():
+    s = Scenario(
+        scenario_id="s1",
+        name="s1",
+        description="demo",
+        worlds=_two_worlds(),
+        program_steps=_two_steps(),
+    )
+    s2 = Scenario.from_dict(s.to_dict())
+    assert s2.scenario_id == s.scenario_id
+    assert s2.worlds == s.worlds
+    assert s2.program_steps == s.program_steps
+    assert s2.program_id is None
+
+
+def test_scenario_round_trip_program_id():
+    s = Scenario(
+        scenario_id="s1",
+        name="s1",
+        worlds=_two_worlds(),
+        program_id="prog-abc",
+    )
+    s2 = Scenario.from_dict(s.to_dict())
+    assert s2.program_id == "prog-abc"
+    assert s2.program_steps is None
+
+
+# ---------------------------------------------------------------------------
+# StepOutcome / WorldResult / DivergenceReport
+# ---------------------------------------------------------------------------
+
+
+def test_step_outcome_rejects_invalid_enums():
+    with pytest.raises(ValueError):
+        StepOutcome(
+            step_index=0, action="a", stage="bogus",  # type: ignore[arg-type]
+            verdict="allow", reason="r", rule_kind="capability",
+        )
+    with pytest.raises(ValueError):
+        StepOutcome(
+            step_index=0, action="a", stage="preview",
+            verdict="bogus",  # type: ignore[arg-type]
+            reason="r", rule_kind="capability",
+        )
+    with pytest.raises(ValueError):
+        StepOutcome(
+            step_index=0, action="a", stage="preview",
+            verdict="allow", reason="r",
+            rule_kind="bogus",  # type: ignore[arg-type]
+        )
+
+
+def test_step_outcome_requires_non_empty_reason():
+    with pytest.raises(ValueError, match="non-empty"):
+        StepOutcome(
+            step_index=0, action="a", stage="preview",
+            verdict="allow", reason="   ", rule_kind="capability",
+        )
+
+
+def test_step_outcome_round_trip():
+    o = StepOutcome(
+        step_index=2, action="normalize_text", stage="replay",
+        verdict="deny", reason="world validation failed: ...",
+        rule_kind="capability",
+    )
+    assert StepOutcome.from_dict(o.to_dict()) == o
+
+
+def test_world_result_round_trip():
+    outcomes = (
+        StepOutcome(0, "count_words", "replay", "allow", "ok", "execution"),
+    )
+    wr = WorldResult(
+        world_id="world_a", world_version="1.0",
+        preview_compatible=True, replay_verdict="allow",
+        step_outcomes=outcomes,
+    )
+    assert wr.key == "world_a@1.0"
+    assert WorldResult.from_dict(wr.to_dict()) == wr
+
+
+def test_divergence_report_round_trip():
+    point = ScenarioDivergencePoint(
+        step_index=1, action="normalize_text",
+        verdicts_by_world={"a@1.0": "allow", "b@1.0": "deny"},
+        reasons_by_world={"a@1.0": "ok", "b@1.0": "denied"},
+    )
+    report = DivergenceReport(
+        scenario_id="s",
+        divergence_points=(point,),
+        all_agree=False,
+    )
+    assert DivergenceReport.from_dict(report.to_dict()) == report
+
+
+# ---------------------------------------------------------------------------
+# ScenarioResult / scrub / run_id
+# ---------------------------------------------------------------------------
+
+
+def _build_minimal_result(run_id: str, ran_at: str) -> ScenarioResult:
+    wr = WorldResult(
+        world_id="world_a", world_version="1.0",
+        preview_compatible=True, replay_verdict="allow",
+        step_outcomes=(
+            StepOutcome(0, "count_words", "replay", "allow", "ok", "execution"),
+        ),
+    )
+    return ScenarioResult(
+        scenario_id="s",
+        program_id="prog-x",
+        world_results=(wr,),
+        divergence=DivergenceReport(scenario_id="s", divergence_points=(), all_agree=True),
+        run_id=run_id,
+        ran_at=ran_at,
+    )
+
+
+def test_scenario_result_round_trip():
+    r = _build_minimal_result("scn-abc123abc123", "2026-01-01T00:00:00+00:00")
+    assert ScenarioResult.from_dict(r.to_dict()) == r
+
+
+def test_scrub_run_metadata_drops_only_non_deterministic_fields():
+    a = _build_minimal_result("scn-aaa", "2026-01-01T00:00:00+00:00")
+    b = _build_minimal_result("scn-bbb", "2026-02-01T00:00:00+00:00")
+    # Different run_id / ran_at — but the rest is identical.
+    assert a.scrub_run_metadata() == b.scrub_run_metadata()
+    # And the scrub must drop exactly those two keys.
+    scrubbed = a.scrub_run_metadata()
+    assert "run_id" not in scrubbed
+    assert "ran_at" not in scrubbed
+    for k in ("scenario_id", "program_id", "world_results", "divergence"):
+        assert k in scrubbed
+
+
+def test_make_scenario_run_id_prefix_and_uniqueness():
+    a = make_scenario_run_id()
+    b = make_scenario_run_id()
+    assert a.startswith("scn-") and b.startswith("scn-")
+    assert a != b

--- a/tests/program_layer/test_scenario_registry.py
+++ b/tests/program_layer/test_scenario_registry.py
@@ -1,0 +1,208 @@
+"""
+test_scenario_registry.py — YAML-backed scenario registry tests.
+
+Covers:
+
+- Round-trip of a valid scenario YAML through ``load_scenario_from_yaml``.
+- Programmatic ``to_dict → YAML text → load_scenario_from_yaml`` equivalence
+  (scenario authoring and scenario loading agree on the schema).
+- ``ScenarioRegistry.get`` resolves known ids and raises
+  ``ScenarioNotFoundError`` for unknown ids.
+- ``list_scenarios`` returns scenarios sorted by id and skips non-YAML files.
+- Malformed YAML raises ``ScenarioLoadError`` with a useful message.
+- The bundled registry contains the two demo scenarios.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from agent_hypervisor.program_layer import (
+    Scenario,
+    ScenarioLoadError,
+    ScenarioNotFoundError,
+    ScenarioRegistry,
+    WorldRef,
+    default_scenario_registry,
+    load_scenario_from_yaml,
+)
+from agent_hypervisor.program_layer.review_models import CandidateStep
+
+
+BUNDLED_SCENARIOS_DIR = (
+    Path(__file__).resolve().parents[2]
+    / "src" / "agent_hypervisor" / "program_layer" / "scenarios"
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _write_yaml(path: Path, data: dict) -> Path:
+    path.write_text(yaml.safe_dump(data, sort_keys=False), encoding="utf-8")
+    return path
+
+
+def _minimal_yaml() -> dict:
+    return {
+        "scenario_id": "unit_test",
+        "name": "Unit test scenario",
+        "description": "tiny demo",
+        "program_steps": [
+            {"tool": "count_words", "params": {"input": "alpha beta"}},
+        ],
+        "worlds": [
+            {"world_id": "world_strict", "version": "1.0"},
+            {"world_id": "world_balanced", "version": "1.0"},
+        ],
+    }
+
+
+# ---------------------------------------------------------------------------
+# Load / round-trip
+# ---------------------------------------------------------------------------
+
+
+def test_load_scenario_from_yaml_happy_path(tmp_path: Path):
+    path = _write_yaml(tmp_path / "s.yaml", _minimal_yaml())
+    scenario = load_scenario_from_yaml(path)
+
+    assert isinstance(scenario, Scenario)
+    assert scenario.scenario_id == "unit_test"
+    assert scenario.name == "Unit test scenario"
+    assert scenario.description == "tiny demo"
+    assert scenario.worlds == (
+        WorldRef("world_strict", "1.0"),
+        WorldRef("world_balanced", "1.0"),
+    )
+    assert scenario.program_steps is not None
+    assert scenario.program_steps[0] == CandidateStep(
+        tool="count_words", params={"input": "alpha beta"}
+    )
+    assert scenario.program_id is None
+
+
+def test_load_missing_file_raises(tmp_path: Path):
+    with pytest.raises(ScenarioLoadError, match="not found"):
+        load_scenario_from_yaml(tmp_path / "nope.yaml")
+
+
+def test_load_invalid_yaml_raises(tmp_path: Path):
+    bad = tmp_path / "bad.yaml"
+    bad.write_text(":\n  - this is: not: valid: yaml:\n    garbage", encoding="utf-8")
+    with pytest.raises(ScenarioLoadError):
+        load_scenario_from_yaml(bad)
+
+
+def test_load_missing_required_field_raises(tmp_path: Path):
+    data = _minimal_yaml()
+    del data["worlds"]
+    path = _write_yaml(tmp_path / "s.yaml", data)
+    with pytest.raises(ScenarioLoadError, match="worlds"):
+        load_scenario_from_yaml(path)
+
+
+def test_load_rejects_single_world(tmp_path: Path):
+    data = _minimal_yaml()
+    data["worlds"] = [data["worlds"][0]]
+    path = _write_yaml(tmp_path / "s.yaml", data)
+    with pytest.raises(ScenarioLoadError):
+        load_scenario_from_yaml(path)
+
+
+def test_load_rejects_latest_version(tmp_path: Path):
+    data = _minimal_yaml()
+    data["worlds"][0]["version"] = "latest"
+    path = _write_yaml(tmp_path / "s.yaml", data)
+    with pytest.raises(ScenarioLoadError):
+        load_scenario_from_yaml(path)
+
+
+def test_round_trip_via_to_dict(tmp_path: Path):
+    """Authoring path: build a Scenario in code, dump to YAML, reload."""
+    s = Scenario(
+        scenario_id="rt",
+        name="round trip",
+        description="d",
+        worlds=(
+            WorldRef("world_strict", "1.0"),
+            WorldRef("world_balanced", "1.0"),
+        ),
+        program_steps=(
+            CandidateStep(tool="count_words", params={"input": "x"}),
+        ),
+    )
+    path = tmp_path / "rt.yaml"
+    path.write_text(yaml.safe_dump(s.to_dict(), sort_keys=False), encoding="utf-8")
+    loaded = load_scenario_from_yaml(path)
+    # Authoring and loading must agree on the wire-level representation.
+    assert loaded.to_dict() == s.to_dict()
+
+
+# ---------------------------------------------------------------------------
+# ScenarioRegistry
+# ---------------------------------------------------------------------------
+
+
+def test_registry_list_scenarios_sorted(tmp_path: Path):
+    _write_yaml(tmp_path / "b.yaml", {**_minimal_yaml(), "scenario_id": "b_scn"})
+    _write_yaml(tmp_path / "a.yaml", {**_minimal_yaml(), "scenario_id": "a_scn"})
+    # Non-YAML file should be ignored.
+    (tmp_path / "notes.txt").write_text("ignore me", encoding="utf-8")
+    # Dotfile should be ignored.
+    (tmp_path / ".hidden.yaml").write_text("garbage", encoding="utf-8")
+
+    reg = ScenarioRegistry(tmp_path)
+    scenarios = reg.list_scenarios()
+    assert [s.scenario_id for s in scenarios] == ["a_scn", "b_scn"]
+
+
+def test_registry_get_returns_scenario(tmp_path: Path):
+    _write_yaml(tmp_path / "s.yaml", _minimal_yaml())
+    reg = ScenarioRegistry(tmp_path)
+    s = reg.get("unit_test")
+    assert s.scenario_id == "unit_test"
+
+
+def test_registry_get_unknown_raises_not_found(tmp_path: Path):
+    _write_yaml(tmp_path / "s.yaml", _minimal_yaml())
+    reg = ScenarioRegistry(tmp_path)
+    with pytest.raises(ScenarioNotFoundError):
+        reg.get("nope")
+
+
+def test_registry_missing_directory_raises_not_found(tmp_path: Path):
+    reg = ScenarioRegistry(tmp_path / "no_such_dir")
+    assert reg.list_scenarios() == []
+    with pytest.raises(ScenarioNotFoundError):
+        reg.get("any")
+
+
+# ---------------------------------------------------------------------------
+# Bundled scenarios
+# ---------------------------------------------------------------------------
+
+
+def test_default_registry_ships_two_scenarios():
+    reg = default_scenario_registry()
+    ids = sorted(s.scenario_id for s in reg.list_scenarios())
+    assert ids == ["external_call_test", "memory_write_test"]
+
+
+def test_default_registry_scenarios_parse_clean():
+    reg = default_scenario_registry()
+    for scenario_id in ("external_call_test", "memory_write_test"):
+        s = reg.get(scenario_id)
+        assert len(s.worlds) == 2
+        assert s.program_steps is not None
+        assert len(s.program_steps) >= 1
+
+
+def test_bundled_scenarios_dir_matches():
+    reg = default_scenario_registry()
+    assert reg.scenarios_dir == BUNDLED_SCENARIOS_DIR

--- a/tests/program_layer/test_scenario_runner.py
+++ b/tests/program_layer/test_scenario_runner.py
@@ -1,0 +1,294 @@
+"""
+test_scenario_runner.py — SYS-3 orchestration invariants.
+
+Covers the five acceptance invariants from the spec:
+
+    1. Same program runs under two worlds and produces opposite verdicts.
+    2. ``detect_divergence`` flags only the diverging step index.
+    3. ``denied_at_preview`` skips the ReplayEngine entirely
+       (verified with a spy engine that records every call).
+    4. Every StepOutcome has a non-empty ``reason`` and a valid ``rule_kind``.
+    5. Running the same scenario twice on identical inputs produces identical
+       ``ScenarioResult`` data after scrubbing ``run_id`` / ``ran_at``.
+"""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+from typing import Any, Optional
+
+import pytest
+
+from agent_hypervisor.program_layer import (
+    ProgramStore,
+    ReplayEngine,
+    Scenario,
+    WorldRef,
+    WorldRegistry,
+    detect_divergence,
+    run_scenario,
+)
+from agent_hypervisor.program_layer.review_models import CandidateStep
+from agent_hypervisor.program_layer.replay_engine import ReplayTrace
+
+
+BUNDLED_WORLDS_DIR = (
+    Path(__file__).resolve().parents[2]
+    / "src" / "agent_hypervisor" / "program_layer" / "worlds"
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def registry(tmp_path: Path) -> WorldRegistry:
+    worlds_dir = tmp_path / "worlds"
+    worlds_dir.mkdir()
+    for yaml in BUNDLED_WORLDS_DIR.glob("*.yaml"):
+        shutil.copy(yaml, worlds_dir / yaml.name)
+    return WorldRegistry(
+        worlds_dir=worlds_dir,
+        active_file=tmp_path / "active.json",
+    )
+
+
+@pytest.fixture
+def store(tmp_path: Path) -> ProgramStore:
+    return ProgramStore(tmp_path / "programs")
+
+
+@pytest.fixture
+def memory_write_scenario() -> Scenario:
+    return Scenario(
+        scenario_id="memory_write_test",
+        name="memory write",
+        description="count then normalize",
+        worlds=(
+            WorldRef("world_strict", "1.0"),
+            WorldRef("world_balanced", "1.0"),
+        ),
+        program_steps=(
+            CandidateStep(tool="count_words", params={"input": "alpha beta"}),
+            CandidateStep(tool="normalize_text", params={"input": "HELLO"}),
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Spy ReplayEngine — records every replay_under_world call.
+# ---------------------------------------------------------------------------
+
+
+class _SpyReplayEngine(ReplayEngine):
+    def __init__(self) -> None:
+        super().__init__()
+        self.calls: list[dict[str, Any]] = []
+
+    def replay_under_world(self, program, world=None, world_source="explicit",
+                          preview_compatible=None, runner=None,
+                          context=None) -> ReplayTrace:
+        self.calls.append(
+            {
+                "program_id": program.id,
+                "world_id": world.world_id if world is not None else None,
+                "world_version": world.version if world is not None else None,
+                "preview_compatible": preview_compatible,
+            }
+        )
+        return super().replay_under_world(
+            program=program,
+            world=world,
+            world_source=world_source,
+            preview_compatible=preview_compatible,
+            runner=runner,
+            context=context,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Invariant 1 — same program, two worlds, opposite verdicts.
+# ---------------------------------------------------------------------------
+
+
+def test_same_program_two_worlds_produce_opposite_verdicts(
+    registry, memory_write_scenario
+):
+    result = run_scenario(memory_write_scenario, registry=registry)
+
+    assert len(result.world_results) == 2
+    by_key = {wr.key: wr for wr in result.world_results}
+
+    strict = by_key["world_strict@1.0"]
+    balanced = by_key["world_balanced@1.0"]
+
+    assert strict.preview_compatible is False
+    assert strict.replay_verdict == "denied_at_preview"
+    # normalize_text must be the denied step under strict.
+    strict_by_idx = {o.step_index: o for o in strict.step_outcomes}
+    assert strict_by_idx[1].verdict == "deny"
+    assert strict_by_idx[1].action == "normalize_text"
+
+    assert balanced.preview_compatible is True
+    assert balanced.replay_verdict == "allow"
+    assert all(o.verdict == "allow" for o in balanced.step_outcomes)
+
+
+# ---------------------------------------------------------------------------
+# Invariant 2 — detect_divergence flags only the diverging step index.
+# ---------------------------------------------------------------------------
+
+
+def test_detect_divergence_flags_only_diverging_step(
+    registry, memory_write_scenario
+):
+    result = run_scenario(memory_write_scenario, registry=registry)
+    report = result.divergence
+
+    assert report.all_agree is False
+    # Only step[1] (normalize_text) must diverge — step[0] was allowed by both.
+    assert [p.step_index for p in report.divergence_points] == [1]
+    point = report.divergence_points[0]
+    assert point.action == "normalize_text"
+    assert set(point.verdicts_by_world.keys()) == {
+        "world_strict@1.0", "world_balanced@1.0",
+    }
+    assert point.verdicts_by_world["world_strict@1.0"] == "deny"
+    assert point.verdicts_by_world["world_balanced@1.0"] == "allow"
+    # Reasons are populated.
+    for reason in point.reasons_by_world.values():
+        assert reason.strip() != ""
+
+
+def test_detect_divergence_returns_all_agree_for_empty_input():
+    report = detect_divergence("scn-1", [])
+    assert report.all_agree is True
+    assert report.divergence_points == ()
+
+
+# ---------------------------------------------------------------------------
+# Invariant 3 — denied_at_preview must NOT invoke the ReplayEngine.
+# ---------------------------------------------------------------------------
+
+
+def test_denied_at_preview_skips_replay_engine(registry):
+    """Scenario where BOTH worlds deny preview — replay must never be called."""
+    scenario = Scenario(
+        scenario_id="never_replay",
+        name="never replay",
+        worlds=(
+            WorldRef("world_strict", "1.0"),
+            # world_strict again isn't legal (duplicate).  Instead use the
+            # balanced world but drive it through a step the balanced world
+            # does NOT allow — none exists, so craft two distinct strict
+            # references by exploiting the fact that two different copies of
+            # world_strict with different versions would be distinct.  Simpler:
+            # use the balanced world but put a step neither allows.  Neither
+            # world allows "save_memory_external", so both worlds preview-deny.
+            WorldRef("world_balanced", "1.0"),
+        ),
+        program_steps=(
+            CandidateStep(tool="save_memory_external", params={}),
+        ),
+    )
+    spy = _SpyReplayEngine()
+
+    result = run_scenario(scenario, registry=registry, replay_engine=spy)
+
+    # Neither world should have reached the replay engine.
+    assert spy.calls == []
+    for wr in result.world_results:
+        assert wr.preview_compatible is False
+        assert wr.replay_verdict == "denied_at_preview"
+        # The single step is denied at preview on both worlds.
+        assert wr.step_outcomes[0].verdict == "deny"
+        assert wr.step_outcomes[0].stage == "preview"
+        assert wr.step_outcomes[0].rule_kind == "capability"
+
+
+def test_spy_engine_called_only_for_compatible_worlds(
+    registry, memory_write_scenario
+):
+    """The spy should see exactly one call — only the balanced world replays."""
+    spy = _SpyReplayEngine()
+    run_scenario(memory_write_scenario, registry=registry, replay_engine=spy)
+
+    assert len(spy.calls) == 1
+    call = spy.calls[0]
+    assert call["world_id"] == "world_balanced"
+    assert call["preview_compatible"] is True
+
+
+# ---------------------------------------------------------------------------
+# Invariant 4 — every StepOutcome carries a non-empty reason and a valid
+# rule_kind ∈ {capability, schema, taint, policy, execution}.
+# ---------------------------------------------------------------------------
+
+
+_VALID_KINDS = {"capability", "schema", "taint", "policy", "execution"}
+
+
+def test_every_step_outcome_has_reason_and_valid_rule_kind(
+    registry, memory_write_scenario
+):
+    result = run_scenario(memory_write_scenario, registry=registry)
+
+    seen = 0
+    for wr in result.world_results:
+        for o in wr.step_outcomes:
+            assert o.reason.strip() != ""
+            assert o.rule_kind in _VALID_KINDS
+            assert o.verdict in {"allow", "deny", "skip"}
+            seen += 1
+    assert seen > 0
+
+
+# ---------------------------------------------------------------------------
+# Invariant 5 — stability across runs on identical inputs.
+# ---------------------------------------------------------------------------
+
+
+def test_scenario_result_stable_across_repeated_runs(
+    registry, memory_write_scenario
+):
+    a = run_scenario(memory_write_scenario, registry=registry)
+    b = run_scenario(memory_write_scenario, registry=registry)
+
+    assert a.run_id != b.run_id  # non-deterministic by design
+    assert a.scrub_run_metadata() == b.scrub_run_metadata()
+
+
+# ---------------------------------------------------------------------------
+# Program resolution: program_id path requires a store.
+# ---------------------------------------------------------------------------
+
+
+def test_scenario_with_program_id_requires_store(registry):
+    scenario = Scenario(
+        scenario_id="needs_store",
+        name="needs store",
+        worlds=(
+            WorldRef("world_strict", "1.0"),
+            WorldRef("world_balanced", "1.0"),
+        ),
+        program_id="prog-absent",
+    )
+    with pytest.raises(ValueError, match="no ProgramStore"):
+        run_scenario(scenario, registry=registry, store=None)
+
+
+def test_scenario_with_unknown_program_id_raises(registry, store):
+    scenario = Scenario(
+        scenario_id="unknown_prog",
+        name="unknown prog",
+        worlds=(
+            WorldRef("world_strict", "1.0"),
+            WorldRef("world_balanced", "1.0"),
+        ),
+        program_id="prog-does-not-exist",
+    )
+    with pytest.raises(KeyError):
+        run_scenario(scenario, registry=registry, store=store)


### PR DESCRIPTION
Add a differential execution analyzer that binds ONE reviewed program to
N worlds, runs preview + replay under each, and surfaces cross-world
divergence with deterministic step-level rule classes.  Sits strictly
above the sealed runtime — no kernel changes.

- scenario_model: Scenario, WorldRef, StepOutcome, WorldResult,
  DivergenceReport, ScenarioResult (frozen, to_dict/from_dict stable,
  rejects "latest" version, requires ≥2 distinct worlds).
- scenario_runner: run_scenario() composes check_compatibility +
  ReplayEngine.replay_under_world; denied_at_preview short-circuits
  before replay; detect_divergence() compares verdicts per step index.
- scenario_registry: YAML-backed ScenarioRegistry mirroring
  WorldRegistry; default_scenario_registry() over bundled examples.
- scenario_trace_store: append-only JSONL sink for ScenarioResult.
- Two bundled scenarios (memory_write_test, external_call_test) reuse
  the existing 4 SUPPORTED_WORKFLOWS with narrative descriptions.
- CLI: `awc scenario list|show|run|compare` with --json and
  --trace-file; exit 6 when worlds diverge (distinct from codes 3/4/5).
- Tests: 51 new tests covering all 5 acceptance invariants — same
  program across 2 worlds, divergence detection, preview prevents
  invalid replay (verified with spy engine), every outcome carries
  a deterministic reason + rule_kind, scrub-stable across runs.
- Example: examples/comparative_playground_demo.py.
- Docs: docs/comparative-playground.md.

https://claude.ai/code/session_01UnL6kX6QjLeCBL3Wmk82eQ