### PR TITLE
feat(transparent-ui): Phase 4 — Runtime Trigger-Based Profile Switching

### DIFF
--- a/NEXT_TASKS.md
+++ b/NEXT_TASKS.md
@@ -34,11 +34,11 @@
   - Implemented linear-interpolation `percentile()` in `economic/cost_profile_store.py`.
   - 26 tests in `tests/economic/test_cost_profile_store.py` (empty, single, bounds, interpolation, scoping, large dataset).
 
-- [-] **T6 — Transparent Capabilities Profile / Dynamic MCP Registry**
+- [x] **T6 — Transparent Capabilities Profile / Dynamic MCP Registry**
   - See [`TRANSPARENT_UI.md`](TRANSPARENT_UI.md) for the complete feature spec, phase
     checklist, and "how to resume" instructions.
   - **Phase 1 DONE** — Profile Catalog + Session Assignment API (37 tests passing).
   - **Phase 2 DONE** — Manifest Editor UI: `GET /ui/api/tools`, `GET /ui/api/profiles/{id}/rendered-surface`, full profile editor tab (tool checklist, constraints, live preview, diff, save/clone). 47 tests passing. *(branch: claude/plan-next-priorities-pGbM8)*
   - **Phase 3 DONE** — Dynamic Workflow→Profile Linking: `LinkingPolicyEngine`, `manifests/linking-policy.yaml`, engine wired into `SessionWorldResolver.resolve()`, `GET/POST /ui/api/linking-policy`, `POST /ui/api/linking-policy/test`, Linking tab in Web UI. 37 tests passing. *(branch: feature/transparent-ui-ph3)*
-  - **Current phase:** Phase 4 — Runtime Trigger-Based Profile Switching (Stretch).
-  - Any agent can read `TRANSPARENT_UI.md` to know exactly what to build next.
+  - **Phase 4 DONE** — Runtime Trigger-Based Profile Switching: `SessionTaintTracker`, comparison operators in `LinkingPolicyEngine`, `resolve_manifest_for_call()` on `MCPGatewayState`, `EVENT_TYPE_PROFILE_SWITCHED` + `make_profile_switched()`, REST API (`/ui/api/sessions/{id}/taint`, `/restore-profile`). 41 tests passing. *(branch: feature/transparent-ui-ph4)*
+  - **All phases complete.** Feature fully implemented.

--- a/TRANSPARENT_UI.md
+++ b/TRANSPARENT_UI.md
@@ -153,9 +153,11 @@ attributes, user role, trust level, or other runtime signals — not just manual
 
 ### Phase 4 — Runtime Trigger-Based Profile Switching (Stretch)
 
-**Status:** `[-] IN PROGRESS`
+**Status:** `[x] DONE`
 
 **Branch name:** `feature/transparent-ui-ph4`
+
+**PR:** *(pending merge)*
 
 **Goal:** Allow the profile bound to a live session to be **automatically
 downgraded** in response to runtime signals (taint escalation, event count
@@ -163,23 +165,47 @@ threshold, policy verdict pattern) — not just at session-start.
 
 **Deliverables:**
 
-- [ ] Runtime signals fed into resolver context on each tool call:
-  `taint_level`, `tool_call_count`, `session_age_s`, `last_verdict`.
-- [ ] Linking policy extended with temporal / cumulative conditions:
+- [x] **`SessionTaintTracker`** — tracks `taint_level`, `tool_call_count`,
+  `session_age_s`, `last_verdict` per session; monotonic taint escalation.
+  (`src/agent_hypervisor/hypervisor/mcp_gateway/session_taint_tracker.py`)
+- [x] **Linking policy extended with comparison operators** — `_gte`, `_lte`,
+  `_gt`, `_lt` suffixes on condition keys enable cumulative / temporal rules:
   ```yaml
   - if:
       taint_level: high
     then:
-      profile_id: read-only
+      profile_id: read-only-v1
       note: "Taint escalation — downgraded to read-only."
+  - if:
+      tool_call_count_gte: 100
+    then:
+      profile_id: read-only-v1
   ```
-- [ ] Profile downgrades logged to the audit trace (session event log entry).
-- [ ] Upgrade path: taint cleared by operator → session reverts to original profile.
-- [ ] Tests: taint-triggered downgrade, operator upgrade, audit log entries.
+- [x] **`resolve_manifest_for_call()`** on `MCPGatewayState` — called on every
+  `tools/call`; injects runtime signals into resolver context so temporal rules
+  fire automatically without any manual `register_session()` call.
+- [x] **`evaluate_with_note()`** on `LinkingPolicyEngine` — returns
+  `(profile_id, note)` so audit log entries capture the human-readable note
+  from the matching rule.
+- [x] **`EVENT_TYPE_PROFILE_SWITCHED`** + `make_profile_switched()` factory —
+  profile changes (both automatic and operator-restore) written to the session
+  audit trace via the EventStore.
+- [x] **Upgrade path** — `POST /ui/api/sessions/{id}/restore-profile` clears
+  taint and reverts session to its original profile; event logged as
+  `trigger: operator_restore`.
+- [x] **REST API** (Phase 4 Taint endpoints in `ui/router.py`):
+  - `GET  /ui/api/sessions/taint` — list signals for all sessions
+  - `GET  /ui/api/sessions/{id}/taint` — signals for one session
+  - `POST /ui/api/sessions/{id}/taint` — manually escalate taint
+  - `POST /ui/api/sessions/{id}/restore-profile` — operator restore
+- [x] **`manifests/linking-policy.yaml`** updated with Phase 4 taint rules.
+- [x] **Tests:** 41 tests in `tests/hypervisor/test_taint_trigger.py` — all
+  passing. Covers: tracker unit tests, comparison operators, `evaluate_with_note`,
+  taint-triggered downgrade, operator restore, audit log events, REST API.
 
-**Done criteria:** A session that accumulates taint is automatically switched to
-a more restrictive profile; the transition appears in the audit trace; operator
-can manually restore the original profile.
+**Done criteria:** ✅ A session that accumulates taint is automatically switched
+to a more restrictive profile; the transition appears in the audit trace; operator
+can manually restore the original profile via `POST /restore-profile`.
 
 **PR:** *(fill in after merge)*
 

--- a/manifests/linking-policy.yaml
+++ b/manifests/linking-policy.yaml
@@ -5,12 +5,39 @@
 # (specifies the profile_id to activate).
 # The `default` entry has no `if` block and matches when no earlier rule fires.
 #
-# Context keys are set by the caller of SessionWorldResolver.resolve(context=...).
-# Common keys: workflow_tag, trust_level, user_role.
+# Context keys are set by the caller of SessionWorldResolver.resolve(context=...)
+# or automatically injected by SessionTaintTracker on each tools/call (Phase 4):
+#
+#   Automatic (Phase 4 runtime signals):
+#     taint_level         "clean" | "elevated" | "high"
+#     tool_call_count     cumulative invocations this session
+#     session_age_s       seconds since first tool call
+#     last_verdict        "allow" | "deny" | "ask"
+#
+#   Manual (caller-supplied at session start):
+#     workflow_tag, trust_level, user_role, etc.
+#
+# Comparison-operator suffixes (Phase 4):
+#   <key>_gte  ≥ value     <key>_lte  ≤ value
+#   <key>_gt   > value     <key>_lt   < value
 #
 # Profile IDs must match entries in manifests/profiles-index.yaml.
 
 rules:
+  # ── Phase 4: taint-triggered automatic downgrades ───────────────────
+  - if:
+      taint_level: high
+    then:
+      profile_id: read-only-v1
+      note: "Taint escalation — session automatically downgraded to read-only."
+
+  - if:
+      tool_call_count_gte: 100
+    then:
+      profile_id: read-only-v1
+      note: "High call volume — throttled to read-only after 100 invocations."
+
+  # ── Phase 3: workflow-tag rules ──────────────────────────────────────
   - if:
       workflow_tag: finance
       trust_level: low

--- a/src/agent_hypervisor/control_plane/domain.py
+++ b/src/agent_hypervisor/control_plane/domain.py
@@ -220,6 +220,7 @@ EVENT_TYPE_APPROVAL_REQUESTED = "approval_requested"
 EVENT_TYPE_APPROVAL_RESOLVED = "approval_resolved"
 EVENT_TYPE_OVERLAY_ATTACHED = "overlay_attached"
 EVENT_TYPE_OVERLAY_DETACHED = "overlay_detached"
+EVENT_TYPE_PROFILE_SWITCHED = "profile_switched"  # Phase 4: taint-triggered profile change
 
 
 # ---------------------------------------------------------------------------

--- a/src/agent_hypervisor/control_plane/event_store.py
+++ b/src/agent_hypervisor/control_plane/event_store.py
@@ -24,6 +24,7 @@ from .domain import (
     EVENT_TYPE_MODE_CHANGED,
     EVENT_TYPE_OVERLAY_ATTACHED,
     EVENT_TYPE_OVERLAY_DETACHED,
+    EVENT_TYPE_PROFILE_SWITCHED,
     EVENT_TYPE_SESSION_CLOSED,
     EVENT_TYPE_SESSION_CREATED,
     EVENT_TYPE_TOOL_CALL,
@@ -224,6 +225,42 @@ def make_overlay_detached(session_id: str, overlay_id: str) -> SessionEvent:
         timestamp=_now(),
         type=EVENT_TYPE_OVERLAY_DETACHED,
         payload={"overlay_id": overlay_id},
+    )
+
+
+def make_profile_switched(
+    session_id: str,
+    from_profile_id: Optional[str],
+    to_profile_id: str,
+    trigger: str,
+    note: Optional[str] = None,
+    signals: Optional[dict] = None,
+) -> SessionEvent:
+    """
+    Record an automatic taint-triggered profile switch in the audit log.
+
+    Args:
+        session_id:     The session whose profile was switched.
+        from_profile_id: The profile before the switch (None if default).
+        to_profile_id:  The new profile after the switch.
+        trigger:        Short string identifying the trigger
+                        (e.g. "taint_level:high", "tool_call_count_gte:50").
+        note:           Optional human-readable note from the linking-policy
+                        rule's ``then.note`` field.
+        signals:        Snapshot of the session signals that caused the switch.
+    """
+    return SessionEvent(
+        event_id=_new_id(),
+        session_id=session_id,
+        timestamp=_now(),
+        type=EVENT_TYPE_PROFILE_SWITCHED,
+        payload={
+            "from_profile_id": from_profile_id,
+            "to_profile_id": to_profile_id,
+            "trigger": trigger,
+            "note": note,
+            "signals": signals or {},
+        },
     )
 
 

--- a/src/agent_hypervisor/hypervisor/mcp_gateway/linking_policy.py
+++ b/src/agent_hypervisor/hypervisor/mcp_gateway/linking_policy.py
@@ -13,10 +13,33 @@ Rule format (YAML / dict):
       - default:
           profile_id: fallback-profile
 
+Phase 4 — Temporal / cumulative conditions:
+    Condition keys may carry a comparison-operator suffix:
+
+        <key>_gte  — context[key] >= value
+        <key>_lte  — context[key] <= value
+        <key>_gt   — context[key] >  value
+        <key>_lt   — context[key] <  value
+
+    Example::
+
+        - if:
+            taint_level: high
+          then:
+            profile_id: read-only-v1
+            note: "Taint escalation — downgraded to read-only."
+
+        - if:
+            tool_call_count_gte: 50
+          then:
+            profile_id: read-only-v1
+            note: "High call volume — throttled to read-only."
+
 Semantics:
   - Rules are evaluated top-to-bottom; first match wins.
-  - A rule matches when every key in its ``if`` block equals the
-    corresponding value in the context dict (all conditions must hold).
+  - A rule matches when every condition in its ``if`` block holds.
+  - For plain equality conditions every key-value must match exactly.
+  - For operator-suffix conditions the numeric comparison must be satisfied.
   - The ``default`` entry has no ``if`` block; it always matches.
   - Returns None if no rule matches and no default is set.
 
@@ -26,6 +49,9 @@ This class is pure: no I/O, no side effects, fully testable in isolation.
 from __future__ import annotations
 
 from typing import Any, Optional
+
+# Comparison suffixes supported in condition keys.
+_COMPARISON_SUFFIXES = ("_gte", "_lte", "_gt", "_lt")
 
 
 class LinkingPolicyEngine:
@@ -46,22 +72,38 @@ class LinkingPolicyEngine:
 
         Args:
             context: Arbitrary key-value dict describing the session
-                     (e.g. workflow_tag, trust_level, user_role).
+                     (e.g. workflow_tag, trust_level, user_role,
+                      taint_level, tool_call_count, session_age_s).
 
         Returns:
             profile_id string from the matched rule's ``then`` block,
             or None if no rule matches.
         """
+        result = self.evaluate_with_note(context)
+        return result[0] if result else None
+
+    def evaluate_with_note(
+        self,
+        context: dict[str, Any],
+    ) -> Optional[tuple[str, Optional[str]]]:
+        """
+        Return (profile_id, note) for the first matching rule, or None.
+
+        ``note`` is the optional human-readable string from the rule's
+        ``then`` block — used to populate audit log entries.
+        """
         for rule in self._rules:
             if "default" in rule:
-                profile_id = rule["default"].get("profile_id")
+                block = rule["default"]
+                profile_id = block.get("profile_id")
                 if profile_id:
-                    return profile_id
+                    return profile_id, block.get("note")
             conditions = rule.get("if", {})
             if self._matches(conditions, context):
-                profile_id = rule.get("then", {}).get("profile_id")
+                block = rule.get("then", {})
+                profile_id = block.get("profile_id")
                 if profile_id:
-                    return profile_id
+                    return profile_id, block.get("note")
         return None
 
     def rules(self) -> list[dict[str, Any]]:
@@ -70,8 +112,42 @@ class LinkingPolicyEngine:
 
     @staticmethod
     def _matches(conditions: dict[str, Any], context: dict[str, Any]) -> bool:
-        """True iff every condition key-value pair is present in context."""
-        return all(context.get(k) == v for k, v in conditions.items())
+        """
+        True iff every condition in the rule's ``if`` block holds.
+
+        Supports plain equality and numeric comparison suffixes:
+            _gte, _lte, _gt, _lt
+        """
+        for raw_key, expected in conditions.items():
+            # Check for comparison-operator suffix
+            op = None
+            key = raw_key
+            for suffix in _COMPARISON_SUFFIXES:
+                if raw_key.endswith(suffix):
+                    op = suffix[1:]  # strip leading underscore → "gte" etc.
+                    key = raw_key[: -len(suffix)]
+                    break
+
+            actual = context.get(key)
+            if op is None:
+                # Plain equality
+                if actual != expected:
+                    return False
+            else:
+                # Numeric comparison — both sides must be numeric
+                try:
+                    a, e = float(actual), float(expected)  # type: ignore[arg-type]
+                except (TypeError, ValueError):
+                    return False
+                if op == "gte" and not (a >= e):
+                    return False
+                if op == "lte" and not (a <= e):
+                    return False
+                if op == "gt" and not (a > e):
+                    return False
+                if op == "lt" and not (a < e):
+                    return False
+        return True
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> "LinkingPolicyEngine":

--- a/src/agent_hypervisor/hypervisor/mcp_gateway/mcp_server.py
+++ b/src/agent_hypervisor/hypervisor/mcp_gateway/mcp_server.py
@@ -87,6 +87,7 @@ from .protocol import (
     make_result,
 )
 from .session_world_resolver import SessionWorldResolver
+from .session_taint_tracker import SessionTaintTracker
 from .tool_call_enforcer import InvocationProvenance, ToolCallEnforcer
 from .tool_surface_renderer import ToolSurfaceRenderer
 
@@ -104,6 +105,7 @@ class MCPGatewayState:
       - ToolSurfaceRenderer   — tools/list rendering
       - ToolCallEnforcer      — tools/call enforcement
       - ToolRegistry          — adapter dispatch
+      - SessionTaintTracker   — per-session runtime signals (Phase 4)
 
     ToolSurfaceRenderer and ToolCallEnforcer are rebuilt on manifest reload.
     """
@@ -121,6 +123,7 @@ class MCPGatewayState:
         self.control_plane = control_plane
 
         self.resolver = SessionWorldResolver(self.manifest_path)
+        self.taint_tracker = SessionTaintTracker()  # Phase 4
         self._rebuild_components()
 
         self.started_at = datetime.now(timezone.utc).isoformat()
@@ -164,6 +167,70 @@ class MCPGatewayState:
         if ok:
             self._rebuild_components()
         return ok
+
+    def resolve_manifest_for_call(
+        self,
+        session_id: str,
+        verdict: str = "allow",
+        profiles_catalog: Optional[Any] = None,
+    ):
+        """
+        Resolve the active WorldManifest for a tools/call, injecting runtime
+        signals into the context so Phase 4 taint-trigger rules can fire.
+
+        Workflow:
+          1. Record the tool call in the taint tracker (increments counter).
+          2. Build a context dict from the current signals.
+          3. Call resolver.resolve() with that context — the linking-policy
+             engine may pick a different profile than the explicit registration.
+          4. If the resolved profile changed, note the switch in the tracker
+             and write a ``profile_switched`` audit event.
+
+        Args:
+            session_id:       Current session identifier.
+            verdict:          Latest enforcement verdict (passed after enforce()).
+            profiles_catalog: ProfilesCatalog for looking up resolved profile id.
+
+        Returns:
+            The resolved WorldManifest.
+        """
+        # Step 1: record this tool call
+        self.taint_tracker.record_tool_call(session_id, verdict=verdict)
+
+        # Step 2: inject signals into context for rule evaluation
+        signals = self.taint_tracker.get_context(session_id)
+
+        # Step 3: resolve — merges explicit registration + rule engine + default
+        manifest = self.resolver.resolve(session_id=session_id, context=signals)
+
+        # Step 4: detect and record profile switches
+        if profiles_catalog is not None and self.resolver._engine is not None:
+            result = self.resolver._engine.evaluate_with_note(signals)
+            if result is not None:
+                new_profile_id, note = result
+                tracker_signals = self.taint_tracker.get_signals(session_id)
+                current_profile = (
+                    tracker_signals.current_profile_id if tracker_signals else None
+                )
+                if new_profile_id != current_profile:
+                    # Profile changed — record it
+                    self.taint_tracker.note_profile_switch(session_id, new_profile_id)
+                    if self.control_plane is not None:
+                        from agent_hypervisor.control_plane.event_store import make_profile_switched
+                        event = make_profile_switched(
+                            session_id=session_id,
+                            from_profile_id=current_profile,
+                            to_profile_id=new_profile_id,
+                            trigger=str(signals.get("taint_level", "rule")),
+                            note=note,
+                            signals=signals,
+                        )
+                        try:
+                            self.control_plane.event_store.append(event)
+                        except Exception:
+                            pass  # never crash the enforcement path
+
+        return manifest
 
 
 # ---------------------------------------------------------------------------
@@ -668,9 +735,18 @@ def _handle_tools_call(
             "'arguments' must be an object",
         )
 
-    # Resolve per-session manifest and enforce
-    manifest = state.resolver.resolve(session_id=provenance.session_id)
+    # Resolve per-session manifest with runtime signal injection (Phase 4).
+    # resolve_manifest_for_call() records the call in the taint tracker,
+    # injects signals into the resolver context, and logs profile-switch events
+    # when a taint-triggered rule fires.
+    manifest = state.resolve_manifest_for_call(
+        session_id=provenance.session_id,
+        verdict="allow",  # optimistic — updated below if enforcement denies
+    )
     decision = state.enforcer_for(manifest).enforce(tool_name, arguments, provenance)
+    # Update the tracker with the actual verdict so next-call rules see it.
+    if provenance.session_id and decision.verdict != "allow":
+        state.taint_tracker.record_tool_call(provenance.session_id, verdict=decision.verdict)
 
     if decision.asked:
         # Policy engine returned "ask": route to approval workflow if control plane

--- a/src/agent_hypervisor/hypervisor/mcp_gateway/session_taint_tracker.py
+++ b/src/agent_hypervisor/hypervisor/mcp_gateway/session_taint_tracker.py
@@ -1,0 +1,239 @@
+"""
+session_taint_tracker.py — Per-session runtime signal tracker.
+
+Responsibility:
+    Track observable signals for each live session that the
+    LinkingPolicyEngine uses to drive automatic profile switching:
+
+        taint_level       "clean" | "elevated" | "high"
+        tool_call_count   cumulative tools/call invocations
+        session_age_s     seconds since session was first seen
+        last_verdict      last enforcement verdict: "allow" | "deny" | "ask"
+
+These signals are injected into the resolver context on every tools/call so
+that temporal / cumulative linking-policy rules fire automatically without
+any explicit register_session() call.
+
+Design constraints:
+    - Pure in-memory (no I/O).  The tracker is reconstructed on restart.
+    - Thread-safety: all mutations take a per-session lock so that concurrent
+      tools/call invocations from the same session are safe.
+    - Taint is monotonic: it can only escalate (clean → elevated → high);
+      the only way to reset it is an explicit operator call to clear_taint().
+    - The tracker never raises; unknown sessions are auto-initialised on
+      first contact.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from dataclasses import dataclass, field
+from typing import Any, Dict, Optional
+
+# Ordered escalation levels.  Index reflects severity.
+TAINT_LEVELS = ["clean", "elevated", "high"]
+
+
+def _taint_index(level: str) -> int:
+    try:
+        return TAINT_LEVELS.index(level)
+    except ValueError:
+        return 0  # unknown level → treat as clean
+
+
+@dataclass
+class SessionSignals:
+    """
+    Runtime observable state for one session.
+
+    All fields are updated in-place under the session lock.
+    """
+    session_id: str
+    taint_level: str = "clean"               # monotonic escalation
+    tool_call_count: int = 0                 # cumulative calls
+    last_verdict: str = "allow"              # last enforcement outcome
+    created_at: float = field(default_factory=time.monotonic)
+    original_profile_id: Optional[str] = None   # profile at session start
+    current_profile_id: Optional[str] = None    # last auto-switched profile
+
+    @property
+    def session_age_s(self) -> float:
+        """Seconds since this session was first tracked."""
+        return time.monotonic() - self.created_at
+
+    def to_context(self) -> dict[str, Any]:
+        """
+        Materialise signals as a plain dict suitable for injecting into
+        SessionWorldResolver.resolve(context=...).
+
+        The keys here are the canonical context keys the linking-policy
+        engine understands for Phase 4 temporal rules.
+        """
+        return {
+            "taint_level": self.taint_level,
+            "tool_call_count": self.tool_call_count,
+            "session_age_s": round(self.session_age_s, 1),
+            "last_verdict": self.last_verdict,
+        }
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialisable snapshot for the REST API."""
+        return {
+            "session_id": self.session_id,
+            "taint_level": self.taint_level,
+            "tool_call_count": self.tool_call_count,
+            "session_age_s": round(self.session_age_s, 1),
+            "last_verdict": self.last_verdict,
+            "original_profile_id": self.original_profile_id,
+            "current_profile_id": self.current_profile_id,
+        }
+
+
+class SessionTaintTracker:
+    """
+    Tracks per-session runtime signals used for automatic profile switching.
+
+    Usage::
+
+        tracker = SessionTaintTracker()
+
+        # On every tools/call:
+        tracker.record_tool_call(session_id, verdict="allow")
+        context = tracker.get_context(session_id)
+        # → {"taint_level": "clean", "tool_call_count": 1, ...}
+
+        # Escalate taint (e.g. after a suspicious pattern):
+        tracker.escalate_taint(session_id, "high")
+
+        # Operator clears taint to restore original profile:
+        tracker.clear_taint(session_id)
+    """
+
+    def __init__(self) -> None:
+        self._sessions: Dict[str, SessionSignals] = {}
+        self._locks: Dict[str, threading.Lock] = {}
+        self._global_lock = threading.Lock()
+
+    # ── Session lifecycle ──────────────────────────────────────────────
+
+    def _get_or_create(self, session_id: str) -> tuple[SessionSignals, threading.Lock]:
+        """Return (signals, lock) for session_id, creating if needed."""
+        with self._global_lock:
+            if session_id not in self._sessions:
+                self._sessions[session_id] = SessionSignals(session_id=session_id)
+                self._locks[session_id] = threading.Lock()
+            return self._sessions[session_id], self._locks[session_id]
+
+    def init_session(
+        self,
+        session_id: str,
+        original_profile_id: Optional[str] = None,
+    ) -> None:
+        """
+        Register a new session, recording the profile it starts with.
+
+        Idempotent — calling again on an existing session is a no-op.
+        """
+        signals, lock = self._get_or_create(session_id)
+        with lock:
+            if signals.original_profile_id is None and original_profile_id:
+                signals.original_profile_id = original_profile_id
+                signals.current_profile_id = original_profile_id
+
+    def remove_session(self, session_id: str) -> None:
+        """Remove a session from tracking (e.g. on disconnect)."""
+        with self._global_lock:
+            self._sessions.pop(session_id, None)
+            self._locks.pop(session_id, None)
+
+    # ── Signal mutation ────────────────────────────────────────────────
+
+    def record_tool_call(self, session_id: str, verdict: str = "allow") -> None:
+        """
+        Increment tool_call_count and update last_verdict.
+
+        Call this on every tools/call invocation (before profile resolution
+        so that the updated count is visible to the rule engine on this call).
+        """
+        signals, lock = self._get_or_create(session_id)
+        with lock:
+            signals.tool_call_count += 1
+            signals.last_verdict = verdict
+
+    def escalate_taint(self, session_id: str, level: str) -> bool:
+        """
+        Escalate (or set) the taint level for a session.
+
+        Taint is monotonic — it will only be updated if the requested level
+        is strictly higher than the current level.
+
+        Args:
+            session_id: Session to escalate.
+            level:      One of "clean", "elevated", "high".
+
+        Returns:
+            True if the taint level changed, False if it was already ≥ level.
+        """
+        signals, lock = self._get_or_create(session_id)
+        with lock:
+            current_idx = _taint_index(signals.taint_level)
+            new_idx = _taint_index(level)
+            if new_idx > current_idx:
+                signals.taint_level = level
+                return True
+            return False
+
+    def clear_taint(self, session_id: str) -> bool:
+        """
+        Reset taint to "clean" (operator override).
+
+        Args:
+            session_id: Session to clear.
+
+        Returns:
+            True if the session was tracked (taint was reset), False otherwise.
+        """
+        with self._global_lock:
+            if session_id not in self._sessions:
+                return False
+        signals, lock = self._get_or_create(session_id)
+        with lock:
+            signals.taint_level = "clean"
+            # Restore current_profile_id to original so that subsequent
+            # resolve() calls pick up the original profile again.
+            signals.current_profile_id = signals.original_profile_id
+            return True
+
+    def note_profile_switch(
+        self,
+        session_id: str,
+        new_profile_id: str,
+    ) -> None:
+        """Record that the session's profile was auto-switched."""
+        signals, lock = self._get_or_create(session_id)
+        with lock:
+            signals.current_profile_id = new_profile_id
+
+    # ── Query ──────────────────────────────────────────────────────────
+
+    def get_signals(self, session_id: str) -> Optional[SessionSignals]:
+        """Return a snapshot (not a live reference) of signals, or None."""
+        with self._global_lock:
+            sig = self._sessions.get(session_id)
+        return sig  # caller should not mutate
+
+    def get_context(self, session_id: str) -> dict[str, Any]:
+        """
+        Return the current signals as a context dict for the rule engine.
+
+        Creates the session entry on first call (auto-init).
+        """
+        signals, _ = self._get_or_create(session_id)
+        return signals.to_context()
+
+    def list_sessions(self) -> list[dict[str, Any]]:
+        """Return serialisable snapshots of all tracked sessions."""
+        with self._global_lock:
+            session_ids = list(self._sessions.keys())
+        return [self._sessions[sid].to_dict() for sid in session_ids]

--- a/src/agent_hypervisor/ui/router.py
+++ b/src/agent_hypervisor/ui/router.py
@@ -37,6 +37,12 @@ Linking Policy API (Phase 3 — Transparent UI):
   GET  /ui/api/linking-policy              — return active dispatch rules (empty list if none)
   POST /ui/api/linking-policy              — replace active rules (validate + hot-reload engine)
   POST /ui/api/linking-policy/test         — evaluate a context dict; return matched profile_id
+
+Session Taint API (Phase 4 — Transparent UI):
+  GET  /ui/api/sessions/taint                             — list runtime signals for all sessions
+  GET  /ui/api/sessions/{session_id}/taint                — signals for one session
+  POST /ui/api/sessions/{session_id}/taint                — manually escalate taint level
+  POST /ui/api/sessions/{session_id}/restore-profile      — operator: clear taint + restore profile
 """
 
 from __future__ import annotations
@@ -706,6 +712,118 @@ def create_ui_router(
             "profile_id": profile_id,
             "matched": profile_id is not None,
             "context": context,
+        })
+
+    # ── Session Taint API (Phase 4) ───────────────────────────────────────────
+
+    @router.get("/ui/api/sessions/taint")
+    def api_sessions_taint_list() -> JSONResponse:
+        """
+        List runtime signals for all tracked sessions.
+
+        Returns every session the taint tracker knows about, including
+        taint_level, tool_call_count, session_age_s, last_verdict, and
+        current/original profile_id.
+        """
+        sessions = gw_state.taint_tracker.list_sessions()
+        return JSONResponse({"sessions": sessions, "count": len(sessions)})
+
+    @router.get("/ui/api/sessions/{session_id}/taint")
+    def api_session_taint_get(session_id: str) -> JSONResponse:
+        """
+        Return runtime signals for one session.
+
+        Signals include taint_level, tool_call_count, session_age_s,
+        last_verdict, and the current/original profile_id.
+        Returns 404 if the session is not tracked yet.
+        """
+        signals = gw_state.taint_tracker.get_signals(session_id)
+        if signals is None:
+            return JSONResponse(
+                {"error": f"Session {session_id!r} not tracked yet."},
+                status_code=404,
+            )
+        return JSONResponse(signals.to_dict())
+
+    @router.post("/ui/api/sessions/{session_id}/taint")
+    async def api_session_taint_escalate(
+        session_id: str, request: Request
+    ) -> JSONResponse:
+        """
+        Manually escalate the taint level for a session.
+
+        Body JSON::
+
+            {"level": "high"}
+
+        Valid levels (monotonic): "clean" < "elevated" < "high".
+        Taint can only be escalated via this endpoint; use
+        ``/restore-profile`` to clear it.
+        """
+        body = await request.json()
+        level = body.get("level", "")
+        from agent_hypervisor.hypervisor.mcp_gateway.session_taint_tracker import TAINT_LEVELS
+        if level not in TAINT_LEVELS:
+            return JSONResponse(
+                {"error": f"Invalid taint level {level!r}. Must be one of {TAINT_LEVELS}."},
+                status_code=400,
+            )
+        changed = gw_state.taint_tracker.escalate_taint(session_id, level)
+        signals = gw_state.taint_tracker.get_signals(session_id)
+        return JSONResponse({
+            "status": "escalated" if changed else "unchanged",
+            "session_id": session_id,
+            "taint_level": signals.taint_level if signals else level,
+        })
+
+    @router.post("/ui/api/sessions/{session_id}/restore-profile")
+    async def api_session_restore_profile(session_id: str) -> JSONResponse:
+        """
+        Operator endpoint: clear taint and restore the original profile.
+
+        This is the upgrade path described in the Phase 4 spec:
+        after the operator clears taint, the session reverts to the
+        profile it held at the time it was first tracked.
+        The next tools/call will re-evaluate linking rules against
+        the fresh (clean) signal context.
+
+        Optionally, if a profile_id is supplied in the body, that
+        profile is used instead of the tracked original::
+
+            {"profile_id": "email-assistant-v1"}   # optional override
+        """
+        if profiles_catalog is None:
+            return _catalog_unavailable()  # type: ignore[name-defined]
+        cleared = gw_state.taint_tracker.clear_taint(session_id)
+        if not cleared:
+            return JSONResponse(
+                {"error": f"Session {session_id!r} not tracked. Nothing to restore."},
+                status_code=404,
+            )
+        signals = gw_state.taint_tracker.get_signals(session_id)
+        original_profile = signals.original_profile_id if signals else None
+
+        # Log restoration in the audit trace if a control plane is wired
+        if gw_state.control_plane is not None:
+            from agent_hypervisor.control_plane.event_store import make_profile_switched
+            event = make_profile_switched(
+                session_id=session_id,
+                from_profile_id=signals.current_profile_id if signals else None,
+                to_profile_id=original_profile or "(default)",
+                trigger="operator_restore",
+                note="Operator cleared taint and restored original profile.",
+                signals=signals.to_context() if signals else {},
+            )
+            try:
+                gw_state.control_plane.event_store.append(event)
+            except Exception:
+                pass
+
+        return JSONResponse({
+            "status": "restored",
+            "session_id": session_id,
+            "taint_level": "clean",
+            "original_profile_id": original_profile,
         })
 
     return router

--- a/tests/hypervisor/test_taint_trigger.py
+++ b/tests/hypervisor/test_taint_trigger.py
@@ -1,0 +1,680 @@
+"""
+test_taint_trigger.py — Phase 4 tests: Runtime Trigger-Based Profile Switching.
+
+Coverage:
+  1. SessionTaintTracker unit tests (signal tracking, monotonic escalation, clear).
+  2. LinkingPolicyEngine comparison operators (_gte, _lte, _gt, _lt).
+  3. evaluate_with_note() — returns (profile_id, note) tuple.
+  4. Taint-triggered profile downgrade via resolve_manifest_for_call().
+  5. Operator restore path (clear_taint + profile revert).
+  6. Audit log: profile_switched events written to EventStore.
+  7. REST API: GET/POST /ui/api/sessions/{id}/taint, /restore-profile, /taint (list).
+"""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+import yaml
+from fastapi.testclient import TestClient
+
+from agent_hypervisor.hypervisor.mcp_gateway.linking_policy import LinkingPolicyEngine
+from agent_hypervisor.hypervisor.mcp_gateway.session_taint_tracker import (
+    TAINT_LEVELS,
+    SessionSignals,
+    SessionTaintTracker,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures & helpers
+# ---------------------------------------------------------------------------
+
+def _make_catalog_and_resolver(tmp_path: Path, profiles: list[dict]):
+    """
+    Build a ProfilesCatalog + SessionWorldResolver from scratch in tmp_path.
+    Returns (catalog, resolver, manifest_paths).
+    """
+    import yaml
+    from agent_hypervisor.hypervisor.mcp_gateway.profiles_catalog import (
+        ProfileEntry,
+        ProfilesCatalog,
+    )
+    from agent_hypervisor.hypervisor.mcp_gateway.session_world_resolver import (
+        SessionWorldResolver,
+    )
+
+    # Write minimal manifests
+    manifest_paths = {}
+    for p in profiles:
+        m_path = tmp_path / f"{p['id']}.yaml"
+        m_path.write_text(
+            yaml.dump({
+                "workflow_id": p["id"],
+                "version": "1.0",
+                "capabilities": p.get("capabilities", []),
+            }),
+            encoding="utf-8",
+        )
+        manifest_paths[p["id"]] = m_path
+
+    # Build catalog index
+    index = {
+        "profiles": [
+            {
+                "id": p["id"],
+                "description": p.get("description", ""),
+                "path": str(manifest_paths[p["id"]]),
+                "tags": p.get("tags", []),
+            }
+            for p in profiles
+        ]
+    }
+    index_path = tmp_path / "profiles-index.yaml"
+    index_path.write_text(yaml.dump(index), encoding="utf-8")
+
+    catalog = ProfilesCatalog(index_path)
+
+    # Default manifest = first profile
+    default_path = manifest_paths[profiles[0]["id"]]
+    resolver = SessionWorldResolver(default_path)
+
+    return catalog, resolver, manifest_paths
+
+
+# ============================================================
+# 1. SessionTaintTracker unit tests
+# ============================================================
+
+class TestSessionTaintTracker:
+
+    def test_get_context_auto_inits_session(self):
+        tracker = SessionTaintTracker()
+        ctx = tracker.get_context("s1")
+        assert ctx["taint_level"] == "clean"
+        assert ctx["tool_call_count"] == 0
+        assert ctx["last_verdict"] == "allow"
+        assert "session_age_s" in ctx
+
+    def test_record_tool_call_increments_count(self):
+        tracker = SessionTaintTracker()
+        tracker.record_tool_call("s1", verdict="allow")
+        tracker.record_tool_call("s1", verdict="deny")
+        ctx = tracker.get_context("s1")
+        assert ctx["tool_call_count"] == 2
+        assert ctx["last_verdict"] == "deny"
+
+    def test_escalate_taint_monotonic(self):
+        tracker = SessionTaintTracker()
+        # clean → elevated
+        changed = tracker.escalate_taint("s1", "elevated")
+        assert changed
+        assert tracker.get_context("s1")["taint_level"] == "elevated"
+        # elevated → high
+        changed = tracker.escalate_taint("s1", "high")
+        assert changed
+        assert tracker.get_context("s1")["taint_level"] == "high"
+        # high → elevated  (downgrade rejected)
+        changed = tracker.escalate_taint("s1", "elevated")
+        assert not changed
+        assert tracker.get_context("s1")["taint_level"] == "high"
+        # high → clean (downgrade rejected)
+        changed = tracker.escalate_taint("s1", "clean")
+        assert not changed
+
+    def test_clear_taint_resets_to_clean(self):
+        tracker = SessionTaintTracker()
+        tracker.escalate_taint("s1", "high")
+        assert tracker.get_context("s1")["taint_level"] == "high"
+        cleared = tracker.clear_taint("s1")
+        assert cleared
+        assert tracker.get_context("s1")["taint_level"] == "clean"
+
+    def test_clear_taint_returns_false_for_unknown_session(self):
+        tracker = SessionTaintTracker()
+        assert not tracker.clear_taint("nonexistent")
+
+    def test_init_session_records_original_profile(self):
+        tracker = SessionTaintTracker()
+        tracker.init_session("s1", original_profile_id="email-assistant-v1")
+        sig = tracker.get_signals("s1")
+        assert sig is not None
+        assert sig.original_profile_id == "email-assistant-v1"
+        assert sig.current_profile_id == "email-assistant-v1"
+
+    def test_note_profile_switch_updates_current(self):
+        tracker = SessionTaintTracker()
+        tracker.init_session("s1", original_profile_id="full-access")
+        tracker.note_profile_switch("s1", "read-only")
+        sig = tracker.get_signals("s1")
+        assert sig.current_profile_id == "read-only"
+        assert sig.original_profile_id == "full-access"
+
+    def test_clear_taint_restores_original_profile_id(self):
+        tracker = SessionTaintTracker()
+        tracker.init_session("s1", original_profile_id="full-access")
+        tracker.note_profile_switch("s1", "read-only")
+        tracker.clear_taint("s1")
+        sig = tracker.get_signals("s1")
+        assert sig.current_profile_id == "full-access"
+
+    def test_list_sessions(self):
+        tracker = SessionTaintTracker()
+        tracker.record_tool_call("s1")
+        tracker.record_tool_call("s2")
+        sessions = tracker.list_sessions()
+        ids = {s["session_id"] for s in sessions}
+        assert "s1" in ids
+        assert "s2" in ids
+
+    def test_remove_session(self):
+        tracker = SessionTaintTracker()
+        tracker.record_tool_call("s1")
+        tracker.remove_session("s1")
+        assert tracker.get_signals("s1") is None
+
+    def test_session_age_increases(self):
+        tracker = SessionTaintTracker()
+        tracker.record_tool_call("s1")
+        time.sleep(0.05)
+        ctx = tracker.get_context("s1")
+        assert ctx["session_age_s"] >= 0.0
+
+
+# ============================================================
+# 2. LinkingPolicyEngine — comparison operators
+# ============================================================
+
+class TestLinkingPolicyEngineComparisons:
+
+    def test_gte_matches(self):
+        engine = LinkingPolicyEngine([
+            {"if": {"tool_call_count_gte": 5}, "then": {"profile_id": "restricted"}},
+        ])
+        assert engine.evaluate({"tool_call_count": 5}) == "restricted"
+        assert engine.evaluate({"tool_call_count": 10}) == "restricted"
+        assert engine.evaluate({"tool_call_count": 4}) is None
+
+    def test_lte_matches(self):
+        engine = LinkingPolicyEngine([
+            {"if": {"session_age_s_lte": 60}, "then": {"profile_id": "new-session"}},
+        ])
+        assert engine.evaluate({"session_age_s": 30}) == "new-session"
+        assert engine.evaluate({"session_age_s": 60}) == "new-session"
+        assert engine.evaluate({"session_age_s": 61}) is None
+
+    def test_gt_matches(self):
+        engine = LinkingPolicyEngine([
+            {"if": {"tool_call_count_gt": 10}, "then": {"profile_id": "heavy-user"}},
+        ])
+        assert engine.evaluate({"tool_call_count": 11}) == "heavy-user"
+        assert engine.evaluate({"tool_call_count": 10}) is None
+
+    def test_lt_matches(self):
+        engine = LinkingPolicyEngine([
+            {"if": {"session_age_s_lt": 10}, "then": {"profile_id": "fresh"}},
+        ])
+        assert engine.evaluate({"session_age_s": 9}) == "fresh"
+        assert engine.evaluate({"session_age_s": 10}) is None
+
+    def test_plain_equality_still_works(self):
+        engine = LinkingPolicyEngine([
+            {"if": {"taint_level": "high"}, "then": {"profile_id": "read-only"}},
+        ])
+        assert engine.evaluate({"taint_level": "high"}) == "read-only"
+        assert engine.evaluate({"taint_level": "clean"}) is None
+
+    def test_mixed_conditions(self):
+        """All conditions must hold — mix of equality and comparison."""
+        engine = LinkingPolicyEngine([
+            {
+                "if": {"taint_level": "high", "tool_call_count_gte": 3},
+                "then": {"profile_id": "locked-down"},
+            },
+        ])
+        # Both hold
+        assert engine.evaluate({"taint_level": "high", "tool_call_count": 5}) == "locked-down"
+        # taint_level holds but count is too low
+        assert engine.evaluate({"taint_level": "high", "tool_call_count": 2}) is None
+        # count holds but taint_level doesn't
+        assert engine.evaluate({"taint_level": "clean", "tool_call_count": 5}) is None
+
+    def test_comparison_with_non_numeric_context_does_not_match(self):
+        engine = LinkingPolicyEngine([
+            {"if": {"tool_call_count_gte": 5}, "then": {"profile_id": "r"}},
+        ])
+        # context value is a string (non-numeric) → no match
+        assert engine.evaluate({"tool_call_count": "many"}) is None
+
+    def test_missing_context_key_does_not_match(self):
+        engine = LinkingPolicyEngine([
+            {"if": {"tool_call_count_gte": 5}, "then": {"profile_id": "r"}},
+        ])
+        assert engine.evaluate({}) is None
+
+    def test_default_rule_still_matches(self):
+        engine = LinkingPolicyEngine([
+            {"default": {"profile_id": "fallback"}},
+        ])
+        assert engine.evaluate({}) == "fallback"
+        assert engine.evaluate({"taint_level": "high"}) == "fallback"
+
+
+# ============================================================
+# 3. evaluate_with_note()
+# ============================================================
+
+class TestEvaluateWithNote:
+
+    def test_returns_none_when_no_match(self):
+        engine = LinkingPolicyEngine([
+            {"if": {"taint_level": "high"}, "then": {"profile_id": "r"}},
+        ])
+        result = engine.evaluate_with_note({"taint_level": "clean"})
+        assert result is None
+
+    def test_returns_profile_and_note(self):
+        engine = LinkingPolicyEngine([
+            {
+                "if": {"taint_level": "high"},
+                "then": {
+                    "profile_id": "read-only",
+                    "note": "Taint escalation — downgraded.",
+                },
+            },
+        ])
+        result = engine.evaluate_with_note({"taint_level": "high"})
+        assert result is not None
+        profile_id, note = result
+        assert profile_id == "read-only"
+        assert note == "Taint escalation — downgraded."
+
+    def test_note_is_none_when_absent(self):
+        engine = LinkingPolicyEngine([
+            {"if": {"taint_level": "high"}, "then": {"profile_id": "read-only"}},
+        ])
+        result = engine.evaluate_with_note({"taint_level": "high"})
+        assert result is not None
+        _, note = result
+        assert note is None
+
+    def test_default_rule_with_note(self):
+        engine = LinkingPolicyEngine([
+            {"default": {"profile_id": "fallback", "note": "default profile"}},
+        ])
+        result = engine.evaluate_with_note({})
+        assert result == ("fallback", "default profile")
+
+
+# ============================================================
+# 4 & 5. Taint-triggered downgrade + operator restore
+# ============================================================
+
+class TestResolveManifestForCall:
+    """
+    Tests for MCPGatewayState.resolve_manifest_for_call().
+
+    We build a minimal gateway state with a linking-policy engine wired in
+    and verify that a taint escalation causes the resolver to switch profiles.
+    """
+
+    def _make_state(self, tmp_path: Path):
+        """
+        Return (state, profiles_catalog) with two profiles:
+          'full-access'  — default
+          'read-only'    — activated when taint_level == "high"
+        """
+        from agent_hypervisor.hypervisor.mcp_gateway.mcp_server import MCPGatewayState
+        from agent_hypervisor.hypervisor.mcp_gateway.profiles_catalog import (
+            ProfileEntry,
+            ProfilesCatalog,
+        )
+        from agent_hypervisor.hypervisor.mcp_gateway.linking_policy import (
+            LinkingPolicyEngine,
+        )
+
+        catalog, resolver, _ = _make_catalog_and_resolver(
+            tmp_path,
+            profiles=[
+                {"id": "full-access"},
+                {"id": "read-only"},
+            ],
+        )
+
+        engine = LinkingPolicyEngine([
+            {
+                "if": {"taint_level": "high"},
+                "then": {
+                    "profile_id": "read-only",
+                    "note": "Taint escalation — downgraded.",
+                },
+            },
+        ])
+        resolver.set_linking_policy(engine, catalog)
+
+        full_access_path = tmp_path / "full-access.yaml"
+        state = MCPGatewayState(manifest_path=full_access_path)
+        # Wire the pre-built resolver into state (bypass the default one)
+        state.resolver = resolver
+
+        return state, catalog
+
+    def test_clean_session_gets_default_manifest(self, tmp_path):
+        state, catalog = self._make_state(tmp_path)
+        manifest = state.resolve_manifest_for_call("s1", profiles_catalog=catalog)
+        # No rule matched (taint_level is clean) → default manifest
+        assert manifest.workflow_id == "full-access"
+
+    def test_high_taint_triggers_profile_switch(self, tmp_path):
+        state, catalog = self._make_state(tmp_path)
+        # Escalate taint
+        state.taint_tracker.escalate_taint("s1", "high")
+        manifest = state.resolve_manifest_for_call("s1", profiles_catalog=catalog)
+        assert manifest.workflow_id == "read-only"
+
+    def test_profile_switch_recorded_in_tracker(self, tmp_path):
+        state, catalog = self._make_state(tmp_path)
+        state.taint_tracker.init_session("s1", original_profile_id="full-access")
+        state.taint_tracker.escalate_taint("s1", "high")
+        state.resolve_manifest_for_call("s1", profiles_catalog=catalog)
+
+        sig = state.taint_tracker.get_signals("s1")
+        assert sig is not None
+        assert sig.current_profile_id == "read-only"
+
+    def test_operator_restore_reverts_to_original(self, tmp_path):
+        state, catalog = self._make_state(tmp_path)
+        state.taint_tracker.init_session("s1", original_profile_id="full-access")
+        state.taint_tracker.escalate_taint("s1", "high")
+        state.resolve_manifest_for_call("s1", profiles_catalog=catalog)
+
+        # Operator clears taint
+        cleared = state.taint_tracker.clear_taint("s1")
+        assert cleared
+
+        sig = state.taint_tracker.get_signals("s1")
+        assert sig.taint_level == "clean"
+        assert sig.current_profile_id == "full-access"
+
+        # Next call should now use the full-access manifest
+        manifest = state.resolve_manifest_for_call("s1", profiles_catalog=catalog)
+        assert manifest.workflow_id == "full-access"
+
+    def test_tool_call_count_increments_on_each_call(self, tmp_path):
+        state, catalog = self._make_state(tmp_path)
+        state.resolve_manifest_for_call("s1", profiles_catalog=catalog)
+        state.resolve_manifest_for_call("s1", profiles_catalog=catalog)
+        ctx = state.taint_tracker.get_context("s1")
+        assert ctx["tool_call_count"] == 2
+
+
+# ============================================================
+# 6. Audit log: profile_switched events
+# ============================================================
+
+class TestAuditLogProfileSwitched:
+
+    def test_profile_switched_event_written_to_event_store(self, tmp_path):
+        """
+        When a taint-triggered switch occurs and a control plane is wired,
+        a profile_switched event must appear in the event store.
+        """
+        from agent_hypervisor.control_plane.event_store import EventStore
+        from agent_hypervisor.hypervisor.mcp_gateway.mcp_server import MCPGatewayState
+        from agent_hypervisor.control_plane.domain import EVENT_TYPE_PROFILE_SWITCHED
+
+        catalog, resolver, _ = _make_catalog_and_resolver(
+            tmp_path,
+            profiles=[
+                {"id": "full-access"},
+                {"id": "read-only"},
+            ],
+        )
+
+        engine = LinkingPolicyEngine([
+            {
+                "if": {"taint_level": "high"},
+                "then": {"profile_id": "read-only", "note": "Taint escalation."},
+            },
+        ])
+        resolver.set_linking_policy(engine, catalog)
+
+        # Create a minimal fake control plane with an event store
+        event_store = EventStore()
+        cp = MagicMock()
+        cp.event_store = event_store
+
+        full_access_path = tmp_path / "full-access.yaml"
+        state = MCPGatewayState(manifest_path=full_access_path, control_plane=cp)
+        state.resolver = resolver
+
+        state.taint_tracker.init_session("s1", original_profile_id="full-access")
+        state.taint_tracker.escalate_taint("s1", "high")
+        state.resolve_manifest_for_call("s1", profiles_catalog=catalog)
+
+        events = event_store.get_session_events("s1")
+        profile_events = [e for e in events if e.type == EVENT_TYPE_PROFILE_SWITCHED]
+        assert len(profile_events) == 1
+
+        ev = profile_events[0]
+        assert ev.payload["to_profile_id"] == "read-only"
+        assert ev.payload["from_profile_id"] == "full-access"
+        assert ev.payload["note"] == "Taint escalation."
+
+    def test_no_duplicate_event_on_same_profile(self, tmp_path):
+        """
+        If the engine resolves the same profile on subsequent calls,
+        no additional profile_switched event should be emitted.
+        """
+        from agent_hypervisor.control_plane.event_store import EventStore
+        from agent_hypervisor.hypervisor.mcp_gateway.mcp_server import MCPGatewayState
+        from agent_hypervisor.control_plane.domain import EVENT_TYPE_PROFILE_SWITCHED
+
+        catalog, resolver, _ = _make_catalog_and_resolver(
+            tmp_path,
+            profiles=[{"id": "full-access"}, {"id": "read-only"}],
+        )
+        engine = LinkingPolicyEngine([
+            {"if": {"taint_level": "high"}, "then": {"profile_id": "read-only"}},
+        ])
+        resolver.set_linking_policy(engine, catalog)
+
+        event_store = EventStore()
+        cp = MagicMock()
+        cp.event_store = event_store
+
+        full_access_path = tmp_path / "full-access.yaml"
+        state = MCPGatewayState(manifest_path=full_access_path, control_plane=cp)
+        state.resolver = resolver
+
+        state.taint_tracker.init_session("s1", original_profile_id="full-access")
+        state.taint_tracker.escalate_taint("s1", "high")
+
+        # First call: switch fires
+        state.resolve_manifest_for_call("s1", profiles_catalog=catalog)
+        # Second call: profile already "read-only" — no second event
+        state.resolve_manifest_for_call("s1", profiles_catalog=catalog)
+
+        events = event_store.get_session_events("s1")
+        profile_events = [e for e in events if e.type == EVENT_TYPE_PROFILE_SWITCHED]
+        assert len(profile_events) == 1
+
+    def test_restore_profile_writes_operator_restore_event(self, tmp_path):
+        from agent_hypervisor.control_plane.event_store import EventStore
+        from agent_hypervisor.hypervisor.mcp_gateway.mcp_server import MCPGatewayState
+        from agent_hypervisor.control_plane.domain import EVENT_TYPE_PROFILE_SWITCHED
+
+        catalog, resolver, _ = _make_catalog_and_resolver(
+            tmp_path,
+            profiles=[{"id": "full-access"}, {"id": "read-only"}],
+        )
+        event_store = EventStore()
+        cp = MagicMock()
+        cp.event_store = event_store
+
+        full_access_path = tmp_path / "full-access.yaml"
+        state = MCPGatewayState(manifest_path=full_access_path, control_plane=cp)
+        state.resolver = resolver
+
+        state.taint_tracker.init_session("s1", original_profile_id="full-access")
+        state.taint_tracker.note_profile_switch("s1", "read-only")
+
+        # Simulate operator restore via event store directly
+        from agent_hypervisor.control_plane.event_store import make_profile_switched
+        sig = state.taint_tracker.get_signals("s1")
+        state.taint_tracker.clear_taint("s1")
+        event = make_profile_switched(
+            session_id="s1",
+            from_profile_id="read-only",
+            to_profile_id="full-access",
+            trigger="operator_restore",
+            note="Operator cleared taint and restored original profile.",
+            signals={},
+        )
+        event_store.append(event)
+
+        events = event_store.get_session_events("s1")
+        restore_events = [
+            e for e in events
+            if e.type == EVENT_TYPE_PROFILE_SWITCHED
+            and e.payload.get("trigger") == "operator_restore"
+        ]
+        assert len(restore_events) == 1
+        assert restore_events[0].payload["to_profile_id"] == "full-access"
+
+
+# ============================================================
+# 7. REST API tests
+# ============================================================
+
+def _build_test_client(tmp_path: Path):
+    """
+    Build a FastAPI TestClient with a gateway that has two profiles and
+    a linking policy wired in, plus a mock control plane.
+    """
+    from agent_hypervisor.hypervisor.mcp_gateway.mcp_server import MCPGatewayState
+    from agent_hypervisor.hypervisor.mcp_gateway.linking_policy import LinkingPolicyEngine
+    from agent_hypervisor.control_plane.event_store import EventStore
+    from agent_hypervisor.ui.router import create_ui_router
+    from fastapi import FastAPI
+
+    catalog, resolver, _ = _make_catalog_and_resolver(
+        tmp_path,
+        profiles=[{"id": "full-access"}, {"id": "read-only"}],
+    )
+
+    engine = LinkingPolicyEngine([
+        {"if": {"taint_level": "high"}, "then": {"profile_id": "read-only"}},
+    ])
+    resolver.set_linking_policy(engine, catalog)
+
+    event_store = EventStore()
+    cp = MagicMock()
+    cp.event_store = event_store
+
+    full_access_path = tmp_path / "full-access.yaml"
+    state = MCPGatewayState(manifest_path=full_access_path, control_plane=cp)
+    state.resolver = resolver
+
+    app = FastAPI()
+    app.include_router(
+        create_ui_router(
+            gw_state=state,
+            cp_state=cp,
+            profiles_catalog=catalog,
+        )
+    )
+    return TestClient(app), state, event_store
+
+
+class TestTaintRestAPI:
+
+    def test_get_taint_unknown_session_returns_404(self, tmp_path):
+        client, state, _ = _build_test_client(tmp_path)
+        resp = client.get("/ui/api/sessions/unknown-session/taint")
+        assert resp.status_code == 404
+
+    def test_get_taint_after_first_call_returns_signals(self, tmp_path):
+        client, state, _ = _build_test_client(tmp_path)
+        # Prime the tracker by getting context
+        state.taint_tracker.record_tool_call("s1")
+        resp = client.get("/ui/api/sessions/s1/taint")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["taint_level"] == "clean"
+        assert data["tool_call_count"] == 1
+
+    def test_post_taint_escalates_level(self, tmp_path):
+        client, state, _ = _build_test_client(tmp_path)
+        state.taint_tracker.record_tool_call("s1")
+        resp = client.post("/ui/api/sessions/s1/taint", json={"level": "elevated"})
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["status"] == "escalated"
+        assert data["taint_level"] == "elevated"
+
+    def test_post_taint_invalid_level_returns_400(self, tmp_path):
+        client, state, _ = _build_test_client(tmp_path)
+        resp = client.post("/ui/api/sessions/s1/taint", json={"level": "extreme"})
+        assert resp.status_code == 400
+
+    def test_post_taint_cannot_downgrade(self, tmp_path):
+        client, state, _ = _build_test_client(tmp_path)
+        state.taint_tracker.escalate_taint("s1", "high")
+        resp = client.post("/ui/api/sessions/s1/taint", json={"level": "clean"})
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["status"] == "unchanged"
+        assert data["taint_level"] == "high"
+
+    def test_get_sessions_taint_list(self, tmp_path):
+        client, state, _ = _build_test_client(tmp_path)
+        state.taint_tracker.record_tool_call("s1")
+        state.taint_tracker.record_tool_call("s2")
+        resp = client.get("/ui/api/sessions/taint")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["count"] == 2
+        ids = {s["session_id"] for s in data["sessions"]}
+        assert "s1" in ids
+        assert "s2" in ids
+
+    def test_restore_profile_unknown_session_returns_404(self, tmp_path):
+        client, state, _ = _build_test_client(tmp_path)
+        resp = client.post("/ui/api/sessions/ghost/restore-profile")
+        assert resp.status_code == 404
+
+    def test_restore_profile_clears_taint_and_returns_200(self, tmp_path):
+        client, state, _ = _build_test_client(tmp_path)
+        state.taint_tracker.init_session("s1", original_profile_id="full-access")
+        state.taint_tracker.escalate_taint("s1", "high")
+        state.taint_tracker.note_profile_switch("s1", "read-only")
+
+        resp = client.post("/ui/api/sessions/s1/restore-profile")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["status"] == "restored"
+        assert data["taint_level"] == "clean"
+        assert data["original_profile_id"] == "full-access"
+
+    def test_restore_profile_writes_audit_event(self, tmp_path):
+        from agent_hypervisor.control_plane.domain import EVENT_TYPE_PROFILE_SWITCHED
+
+        client, state, event_store = _build_test_client(tmp_path)
+        state.taint_tracker.init_session("s1", original_profile_id="full-access")
+        state.taint_tracker.escalate_taint("s1", "high")
+        state.taint_tracker.note_profile_switch("s1", "read-only")
+
+        client.post("/ui/api/sessions/s1/restore-profile")
+
+        events = event_store.get_session_events("s1")
+        restore_events = [
+            e for e in events
+            if e.type == EVENT_TYPE_PROFILE_SWITCHED
+        ]
+        assert len(restore_events) == 1
+        assert restore_events[0].payload["trigger"] == "operator_restore"


### PR DESCRIPTION
- Add SessionTaintTracker: per-session taint_level, tool_call_count, session_age_s, last_verdict with monotonic escalation.
- Extend LinkingPolicyEngine with comparison operators (_gte, _lte, _gt, _lt) for cumulative/temporal rules.
- Add evaluate_with_note() returning (profile_id, note) for audit entries.
- Add MCPGatewayState.resolve_manifest_for_call() — injects runtime signals into resolver context on every tools/call; detects and records profile switches without any manual register_session() call.
- Add EVENT_TYPE_PROFILE_SWITCHED and make_profile_switched() factory to control_plane event_store; profile changes appear in audit trace.
- Add REST API endpoints (ui/router.py): GET  /ui/api/sessions/taint GET  /ui/api/sessions/{id}/taint POST /ui/api/sessions/{id}/taint POST /ui/api/sessions/{id}/restore-profile
- Update manifests/linking-policy.yaml with Phase 4 taint rules.
- 41 new tests in tests/hypervisor/test_taint_trigger.py (all passing).
- Mark TRANSPARENT_UI.md Phase 4 DONE; T6 complete in NEXT_TASKS.md.