### PR TITLE
feat(transparent-ui): Phase 3 — Dynamic Workflow→Profile Linking (Rule Engine)

### DIFF
--- a/NEXT_TASKS.md
+++ b/NEXT_TASKS.md
@@ -39,5 +39,6 @@
     checklist, and "how to resume" instructions.
   - **Phase 1 DONE** — Profile Catalog + Session Assignment API (37 tests passing).
   - **Phase 2 DONE** — Manifest Editor UI: `GET /ui/api/tools`, `GET /ui/api/profiles/{id}/rendered-surface`, full profile editor tab (tool checklist, constraints, live preview, diff, save/clone). 47 tests passing. *(branch: claude/plan-next-priorities-pGbM8)*
-  - **Current phase:** Phase 3 — Dynamic Workflow→Profile Linking (Rule Engine).
+  - **Phase 3 DONE** — Dynamic Workflow→Profile Linking: `LinkingPolicyEngine`, `manifests/linking-policy.yaml`, engine wired into `SessionWorldResolver.resolve()`, `GET/POST /ui/api/linking-policy`, `POST /ui/api/linking-policy/test`, Linking tab in Web UI. 37 tests passing. *(branch: feature/transparent-ui-ph3)*
+  - **Current phase:** Phase 4 — Runtime Trigger-Based Profile Switching (Stretch).
   - Any agent can read `TRANSPARENT_UI.md` to know exactly what to build next.

--- a/TRANSPARENT_UI.md
+++ b/TRANSPARENT_UI.md
@@ -119,9 +119,11 @@ rendered tool surface update live, and save — without ever opening a YAML file
 
 ### Phase 3 — Dynamic Workflow→Profile Linking (Rule Engine)
 
-**Status:** `[-] IN PROGRESS`
+**Status:** `[x] DONE`
 
 **Branch name:** `feature/transparent-ui-ph3`
+
+**PR:** *(pending merge)*
 
 **Goal:** Wire the unused `context` dict in `SessionWorldResolver.resolve()` to
 a declarative rule evaluator so that profile selection can be driven by workflow
@@ -130,42 +132,28 @@ attributes, user role, trust level, or other runtime signals — not just manual
 
 **Deliverables:**
 
-- [ ] **Linking-policy schema** — a new YAML format (e.g. `manifests/linking-policy.yaml`):
-  ```yaml
-  rules:
-    - if:
-        workflow_tag: finance
-        trust_level: low
-      then:
-        profile_id: read-only
-    - if:
-        workflow_tag: email
-      then:
-        profile_id: email-assistant-v1
-    - default:
-        profile_id: email-assistant-v1
-  ```
-- [ ] **`LinkingPolicyEngine`** — evaluates rules against the `context` dict;
+- [x] **Linking-policy schema** — `manifests/linking-policy.yaml` with rule-based dispatch.
+- [x] **`LinkingPolicyEngine`** — evaluates rules against the `context` dict;
   returns the matched `profile_id`. Pure function, no I/O, testable in isolation.
-- [ ] **Wire into `SessionWorldResolver.resolve()`** — when `context` is provided
+  (`src/agent_hypervisor/hypervisor/mcp_gateway/linking_policy.py`)
+- [x] **Wire into `SessionWorldResolver.resolve()`** — when `context` is provided
   and a `LinkingPolicyEngine` is configured, use it to select the profile; fall
   back to explicit session registry, then default manifest.
-- [ ] `GET /ui/api/linking-policy` — return active rules.
-- [ ] `POST /ui/api/linking-policy` — replace active rules (validate + hot-reload).
-- [ ] **Linking-policy editor tab** in Web UI — table of rules with add/edit/delete,
+- [x] `GET /ui/api/linking-policy` — return active rules.
+- [x] `POST /ui/api/linking-policy` — replace active rules (validate + hot-reload).
+- [x] `POST /ui/api/linking-policy/test` — evaluate a context dict against active rules.
+- [x] **Linking-policy editor tab** in Web UI — table of rules with add/edit/delete/reorder,
   live "which profile would be used?" test input form.
-- [ ] Tests: rule evaluation correctness; fallback chain; context-free session still
-  uses registered manifest.
+- [x] Tests: 37 tests in `tests/hypervisor/test_linking_policy.py` — rule evaluation
+  correctness, fallback chain, context-free session, API endpoints, startup load. All passing. ✅
 
-**Done criteria:** A session started with `context={"workflow_tag": "finance", "trust_level": "low"}` automatically receives the `read-only` profile without any explicit `register_session()` call.
-
-**PR:** *(fill in after merge)*
+**Done criteria:** A session started with `context={"workflow_tag": "finance", "trust_level": "low"}` automatically receives the `read-only-v1` profile without any explicit `register_session()` call. ✅
 
 ---
 
 ### Phase 4 — Runtime Trigger-Based Profile Switching (Stretch)
 
-**Status:** `[ ] NOT STARTED`
+**Status:** `[-] IN PROGRESS`
 
 **Branch name:** `feature/transparent-ui-ph4`
 

--- a/manifests/linking-policy.yaml
+++ b/manifests/linking-policy.yaml
@@ -1,0 +1,31 @@
+# linking-policy.yaml — Declarative workflow→profile dispatch rules.
+#
+# Rules are evaluated top-to-bottom; the first match wins.
+# Each rule has an `if` block (all conditions must hold) and a `then` block
+# (specifies the profile_id to activate).
+# The `default` entry has no `if` block and matches when no earlier rule fires.
+#
+# Context keys are set by the caller of SessionWorldResolver.resolve(context=...).
+# Common keys: workflow_tag, trust_level, user_role.
+#
+# Profile IDs must match entries in manifests/profiles-index.yaml.
+
+rules:
+  - if:
+      workflow_tag: finance
+      trust_level: low
+    then:
+      profile_id: read-only-v1
+
+  - if:
+      workflow_tag: finance
+    then:
+      profile_id: read-only-v1
+
+  - if:
+      workflow_tag: email
+    then:
+      profile_id: email-assistant-v1
+
+  - default:
+      profile_id: email-assistant-v1

--- a/src/agent_hypervisor/hypervisor/mcp_gateway/linking_policy.py
+++ b/src/agent_hypervisor/hypervisor/mcp_gateway/linking_policy.py
@@ -1,0 +1,79 @@
+"""
+linking_policy.py — Declarative workflow→profile rule engine.
+
+Evaluates a list of rules against a session context dict and returns
+the profile_id of the first matching rule.
+
+Rule format (YAML / dict):
+    rules:
+      - if: {workflow_tag: finance, trust_level: low}
+        then: {profile_id: read-only}
+      - if: {workflow_tag: email}
+        then: {profile_id: email-assistant-v1}
+      - default:
+          profile_id: fallback-profile
+
+Semantics:
+  - Rules are evaluated top-to-bottom; first match wins.
+  - A rule matches when every key in its ``if`` block equals the
+    corresponding value in the context dict (all conditions must hold).
+  - The ``default`` entry has no ``if`` block; it always matches.
+  - Returns None if no rule matches and no default is set.
+
+This class is pure: no I/O, no side effects, fully testable in isolation.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+
+class LinkingPolicyEngine:
+    """
+    Evaluates linking-policy rules against a session context dict.
+
+    Args:
+        rules: List of rule dicts from the linking-policy YAML
+               (the value of the top-level ``rules`` key).
+    """
+
+    def __init__(self, rules: list[dict[str, Any]]) -> None:
+        self._rules = rules
+
+    def evaluate(self, context: dict[str, Any]) -> Optional[str]:
+        """
+        Return the profile_id matched by the first applicable rule.
+
+        Args:
+            context: Arbitrary key-value dict describing the session
+                     (e.g. workflow_tag, trust_level, user_role).
+
+        Returns:
+            profile_id string from the matched rule's ``then`` block,
+            or None if no rule matches.
+        """
+        for rule in self._rules:
+            if "default" in rule:
+                profile_id = rule["default"].get("profile_id")
+                if profile_id:
+                    return profile_id
+            conditions = rule.get("if", {})
+            if self._matches(conditions, context):
+                profile_id = rule.get("then", {}).get("profile_id")
+                if profile_id:
+                    return profile_id
+        return None
+
+    def rules(self) -> list[dict[str, Any]]:
+        """Return a copy of the current rule list."""
+        return list(self._rules)
+
+    @staticmethod
+    def _matches(conditions: dict[str, Any], context: dict[str, Any]) -> bool:
+        """True iff every condition key-value pair is present in context."""
+        return all(context.get(k) == v for k, v in conditions.items())
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "LinkingPolicyEngine":
+        """Construct from the parsed YAML dict (expects a ``rules`` key)."""
+        return cls(data.get("rules", []))

--- a/src/agent_hypervisor/hypervisor/mcp_gateway/session_world_resolver.py
+++ b/src/agent_hypervisor/hypervisor/mcp_gateway/session_world_resolver.py
@@ -4,16 +4,10 @@ session_world_resolver.py — Session to WorldManifest binding.
 Responsibility:
     Map a session/request context to the active WorldManifest.
 
-v1 implementation:
-    Single static manifest per gateway instance (the default), plus an
-    optional per-session registry. Sessions without an explicit binding
-    fall back to the default manifest.
-
-Extension path:
-    register_session(session_id, manifest_path) binds a specific session
-    to a different WorldManifest loaded from disk. This is the intended
-    evolution of the resolve(session_id, context) signature that was
-    designed to support this pattern from the start.
+Resolution priority (highest to lowest):
+    1. Explicit per-session registration (register_session).
+    2. LinkingPolicyEngine evaluation against the provided context dict.
+    3. Default manifest (gateway-level fallback).
 
 Invariants:
     - If the default manifest file cannot be loaded at startup, the resolver
@@ -25,15 +19,23 @@ Invariants:
     - The resolver never returns None — callers can always depend on a manifest.
     - Unregistering a session is safe to call even if the session is not
       registered (idempotent, returns False in that case).
+    - If the LinkingPolicyEngine returns a profile_id that is not in the
+      catalog (or the catalog is not configured), the engine result is silently
+      skipped and the default manifest is used. This preserves fail-safe
+      behaviour: a misconfigured linking rule never causes a crash.
 """
 
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any, Optional
+from typing import TYPE_CHECKING, Any, Optional
 
 from agent_hypervisor.compiler.manifest import load_manifest
 from agent_hypervisor.compiler.schema import WorldManifest
+
+if TYPE_CHECKING:
+    from agent_hypervisor.hypervisor.mcp_gateway.linking_policy import LinkingPolicyEngine
+    from agent_hypervisor.hypervisor.mcp_gateway.profiles_catalog import ProfilesCatalog
 
 
 class SessionWorldResolver:
@@ -55,6 +57,13 @@ class SessionWorldResolver:
         resolver.unregister_session("s1")
         manifest = resolver.resolve(session_id="s1")
         # → back to default manifest
+
+        # Dynamic: rule-based dispatch via context dict
+        engine = LinkingPolicyEngine(rules=[...])
+        catalog = ProfilesCatalog(Path("manifests/profiles-index.yaml"))
+        resolver.set_linking_policy(engine, catalog)
+        manifest = resolver.resolve(session_id="s2", context={"workflow_tag": "finance"})
+        # → manifest for whichever profile_id the rule selects
     """
 
     def __init__(self, manifest_path: Path) -> None:
@@ -62,7 +71,30 @@ class SessionWorldResolver:
         self._manifest: Optional[WorldManifest] = None
         # session_id → WorldManifest (per-session overrides)
         self._session_registry: dict[str, WorldManifest] = {}
+        self._engine: Optional["LinkingPolicyEngine"] = None
+        self._catalog: Optional["ProfilesCatalog"] = None
         self._load()  # Raises on failure — intentional (fail closed at startup)
+
+    def set_linking_policy(
+        self,
+        engine: "LinkingPolicyEngine",
+        catalog: "ProfilesCatalog",
+    ) -> None:
+        """
+        Configure the rule engine used for context-driven profile dispatch.
+
+        Args:
+            engine:  A LinkingPolicyEngine with the active rule set.
+            catalog: A ProfilesCatalog used to load the manifest for the
+                     matched profile_id.
+        """
+        self._engine = engine
+        self._catalog = catalog
+
+    def clear_linking_policy(self) -> None:
+        """Remove the rule engine; context-based dispatch falls back to default."""
+        self._engine = None
+        self._catalog = None
 
     def resolve(
         self,
@@ -72,28 +104,43 @@ class SessionWorldResolver:
         """
         Return the WorldManifest for this session.
 
-        If the session has a registered manifest (via register_session),
-        that manifest is returned. Otherwise the default manifest is used.
+        Resolution order:
+        1. Explicit per-session registration (register_session).
+        2. LinkingPolicyEngine result when context is provided.
+        3. Default gateway-level manifest.
 
         Args:
-            session_id: Optional session identifier. If registered, the
-                        session-specific manifest is returned.
-            context:    Optional context dict (reserved for future use).
+            session_id: Optional session identifier.
+            context:    Optional context dict for rule-based dispatch
+                        (e.g. {"workflow_tag": "finance", "trust_level": "low"}).
 
         Returns:
             The active WorldManifest for this session.
 
         Raises:
-            RuntimeError: If no manifest is loaded (should not happen after
-                          successful __init__, but included for safety).
+            RuntimeError: If no manifest is loaded.
         """
         if self._manifest is None:
             raise RuntimeError(
                 "SessionWorldResolver has no manifest loaded. "
                 "Check manifest_path and startup logs."
             )
+
+        # Priority 1: explicit per-session binding
         if session_id and session_id in self._session_registry:
             return self._session_registry[session_id]
+
+        # Priority 2: rule engine evaluation
+        if context and self._engine is not None and self._catalog is not None:
+            profile_id = self._engine.evaluate(context)
+            if profile_id:
+                try:
+                    return self._catalog.load_manifest(profile_id)
+                except Exception:
+                    # Misconfigured rule (unknown profile) — fall through to default
+                    pass
+
+        # Priority 3: default manifest
         return self._manifest
 
     def register_session(self, session_id: str, manifest_path: Path) -> WorldManifest:
@@ -162,6 +209,13 @@ class SessionWorldResolver:
         except Exception:
             # Retain existing manifest — do not fail open
             return False
+
+    @property
+    def linking_policy_rules(self) -> list[dict]:
+        """Return active linking-policy rules, or empty list if none configured."""
+        if self._engine is None:
+            return []
+        return self._engine.rules()
 
     @property
     def manifest_path(self) -> Path:

--- a/src/agent_hypervisor/ui/router.py
+++ b/src/agent_hypervisor/ui/router.py
@@ -32,6 +32,11 @@ Profile Catalog API (Phase 1 — Transparent UI):
   POST /ui/api/sessions/{session_id}/profile           — assign a profile to a live session
   DELETE /ui/api/sessions/{session_id}/profile         — revert session to default profile
   GET  /ui/api/sessions                                — list active sessions + their bound profile
+
+Linking Policy API (Phase 3 — Transparent UI):
+  GET  /ui/api/linking-policy              — return active dispatch rules (empty list if none)
+  POST /ui/api/linking-policy              — replace active rules (validate + hot-reload engine)
+  POST /ui/api/linking-policy/test         — evaluate a context dict; return matched profile_id
 """
 
 from __future__ import annotations
@@ -49,6 +54,7 @@ from agent_hypervisor.hypervisor.mcp_gateway.profiles_catalog import (
     ProfileEntry,
     ProfilesCatalog,
 )
+from agent_hypervisor.hypervisor.mcp_gateway.linking_policy import LinkingPolicyEngine
 
 _STATIC = Path(__file__).parent / "static"
 # Reports live in _research/ at the repo root.
@@ -60,22 +66,36 @@ def create_ui_router(
     cp_state: Optional[Any] = None,
     policy_path: Optional[Path] = None,
     profiles_catalog: Optional["ProfilesCatalog"] = None,
+    linking_policy_path: Optional[Path] = None,
 ) -> APIRouter:
     """
     Build and return the FastAPI router for the Web UI.
 
     Args:
-        gw_state:         MCPGatewayState — provides manifest and session info.
-        cp_state:         Optional ControlPlaneState — approvals and event log.
-        policy_path:      Path to the provenance policy YAML.
-        profiles_catalog: Optional ProfilesCatalog. When provided, the
-                          /ui/api/profiles* and /ui/api/sessions* endpoints
-                          are active. Without it those endpoints return 503.
+        gw_state:             MCPGatewayState — provides manifest and session info.
+        cp_state:             Optional ControlPlaneState — approvals and event log.
+        policy_path:          Path to the provenance policy YAML.
+        profiles_catalog:     Optional ProfilesCatalog. When provided, the
+                              /ui/api/profiles* and /ui/api/sessions* endpoints
+                              are active. Without it those endpoints return 503.
+        linking_policy_path:  Path to the linking-policy YAML file used for
+                              GET/POST persistence. When provided the resolver
+                              is pre-loaded with rules from this file.
 
     Returns:
         APIRouter with /ui/* routes (no prefix set; caller includes directly).
     """
     router = APIRouter()
+
+    # Pre-load linking policy from disk if a path is configured
+    if linking_policy_path is not None and Path(linking_policy_path).exists():
+        try:
+            _lp_data = yaml.safe_load(Path(linking_policy_path).read_text(encoding="utf-8")) or {}
+            _engine = LinkingPolicyEngine.from_dict(_lp_data)
+            if profiles_catalog is not None:
+                gw_state.resolver.set_linking_policy(_engine, profiles_catalog)
+        except Exception:
+            pass  # Startup continues with no engine if the file is malformed
 
     # ── Static files ─────────────────────────────────────────────────────────
 
@@ -578,6 +598,114 @@ def create_ui_router(
                 default_manifest.workflow_id if default_manifest else None
             ),
             "session_count": len(registry),
+        })
+
+    # ── Linking Policy API ────────────────────────────────────────────────────
+
+    @router.get("/ui/api/linking-policy")
+    def api_linking_policy_get() -> JSONResponse:
+        """
+        Return the active workflow→profile dispatch rules.
+
+        Returns an empty list when no linking policy is configured.
+        """
+        rules = gw_state.resolver.linking_policy_rules
+        return JSONResponse({"rules": rules, "count": len(rules)})
+
+    @router.post("/ui/api/linking-policy")
+    async def api_linking_policy_post(request: Request) -> JSONResponse:
+        """
+        Replace the active linking-policy rules.
+
+        Body JSON::
+
+            {"rules": [{"if": {"workflow_tag": "finance"}, "then": {"profile_id": "read-only-v1"}}, ...]}
+
+        Validates that:
+        - ``rules`` is a list.
+        - Each rule has either ``if``+``then`` or ``default``.
+        - profile_ids referenced in rules exist in the catalog (when catalog is set).
+
+        On success, hot-reloads the engine and persists the new rules to
+        ``linking_policy_path`` (if configured).
+        """
+        if profiles_catalog is None:
+            return JSONResponse(
+                {"error": "Profiles catalog not configured; linking policy unavailable."},
+                status_code=503,
+            )
+        body = await request.json()
+        rules = body.get("rules")
+        if not isinstance(rules, list):
+            return JSONResponse(
+                {"error": "'rules' must be a list."},
+                status_code=400,
+            )
+        # Validate rule structure
+        for i, rule in enumerate(rules):
+            if not isinstance(rule, dict):
+                return JSONResponse(
+                    {"error": f"Rule at index {i} must be a dict."},
+                    status_code=400,
+                )
+            has_if_then = "if" in rule and "then" in rule
+            has_default = "default" in rule
+            if not has_if_then and not has_default:
+                return JSONResponse(
+                    {"error": f"Rule at index {i} must have 'if'+'then' or 'default'."},
+                    status_code=400,
+                )
+            # Check profile_id exists in catalog
+            profile_id = (
+                rule.get("then", {}).get("profile_id")
+                if has_if_then
+                else rule.get("default", {}).get("profile_id")
+            )
+            if profile_id and profiles_catalog.get(profile_id) is None:
+                return JSONResponse(
+                    {"error": f"Unknown profile_id {profile_id!r} in rule at index {i}."},
+                    status_code=400,
+                )
+        # Build and activate new engine
+        new_engine = LinkingPolicyEngine(rules)
+        gw_state.resolver.set_linking_policy(new_engine, profiles_catalog)
+        # Persist to disk if a path is configured
+        if linking_policy_path is not None:
+            try:
+                Path(linking_policy_path).write_text(
+                    yaml.dump({"rules": rules}, default_flow_style=False, sort_keys=False),
+                    encoding="utf-8",
+                )
+            except Exception as exc:
+                return JSONResponse(
+                    {"status": "active", "persisted": False, "error": str(exc), "count": len(rules)},
+                )
+        return JSONResponse({"status": "active", "persisted": linking_policy_path is not None, "count": len(rules)})
+
+    @router.post("/ui/api/linking-policy/test")
+    async def api_linking_policy_test(request: Request) -> JSONResponse:
+        """
+        Test the active linking-policy against a context dict.
+
+        Body JSON::
+
+            {"context": {"workflow_tag": "finance", "trust_level": "low"}}
+
+        Returns which profile_id would be selected, or null if no rule matches.
+        """
+        body = await request.json()
+        context = body.get("context", {})
+        if not isinstance(context, dict):
+            return JSONResponse({"error": "'context' must be a dict."}, status_code=400)
+        rules = gw_state.resolver.linking_policy_rules
+        if not rules:
+            return JSONResponse({"profile_id": None, "matched": False, "reason": "no linking policy configured"})
+        engine = LinkingPolicyEngine(rules)
+        profile_id = engine.evaluate(context)
+        return JSONResponse({
+            "profile_id": profile_id,
+            "matched": profile_id is not None,
+            "context": context,
         })
 
     return router

--- a/src/agent_hypervisor/ui/static/app.js
+++ b/src/agent_hypervisor/ui/static/app.js
@@ -58,6 +58,7 @@ async function loadTab(tab) {
     if (tab === 'provenance') await loadProvenance();
     if (tab === 'simulator')  await loadSimulator();
     if (tab === 'benchmarks') await loadBenchmarks();
+    if (tab === 'linking')    await loadLinking();
     lastRefresh = Date.now();
     setRefreshLabel();
   } catch (err) {
@@ -1216,6 +1217,236 @@ function renderMdTable(rows) {
         `<tr>${row.map(c => `<td>${mdInline(c)}</td>`).join('')}</tr>`
       ).join('')}</tbody>
     </table>`;
+}
+
+// ── Linking Policy tab ────────────────────────────────────────────────────
+
+// In-memory copy of the rules being edited
+let linkingRules = [];
+// Draft rule being built in the "Add rule" form
+let linkingDraftConditions = []; // [{key, value}]
+
+async function loadLinking() {
+  const panel = document.getElementById('tab-linking');
+  try {
+    const data = await apiFetch('/ui/api/linking-policy');
+    linkingRules = data.rules || [];
+    renderLinkingPanel(panel);
+  } catch (err) {
+    panel.innerHTML = `<div class="error-box">Failed to load linking policy: ${esc(String(err))}</div>`;
+  }
+}
+
+function renderLinkingPanel(panel) {
+  panel.innerHTML = `
+    <div class="section">
+      <div class="section-header">
+        <h2>Workflow → Profile Linking Rules</h2>
+        <p class="section-desc">
+          Rules are evaluated top-to-bottom. The first matching rule selects the
+          profile for the session. The <code>default</code> entry matches when no
+          earlier rule fires.
+        </p>
+      </div>
+      ${renderLinkingRulesTable()}
+      <div class="linking-actions">
+        <button class="btn-primary" onclick="saveLinkingRules()">Save rules</button>
+        <span id="linking-save-status" class="save-status"></span>
+      </div>
+    </div>
+
+    <div class="section">
+      <h3>Add rule</h3>
+      <div class="linking-add-form" id="linking-add-form">
+        <div class="form-row">
+          <label>Type</label>
+          <select id="linking-rule-type" onchange="renderLinkingAddForm()">
+            <option value="conditional">Conditional (if → then)</option>
+            <option value="default">Default (catch-all)</option>
+          </select>
+        </div>
+        <div id="linking-conditions-block">
+          <div class="form-row conditions-header">
+            <label>Conditions (all must match)</label>
+            <button class="btn-sm" onclick="addLinkingCondition()">+ condition</button>
+          </div>
+          <div id="linking-conditions-list"></div>
+        </div>
+        <div class="form-row">
+          <label>Profile ID</label>
+          <input type="text" id="linking-profile-id" placeholder="e.g. read-only-v1" style="width:240px">
+        </div>
+        <button class="btn-secondary" onclick="commitLinkingRule()">Add rule</button>
+      </div>
+    </div>
+
+    <div class="section">
+      <h3>Test linking policy</h3>
+      <div class="form-row">
+        <label>Context JSON</label>
+        <textarea id="linking-test-ctx" rows="4" style="width:400px;font-family:monospace"
+          placeholder='{"workflow_tag": "finance", "trust_level": "low"}'></textarea>
+      </div>
+      <button class="btn-secondary" onclick="testLinkingPolicy()">Evaluate</button>
+      <div id="linking-test-result" style="margin-top:8px"></div>
+    </div>`;
+
+  renderLinkingConditionsList();
+}
+
+function renderLinkingRulesTable() {
+  if (linkingRules.length === 0) {
+    return emptyState('No rules', 'Add a rule below or save an empty list to clear the policy.');
+  }
+  const rows = linkingRules.map((rule, idx) => {
+    const isDefault = 'default' in rule;
+    const conditions = isDefault
+      ? '<em>default</em>'
+      : Object.entries(rule.if || {})
+          .map(([k, v]) => `<code>${esc(k)} = ${esc(String(v))}</code>`)
+          .join(', ') || '(no conditions)';
+    const profileId = isDefault
+      ? esc(rule.default?.profile_id || '—')
+      : esc(rule.then?.profile_id || '—');
+    const moveUp = idx > 0
+      ? `<button class="btn-sm" onclick="moveLinkingRule(${idx}, -1)">↑</button>`
+      : '';
+    const moveDown = idx < linkingRules.length - 1
+      ? `<button class="btn-sm" onclick="moveLinkingRule(${idx}, 1)">↓</button>`
+      : '';
+    return `<tr>
+      <td class="mono small">${conditions}</td>
+      <td><span class="badge">${profileId}</span></td>
+      <td>${moveUp}${moveDown}<button class="btn-sm danger" onclick="deleteLinkingRule(${idx})">✕</button></td>
+    </tr>`;
+  }).join('');
+  return `
+    <table class="data-table">
+      <thead><tr><th>If (conditions)</th><th>Then (profile)</th><th>Actions</th></tr></thead>
+      <tbody>${rows}</tbody>
+    </table>`;
+}
+
+function renderLinkingAddForm() {
+  const type = document.getElementById('linking-rule-type')?.value;
+  const block = document.getElementById('linking-conditions-block');
+  if (block) block.style.display = type === 'default' ? 'none' : '';
+}
+
+function renderLinkingConditionsList() {
+  const container = document.getElementById('linking-conditions-list');
+  if (!container) return;
+  if (linkingDraftConditions.length === 0) {
+    container.innerHTML = '<div class="empty-hint">No conditions — add one above.</div>';
+    return;
+  }
+  container.innerHTML = linkingDraftConditions.map((c, i) => `
+    <div class="form-row condition-row">
+      <input type="text" value="${esc(c.key)}" placeholder="key"
+        oninput="linkingDraftConditions[${i}].key=this.value" style="width:140px">
+      <span>=</span>
+      <input type="text" value="${esc(c.value)}" placeholder="value"
+        oninput="linkingDraftConditions[${i}].value=this.value" style="width:140px">
+      <button class="btn-sm danger" onclick="removeLinkingCondition(${i})">✕</button>
+    </div>`).join('');
+}
+
+function addLinkingCondition() {
+  linkingDraftConditions.push({ key: '', value: '' });
+  renderLinkingConditionsList();
+}
+
+function removeLinkingCondition(idx) {
+  linkingDraftConditions.splice(idx, 1);
+  renderLinkingConditionsList();
+}
+
+function commitLinkingRule() {
+  const type = document.getElementById('linking-rule-type')?.value;
+  const profileId = document.getElementById('linking-profile-id')?.value?.trim();
+  if (!profileId) {
+    alert('Profile ID is required.');
+    return;
+  }
+  if (type === 'default') {
+    linkingRules.push({ default: { profile_id: profileId } });
+  } else {
+    const conditions = {};
+    for (const c of linkingDraftConditions) {
+      if (c.key.trim()) conditions[c.key.trim()] = c.value;
+    }
+    linkingRules.push({ if: conditions, then: { profile_id: profileId } });
+  }
+  linkingDraftConditions = [];
+  const panel = document.getElementById('tab-linking');
+  renderLinkingPanel(panel);
+}
+
+function deleteLinkingRule(idx) {
+  linkingRules.splice(idx, 1);
+  const panel = document.getElementById('tab-linking');
+  renderLinkingPanel(panel);
+}
+
+function moveLinkingRule(idx, direction) {
+  const target = idx + direction;
+  if (target < 0 || target >= linkingRules.length) return;
+  [linkingRules[idx], linkingRules[target]] = [linkingRules[target], linkingRules[idx]];
+  const panel = document.getElementById('tab-linking');
+  renderLinkingPanel(panel);
+}
+
+async function saveLinkingRules() {
+  const statusEl = document.getElementById('linking-save-status');
+  if (statusEl) statusEl.textContent = 'Saving…';
+  try {
+    const resp = await fetch('/ui/api/linking-policy', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ rules: linkingRules }),
+    });
+    const data = await resp.json();
+    if (!resp.ok) {
+      if (statusEl) statusEl.textContent = `Error: ${data.error || resp.statusText}`;
+      return;
+    }
+    if (statusEl) statusEl.textContent = `Saved (${data.count} rule${data.count !== 1 ? 's' : ''})`;
+  } catch (err) {
+    if (statusEl) statusEl.textContent = `Error: ${err}`;
+  }
+}
+
+async function testLinkingPolicy() {
+  const ctxRaw = document.getElementById('linking-test-ctx')?.value || '{}';
+  const resultEl = document.getElementById('linking-test-result');
+  let context;
+  try {
+    context = JSON.parse(ctxRaw);
+  } catch {
+    if (resultEl) resultEl.innerHTML = '<span class="error-text">Invalid JSON in context field.</span>';
+    return;
+  }
+  try {
+    const resp = await fetch('/ui/api/linking-policy/test', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ context }),
+    });
+    const data = await resp.json();
+    if (!resp.ok) {
+      if (resultEl) resultEl.innerHTML = `<span class="error-text">${esc(data.error || resp.statusText)}</span>`;
+      return;
+    }
+    if (resultEl) {
+      if (data.matched) {
+        resultEl.innerHTML = `<span class="badge success">Profile: ${esc(data.profile_id)}</span>`;
+      } else {
+        resultEl.innerHTML = `<span class="badge muted">No match — ${esc(data.reason || 'default manifest will be used')}</span>`;
+      }
+    }
+  } catch (err) {
+    if (resultEl) resultEl.innerHTML = `<span class="error-text">${esc(String(err))}</span>`;
+  }
 }
 
 // ── Shared helpers ────────────────────────────────────────────────────────

--- a/src/agent_hypervisor/ui/static/index.html
+++ b/src/agent_hypervisor/ui/static/index.html
@@ -31,6 +31,7 @@
       <button class="tab-btn" data-tab="provenance">Provenance</button>
       <button class="tab-btn" data-tab="simulator">Simulator</button>
       <button class="tab-btn" data-tab="benchmarks">Benchmarks</button>
+      <button class="tab-btn" data-tab="linking">Linking</button>
       <div class="tab-refresh">
         <span class="refresh-label" id="refresh-label">—</span>
       </div>
@@ -44,6 +45,7 @@
       <div id="tab-provenance" class="tab-panel"><div class="loading"><div class="spinner"></div>Loading…</div></div>
       <div id="tab-simulator"  class="tab-panel"><div class="loading"><div class="spinner"></div>Loading…</div></div>
       <div id="tab-benchmarks" class="tab-panel"><div class="loading"><div class="spinner"></div>Loading…</div></div>
+      <div id="tab-linking"   class="tab-panel"><div class="loading"><div class="spinner"></div>Loading…</div></div>
     </main>
   </div>
   <script src="/ui/app.js"></script>

--- a/tests/hypervisor/test_linking_policy.py
+++ b/tests/hypervisor/test_linking_policy.py
@@ -1,0 +1,442 @@
+"""
+test_linking_policy.py — Tests for Phase 3: Dynamic Workflow→Profile Linking.
+
+Covers:
+  - LinkingPolicyEngine unit tests (pure function, no I/O)
+  - SessionWorldResolver integration: context-driven dispatch, priority ordering
+  - REST API: GET/POST /ui/api/linking-policy and /ui/api/linking-policy/test
+"""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+_REPO_ROOT = Path(__file__).parent.parent.parent
+_MANIFESTS_DIR = _REPO_ROOT / "manifests"
+
+
+# ===========================================================================
+# Fixtures
+# ===========================================================================
+
+@pytest.fixture()
+def tmp_catalog_dir(tmp_path: Path):
+    """Temp dir with a minimal profiles-index.yaml and two manifests."""
+    shutil.copy(_MANIFESTS_DIR / "example_world.yaml",  tmp_path / "example_world.yaml")
+    shutil.copy(_MANIFESTS_DIR / "read_only_world.yaml", tmp_path / "read_only_world.yaml")
+    (tmp_path / "profiles-index.yaml").write_text(
+        "profiles:\n"
+        "  - id: email-assistant-v1\n"
+        "    description: Email assistant\n"
+        "    path: example_world.yaml\n"
+        "    tags: [email]\n"
+        "  - id: read-only-v1\n"
+        "    description: Read-only world\n"
+        "    path: read_only_world.yaml\n"
+        "    tags: [readonly]\n",
+        encoding="utf-8",
+    )
+    return tmp_path
+
+
+@pytest.fixture()
+def catalog(tmp_catalog_dir: Path):
+    from agent_hypervisor.hypervisor.mcp_gateway.profiles_catalog import ProfilesCatalog
+    return ProfilesCatalog(tmp_catalog_dir / "profiles-index.yaml")
+
+
+@pytest.fixture()
+def resolver(tmp_catalog_dir: Path):
+    from agent_hypervisor.hypervisor.mcp_gateway.session_world_resolver import SessionWorldResolver
+    return SessionWorldResolver(tmp_catalog_dir / "example_world.yaml")
+
+
+def _make_gw_state_with_resolver(resolver_obj):
+    """Build a minimal MCPGatewayState mock wrapping a real SessionWorldResolver."""
+    renderer = MagicMock()
+    renderer.render.return_value = []
+
+    gw = MagicMock()
+    gw.resolver = resolver_obj
+    gw.renderer = renderer
+    gw.renderer_for.return_value = renderer
+    gw.manifest_path = _MANIFESTS_DIR / "example_world.yaml"
+    gw.started_at = "2026-01-01T00:00:00+00:00"
+    return gw
+
+
+def _make_app(resolver_obj, catalog_obj=None, linking_policy_path=None):
+    from agent_hypervisor.ui.router import create_ui_router
+    gw_state = _make_gw_state_with_resolver(resolver_obj)
+    app = FastAPI()
+    app.include_router(
+        create_ui_router(
+            gw_state,
+            profiles_catalog=catalog_obj,
+            linking_policy_path=linking_policy_path,
+        )
+    )
+    return app, gw_state
+
+
+# ===========================================================================
+# LinkingPolicyEngine — unit tests
+# ===========================================================================
+
+class TestLinkingPolicyEngineBasic:
+
+    def test_exact_single_condition_match(self):
+        from agent_hypervisor.hypervisor.mcp_gateway.linking_policy import LinkingPolicyEngine
+        engine = LinkingPolicyEngine([
+            {"if": {"workflow_tag": "finance"}, "then": {"profile_id": "read-only-v1"}},
+        ])
+        assert engine.evaluate({"workflow_tag": "finance"}) == "read-only-v1"
+
+    def test_no_match_returns_none(self):
+        from agent_hypervisor.hypervisor.mcp_gateway.linking_policy import LinkingPolicyEngine
+        engine = LinkingPolicyEngine([
+            {"if": {"workflow_tag": "finance"}, "then": {"profile_id": "read-only-v1"}},
+        ])
+        assert engine.evaluate({"workflow_tag": "email"}) is None
+
+    def test_empty_rules_returns_none(self):
+        from agent_hypervisor.hypervisor.mcp_gateway.linking_policy import LinkingPolicyEngine
+        engine = LinkingPolicyEngine([])
+        assert engine.evaluate({"workflow_tag": "finance"}) is None
+
+    def test_empty_context_no_match(self):
+        from agent_hypervisor.hypervisor.mcp_gateway.linking_policy import LinkingPolicyEngine
+        engine = LinkingPolicyEngine([
+            {"if": {"workflow_tag": "finance"}, "then": {"profile_id": "read-only-v1"}},
+        ])
+        assert engine.evaluate({}) is None
+
+    def test_default_matches_when_no_conditions_met(self):
+        from agent_hypervisor.hypervisor.mcp_gateway.linking_policy import LinkingPolicyEngine
+        engine = LinkingPolicyEngine([
+            {"if": {"workflow_tag": "finance"}, "then": {"profile_id": "read-only-v1"}},
+            {"default": {"profile_id": "email-assistant-v1"}},
+        ])
+        assert engine.evaluate({"workflow_tag": "other"}) == "email-assistant-v1"
+
+    def test_default_matches_empty_context(self):
+        from agent_hypervisor.hypervisor.mcp_gateway.linking_policy import LinkingPolicyEngine
+        engine = LinkingPolicyEngine([
+            {"default": {"profile_id": "email-assistant-v1"}},
+        ])
+        assert engine.evaluate({}) == "email-assistant-v1"
+
+    def test_first_match_wins(self):
+        from agent_hypervisor.hypervisor.mcp_gateway.linking_policy import LinkingPolicyEngine
+        engine = LinkingPolicyEngine([
+            {"if": {"workflow_tag": "finance"}, "then": {"profile_id": "read-only-v1"}},
+            {"if": {"workflow_tag": "finance"}, "then": {"profile_id": "email-assistant-v1"}},
+        ])
+        assert engine.evaluate({"workflow_tag": "finance"}) == "read-only-v1"
+
+    def test_multiple_conditions_all_must_match(self):
+        from agent_hypervisor.hypervisor.mcp_gateway.linking_policy import LinkingPolicyEngine
+        engine = LinkingPolicyEngine([
+            {
+                "if": {"workflow_tag": "finance", "trust_level": "low"},
+                "then": {"profile_id": "read-only-v1"},
+            },
+        ])
+        # Both conditions present
+        assert engine.evaluate({"workflow_tag": "finance", "trust_level": "low"}) == "read-only-v1"
+        # Only one condition — should not match
+        assert engine.evaluate({"workflow_tag": "finance"}) is None
+        assert engine.evaluate({"trust_level": "low"}) is None
+
+    def test_extra_context_keys_allowed(self):
+        from agent_hypervisor.hypervisor.mcp_gateway.linking_policy import LinkingPolicyEngine
+        engine = LinkingPolicyEngine([
+            {"if": {"workflow_tag": "finance"}, "then": {"profile_id": "read-only-v1"}},
+        ])
+        # Extra context keys beyond what the rule tests are fine
+        assert engine.evaluate({"workflow_tag": "finance", "user_role": "admin"}) == "read-only-v1"
+
+    def test_rules_returns_copy(self):
+        from agent_hypervisor.hypervisor.mcp_gateway.linking_policy import LinkingPolicyEngine
+        rules = [{"if": {"x": "1"}, "then": {"profile_id": "p"}}]
+        engine = LinkingPolicyEngine(rules)
+        returned = engine.rules()
+        returned.append({"extra": True})
+        assert len(engine.rules()) == 1  # original unmodified
+
+    def test_from_dict_constructor(self):
+        from agent_hypervisor.hypervisor.mcp_gateway.linking_policy import LinkingPolicyEngine
+        data = {"rules": [{"default": {"profile_id": "email-assistant-v1"}}]}
+        engine = LinkingPolicyEngine.from_dict(data)
+        assert engine.evaluate({}) == "email-assistant-v1"
+
+    def test_from_dict_empty(self):
+        from agent_hypervisor.hypervisor.mcp_gateway.linking_policy import LinkingPolicyEngine
+        engine = LinkingPolicyEngine.from_dict({})
+        assert engine.evaluate({"x": "y"}) is None
+
+    def test_default_before_conditional_is_evaluated_first(self):
+        from agent_hypervisor.hypervisor.mcp_gateway.linking_policy import LinkingPolicyEngine
+        # A default that appears first should fire before any later conditional
+        engine = LinkingPolicyEngine([
+            {"default": {"profile_id": "email-assistant-v1"}},
+            {"if": {"workflow_tag": "finance"}, "then": {"profile_id": "read-only-v1"}},
+        ])
+        # Default wins because it comes first
+        assert engine.evaluate({"workflow_tag": "finance"}) == "email-assistant-v1"
+
+
+# ===========================================================================
+# SessionWorldResolver — context-driven dispatch integration tests
+# ===========================================================================
+
+class TestSessionWorldResolverLinkingPolicy:
+
+    def test_no_engine_returns_default(self, resolver, tmp_catalog_dir):
+        manifest = resolver.resolve(session_id="s1", context={"workflow_tag": "finance"})
+        assert manifest is not None
+        assert manifest.workflow_id  # uses default manifest
+
+    def test_engine_selects_profile_from_context(self, resolver, catalog):
+        from agent_hypervisor.hypervisor.mcp_gateway.linking_policy import LinkingPolicyEngine
+        engine = LinkingPolicyEngine([
+            {"if": {"workflow_tag": "readonly"}, "then": {"profile_id": "read-only-v1"}},
+        ])
+        resolver.set_linking_policy(engine, catalog)
+        manifest = resolver.resolve(session_id="s1", context={"workflow_tag": "readonly"})
+        assert manifest.workflow_id == "read-only-v1"
+
+    def test_explicit_registry_takes_precedence_over_engine(self, resolver, catalog, tmp_catalog_dir):
+        from agent_hypervisor.hypervisor.mcp_gateway.linking_policy import LinkingPolicyEngine
+        engine = LinkingPolicyEngine([
+            {"default": {"profile_id": "read-only-v1"}},
+        ])
+        resolver.set_linking_policy(engine, catalog)
+        # Explicitly register session to email manifest
+        resolver.register_session("s1", tmp_catalog_dir / "example_world.yaml")
+        manifest = resolver.resolve(session_id="s1", context={"workflow_tag": "readonly"})
+        # Should get email-assistant manifest (explicit wins)
+        assert manifest.workflow_id == "email-assistant-v1"
+
+    def test_no_context_skips_engine(self, resolver, catalog):
+        from agent_hypervisor.hypervisor.mcp_gateway.linking_policy import LinkingPolicyEngine
+        engine = LinkingPolicyEngine([
+            {"default": {"profile_id": "read-only-v1"}},
+        ])
+        resolver.set_linking_policy(engine, catalog)
+        # No context provided — engine not evaluated, default manifest used
+        manifest = resolver.resolve(session_id="s1")
+        default = resolver.manifest
+        assert manifest is default
+
+    def test_engine_unknown_profile_falls_back_to_default(self, resolver, catalog):
+        from agent_hypervisor.hypervisor.mcp_gateway.linking_policy import LinkingPolicyEngine
+        engine = LinkingPolicyEngine([
+            {"default": {"profile_id": "nonexistent-profile-xyz"}},
+        ])
+        resolver.set_linking_policy(engine, catalog)
+        # Unknown profile_id — should silently fall back to default, not raise
+        manifest = resolver.resolve(session_id="s1", context={"x": "y"})
+        assert manifest is resolver.manifest
+
+    def test_clear_linking_policy_reverts_to_default(self, resolver, catalog):
+        from agent_hypervisor.hypervisor.mcp_gateway.linking_policy import LinkingPolicyEngine
+        engine = LinkingPolicyEngine([
+            {"default": {"profile_id": "read-only-v1"}},
+        ])
+        resolver.set_linking_policy(engine, catalog)
+        resolver.clear_linking_policy()
+        # Now engine is gone; default manifest should be returned
+        manifest = resolver.resolve(session_id="s1", context={"x": "y"})
+        assert manifest is resolver.manifest
+
+    def test_linking_policy_rules_property_empty_when_no_engine(self, resolver):
+        assert resolver.linking_policy_rules == []
+
+    def test_linking_policy_rules_property_returns_rules(self, resolver, catalog):
+        from agent_hypervisor.hypervisor.mcp_gateway.linking_policy import LinkingPolicyEngine
+        rules = [{"default": {"profile_id": "read-only-v1"}}]
+        resolver.set_linking_policy(LinkingPolicyEngine(rules), catalog)
+        assert resolver.linking_policy_rules == rules
+
+
+# ===========================================================================
+# REST API tests — GET/POST /ui/api/linking-policy
+# ===========================================================================
+
+class TestLinkingPolicyAPIGet:
+
+    def test_returns_empty_list_when_no_engine(self, resolver, catalog):
+        app, _ = _make_app(resolver, catalog)
+        client = TestClient(app)
+        resp = client.get("/ui/api/linking-policy")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["rules"] == []
+        assert data["count"] == 0
+
+    def test_returns_rules_after_engine_set(self, resolver, catalog):
+        from agent_hypervisor.hypervisor.mcp_gateway.linking_policy import LinkingPolicyEngine
+        rules = [{"if": {"workflow_tag": "finance"}, "then": {"profile_id": "read-only-v1"}}]
+        resolver.set_linking_policy(LinkingPolicyEngine(rules), catalog)
+        app, _ = _make_app(resolver, catalog)
+        client = TestClient(app)
+        resp = client.get("/ui/api/linking-policy")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["count"] == 1
+        assert data["rules"][0]["then"]["profile_id"] == "read-only-v1"
+
+
+class TestLinkingPolicyAPIPost:
+
+    def test_set_rules_returns_200(self, resolver, catalog):
+        app, _ = _make_app(resolver, catalog)
+        client = TestClient(app)
+        rules = [{"if": {"workflow_tag": "finance"}, "then": {"profile_id": "read-only-v1"}}]
+        resp = client.post("/ui/api/linking-policy", json={"rules": rules})
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["status"] == "active"
+        assert data["count"] == 1
+
+    def test_rules_are_active_after_post(self, resolver, catalog):
+        app, _ = _make_app(resolver, catalog)
+        client = TestClient(app)
+        rules = [{"default": {"profile_id": "read-only-v1"}}]
+        client.post("/ui/api/linking-policy", json={"rules": rules})
+        assert resolver.linking_policy_rules == rules
+
+    def test_invalid_rules_not_a_list_returns_400(self, resolver, catalog):
+        app, _ = _make_app(resolver, catalog)
+        client = TestClient(app)
+        resp = client.post("/ui/api/linking-policy", json={"rules": "not-a-list"})
+        assert resp.status_code == 400
+
+    def test_rule_without_if_or_default_returns_400(self, resolver, catalog):
+        app, _ = _make_app(resolver, catalog)
+        client = TestClient(app)
+        resp = client.post("/ui/api/linking-policy", json={"rules": [{"bad": "rule"}]})
+        assert resp.status_code == 400
+
+    def test_unknown_profile_id_returns_400(self, resolver, catalog):
+        app, _ = _make_app(resolver, catalog)
+        client = TestClient(app)
+        rules = [{"default": {"profile_id": "nonexistent-xyz"}}]
+        resp = client.post("/ui/api/linking-policy", json={"rules": rules})
+        assert resp.status_code == 400
+        assert "nonexistent-xyz" in resp.json()["error"]
+
+    def test_no_catalog_returns_503(self, resolver):
+        app, _ = _make_app(resolver, catalog_obj=None)
+        client = TestClient(app)
+        resp = client.post("/ui/api/linking-policy", json={"rules": []})
+        assert resp.status_code == 503
+
+    def test_persists_to_file_when_path_configured(self, resolver, catalog, tmp_path):
+        import yaml
+        policy_file = tmp_path / "linking-policy.yaml"
+        app, _ = _make_app(resolver, catalog, linking_policy_path=policy_file)
+        client = TestClient(app)
+        rules = [{"default": {"profile_id": "read-only-v1"}}]
+        resp = client.post("/ui/api/linking-policy", json={"rules": rules})
+        assert resp.status_code == 200
+        assert resp.json()["persisted"] is True
+        saved = yaml.safe_load(policy_file.read_text())
+        assert saved["rules"] == rules
+
+    def test_empty_rules_clears_policy(self, resolver, catalog):
+        from agent_hypervisor.hypervisor.mcp_gateway.linking_policy import LinkingPolicyEngine
+        resolver.set_linking_policy(
+            LinkingPolicyEngine([{"default": {"profile_id": "read-only-v1"}}]),
+            catalog,
+        )
+        app, _ = _make_app(resolver, catalog)
+        client = TestClient(app)
+        resp = client.post("/ui/api/linking-policy", json={"rules": []})
+        assert resp.status_code == 200
+        assert resolver.linking_policy_rules == []
+
+
+class TestLinkingPolicyAPITest:
+
+    def test_matched_rule_returns_profile_id(self, resolver, catalog):
+        from agent_hypervisor.hypervisor.mcp_gateway.linking_policy import LinkingPolicyEngine
+        rules = [{"if": {"workflow_tag": "finance"}, "then": {"profile_id": "read-only-v1"}}]
+        resolver.set_linking_policy(LinkingPolicyEngine(rules), catalog)
+        app, _ = _make_app(resolver, catalog)
+        client = TestClient(app)
+        resp = client.post(
+            "/ui/api/linking-policy/test",
+            json={"context": {"workflow_tag": "finance"}},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["matched"] is True
+        assert data["profile_id"] == "read-only-v1"
+
+    def test_no_match_returns_null_profile(self, resolver, catalog):
+        from agent_hypervisor.hypervisor.mcp_gateway.linking_policy import LinkingPolicyEngine
+        rules = [{"if": {"workflow_tag": "finance"}, "then": {"profile_id": "read-only-v1"}}]
+        resolver.set_linking_policy(LinkingPolicyEngine(rules), catalog)
+        app, _ = _make_app(resolver, catalog)
+        client = TestClient(app)
+        resp = client.post(
+            "/ui/api/linking-policy/test",
+            json={"context": {"workflow_tag": "email"}},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["matched"] is False
+        assert data["profile_id"] is None
+
+    def test_no_engine_configured_returns_no_match(self, resolver, catalog):
+        app, _ = _make_app(resolver, catalog)
+        client = TestClient(app)
+        resp = client.post(
+            "/ui/api/linking-policy/test",
+            json={"context": {"workflow_tag": "finance"}},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["matched"] is False
+        assert data["profile_id"] is None
+
+    def test_invalid_context_returns_400(self, resolver, catalog):
+        app, _ = _make_app(resolver, catalog)
+        client = TestClient(app)
+        resp = client.post("/ui/api/linking-policy/test", json={"context": "not-a-dict"})
+        assert resp.status_code == 400
+
+
+# ===========================================================================
+# Startup: pre-load linking policy from disk
+# ===========================================================================
+
+class TestLinkingPolicyStartupLoad:
+
+    def test_startup_loads_policy_from_file(self, resolver, catalog, tmp_path):
+        """When linking_policy_path is provided and exists, engine is pre-loaded."""
+        import yaml
+        policy_file = tmp_path / "linking-policy.yaml"
+        rules = [{"default": {"profile_id": "read-only-v1"}}]
+        policy_file.write_text(
+            yaml.dump({"rules": rules}, default_flow_style=False),
+            encoding="utf-8",
+        )
+        # Build app — startup hook should load the engine
+        app, gw_state = _make_app(resolver, catalog, linking_policy_path=policy_file)
+        # The resolver (which is the real one) should now have the engine loaded
+        assert resolver.linking_policy_rules == rules
+
+    def test_startup_missing_file_does_not_crash(self, resolver, catalog, tmp_path):
+        """If the linking policy file doesn't exist, startup continues without engine."""
+        policy_file = tmp_path / "nonexistent.yaml"
+        app, _ = _make_app(resolver, catalog, linking_policy_path=policy_file)
+        assert resolver.linking_policy_rules == []


### PR DESCRIPTION
Implements T6 Phase 3 from TRANSPARENT_UI.md: wires the previously-unused
context dict in SessionWorldResolver.resolve() to a declarative rule evaluator
(LinkingPolicyEngine) so profile selection is driven by workflow attributes,
user role, or trust level rather than manual register_session() calls.

Changes:
- src/agent_hypervisor/hypervisor/mcp_gateway/linking_policy.py (new)
  LinkingPolicyEngine: pure function, top-to-bottom rule evaluation,
  all-conditions-must-match semantics, default catch-all support.

- manifests/linking-policy.yaml (new)
  Starter policy with finance/email rules and a default fallback.

- session_world_resolver.py
  set_linking_policy(engine, catalog) / clear_linking_policy() methods.
  resolve() now follows: explicit registry → engine(context) → default.
  Misconfigured profile_id in engine silently falls back (fail safe).

- ui/router.py
  GET  /ui/api/linking-policy       — return active rules
  POST /ui/api/linking-policy       — replace rules + hot-reload + persist
  POST /ui/api/linking-policy/test  — evaluate a context dict
  linking_policy_path param: pre-loads engine from disk at startup.

- ui/static/index.html + app.js
  New "Linking" tab: rule table with reorder/delete, add-rule form,
  test input form ("which profile would be selected for this context?").

- tests/hypervisor/test_linking_policy.py (new)
  37 tests: engine unit tests, resolver integration, API endpoints,
  startup pre-load. All passing.

https://claude.ai/code/session_016AY55qGsNkVtokH4XniskE