### PR TITLE
docs: merge cost estimation into v0.3 toolchain; create GH issues #120-#128

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -202,10 +202,10 @@ docker build -t agent-hypervisor .
 ### Module Responsibilities
 
 - `runtime/` — No I/O except subprocess dispatch. No LLM calls. No mutable shared state.
-- `compiler/` — Pure transformation: YAML → deterministic policy artifacts. CLI wrappers only.
+- `compiler/` — Pure transformation: YAML → deterministic policy artifacts. CLI wrappers only. All v0.3 toolchain CLI commands (`ahc validate`, `ahc simulate`, `ahc diff`, `ahc coverage`, `ahc tune`, `ahc cost-estimate`, `ahc cost-profile`) live here.
 - `authoring/` — Design-time only. Defines what is possible; does not execute anything.
 - `hypervisor/` — PoC-quality gateway and policy engine. Not production hardened.
-- `economic/` — First-class budget enforcement. Cost decisions happen at IR construction, not post-hoc.
+- `economic/` — First-class budget enforcement. Cost decisions happen at IR construction, not post-hoc. Cost CLI tools are surfaced through `compiler/cli.py`, not added directly to this package.
 
 ### File Naming
 
@@ -233,7 +233,7 @@ gh project item-list 7 --owner sv-pro --limit 50 --format json
 
 Or use the `/gh-board` command for a full audit with drift detection.
 
-Issue → milestone mapping: M2 (#10–17), M3 (#18–23), M4 (#24–30), M5 (#31–34)
+Issue → milestone mapping: M2 (#10–17), M3 (#18–23), M4 (#24–30), M5 (#31–34), v0.2 (#120), v0.3 (#121–#128)
 
 ---
 
@@ -259,8 +259,12 @@ Issue → milestone mapping: M2 (#10–17), M3 (#18–23), M4 (#24–30), M5 (#3
 - Capability DSL, named policy presets
 - MCP integration wrapper
 - Hypervisor PoC and gateway
-- Economic constraints
+- Economic constraints (Phases 1–3 complete; Phases 4–5 tracked with v0.3 toolchain)
 - Program layer
+
+**In Progress**:
+- v0.2 Phase 4 — Compiler integration (v2 schema → M2 compiler; blocker for v0.3)
+- v0.3 toolchain — `ahc validate`, `ahc simulate`, `ahc diff`, `ahc coverage`, `ahc tune`, `ahc cost-estimate`, `ahc cost-profile` (see `NEXT_TASKS.md` for task-by-task status)
 
 **Do not modify**:
 - `archive/` — Historical experimental code
@@ -282,7 +286,10 @@ Issue → milestone mapping: M2 (#10–17), M3 (#18–23), M4 (#24–30), M5 (#3
 | Published articles | `docs/pub/the-missing-layer/` |
 | Changelog | `CHANGELOG.md` |
 | Roadmap | `ROADMAP.md` |
+| Next tasks (checklist) | `NEXT_TASKS.md` |
+| Session context / quick-ref | `MEMORY.md` |
 | Component maturity | `STATUS.md` |
+| Wiki (curated knowledge) | `wiki/index.md` |
 
 ---
 
@@ -330,3 +337,4 @@ Issue → milestone mapping: M2 (#10–17), M3 (#18–23), M4 (#24–30), M5 (#3
 - Do not modify `archive/` or `lab/` directories.
 - Do not add probabilistic filtering ("check if this looks safe") to the runtime layer — use deterministic constraints.
 - Do not add backwards-compatibility shims unless explicitly required; prefer clean API changes with updated callers.
+- Do not add cost CLI commands outside of `compiler/cli.py`. The `economic/` package contains enforcement logic; the CLI surface lives in the compiler toolchain.

--- a/MEMORY.md
+++ b/MEMORY.md
@@ -1,0 +1,83 @@
+# MEMORY.md
+
+> Quick-reference for session context. Updated at the end of each planning or implementation session.
+> For the full roadmap see `ROADMAP.md`. For the task checklist see `NEXT_TASKS.md`.
+
+---
+
+## Current Milestone
+
+**v0.2 Phase 4 — Compiler Integration** is the immediate blocker (GH #120, PR pending).
+
+Once merged, all v0.3 tasks unblock.
+
+---
+
+## Strategic Direction (as of 2026-04-22)
+
+Two directions have been **merged into one**:
+
+| Old framing | New framing |
+|-------------|-------------|
+| v0.3 toolchain (validate/simulate/diff/coverage/tune) | ✅ same |
+| Economic Phases 4–5 (replanning, governance) | Delivered **inside** v0.3 toolchain |
+
+Cost estimation is part of the expanded toolchain, not a parallel track. Rationale: `ahc simulate`, `ahc coverage`, and `ahc tune` are more useful when they include cost projections alongside policy decisions. See ROADMAP.md v0.3 section.
+
+---
+
+## Critical Integration Gaps
+
+These are known gaps in the current codebase that must be closed during v0.3:
+
+1. **`EconomicPolicyEngine.evaluate_budget()` is not wired** onto the runtime enforcement path.
+   - Module exists: `src/agent_hypervisor/economic/economic_policy.py`
+   - Not imported or called in any runtime module — cost enforcement is currently inert.
+   - Fix: v0.3-T2 (GH #37).
+
+2. **No `ahc cost-profile` CLI command** exists yet.
+   - `CostProfileStore.percentile()` is implemented and tested.
+   - CLI command is in the roadmap but missing from `compiler/cli.py`.
+   - Fix: v0.3-T2 (GH #37).
+
+3. **No `economic.model_pricing` section in example manifests.**
+   - The emitter outputs `budgets` from the manifest but no example shows `model_pricing`.
+   - Fix: add example during v0.3-T2 / T3.
+
+---
+
+## v0.3 Task Sequence (GH issues)
+
+| # | Task | GH Issue | Depends on |
+|---|------|----------|------------|
+| T0 | v0.2 Phase 4 — Compiler integration | #120 | — |
+| T1 | `ahc validate` | #121 | #120 |
+| T2 | `ahc cost-profile` + runtime enforcement wiring | #122 | #120 |
+| T3 | `ahc cost-estimate` | #123 | #122 |
+| T4 | `ahc simulate` (with cost output) | #124 | #121, #123 |
+| T5 | `ahc diff` | #125 | #121 |
+| T6 | `ahc coverage` (with budget utilization) | #126 | #124, #125 |
+| T7 | `ahc tune` (with budget suggestions) | #127 | #126, #123 |
+| T8 | Role-based budget policies in Manifest v2 | #128 | #122 |
+
+---
+
+## Key Files for Next Task (v0.2 Phase 4)
+
+- `src/agent_hypervisor/compiler/loader_v2.py` — v2 schema loader (extend to parse new entity types)
+- `src/agent_hypervisor/compiler/emitter.py` — policy table emitter (extend to emit v2 artifacts)
+- `src/agent_hypervisor/compiler/cli.py` — `ahc build` command
+- `manifests/schema_v2.yaml` — authoritative v2 schema definition
+- `manifests/workspace_v2.yaml` — reference v2 manifest for testing
+- `tests/compiler/` — add test for v2 compiler round-trip
+
+---
+
+## Issue → Milestone Mapping
+
+| Milestone | Issues |
+|-----------|--------|
+| M2–M4 | #10–#30 (complete) |
+| M5 | #31–#34 (complete) |
+| v0.2 | #120 |
+| v0.3 | #121–#128 |

--- a/NEXT_TASKS.md
+++ b/NEXT_TASKS.md
@@ -26,6 +26,53 @@
   - Rewrite the AgentDojo workspace manifest using the v2 schema.
   - Ensure it provides more precise taint containment decisions.
 
-- [-] **Phase 4 — Compiler integration** *(PR: pending)*
+- [-] **Phase 4 — Compiler integration** *(PR: pending)* — GH #120
   - Wire v2 schema into the M2 compiler.
   - Update `ahc build` to parse and output artifacts based on the new types (e.g., data-class taint propagation table).
+  - **Blocker for all v0.3 tasks below.**
+
+---
+
+### v0.3 — Manifest Designer / Compiler / Tuner (with integrated cost estimation)
+
+> Cost estimation (Economic Phases 4–5) is delivered through this toolchain, not as a separate track.
+> See ROADMAP.md v0.3 section for full rationale and success criteria.
+
+- [ ] **v0.3-T1 — `ahc validate`** — GH #121
+  - Schema-level validation: required fields, type checks, cross-references, unknown action detection.
+  - Budget sanity check: declared budgets must cover at least one known model in the pricing registry.
+  - Tests: `tests/compiler/test_validate.py`.
+
+- [ ] **v0.3-T2 — `ahc cost-profile` + runtime enforcement wiring** — GH #122
+  - Implement `ahc cost-profile <trace-set>` CLI command (currently in roadmap but unimplemented).
+  - Wire `EconomicPolicyEngine.evaluate_budget()` onto the runtime enforcement path (currently not called).
+  - Tests: extend `tests/economic/` and `tests/runtime/test_invariants.py`.
+
+- [ ] **v0.3-T3 — `ahc cost-estimate`** — GH #123
+  - `ahc cost-estimate <plan-file>` — estimate total cost for a plan using `CostProfileStore` percentiles.
+  - Falls back to static pricing when no trace profiles exist.
+  - Tests: `tests/compiler/test_cost_estimate.py`.
+
+- [ ] **v0.3-T4 — `ahc simulate` (with cost output)** — GH #124
+  - Dry-run trace/scenarios against manifest; output decision table + p50/p90 cost projection per step.
+  - Simulation fidelity: same decisions as live runtime for the reference scenario set.
+  - Tests: simulation fidelity test against workspace manifest.
+
+- [ ] **v0.3-T5 — `ahc diff`** — GH #125
+  - Structural diff between two manifest versions (actions, taint rules, escalations, budget limits).
+  - Tests: `tests/compiler/test_diff.py`.
+
+- [ ] **v0.3-T6 — `ahc coverage` (with budget utilization)** — GH #126
+  - Annotate exercised vs. dead manifest rules; annotate budget bucket utilization.
+  - Must identify at least one dead rule in workspace manifest (acceptance criterion).
+  - Tests: `tests/compiler/test_coverage.py`.
+
+- [ ] **v0.3-T7 — `ahc tune` (with budget suggestions)** — GH #127
+  - Suggest manifest + budget edits from failing scenarios and cost trace profiles.
+  - At least one manifest iteration driven by `ahc tune` output (acceptance criterion).
+  - Tests: `tests/compiler/test_tune.py`.
+
+- [ ] **v0.3-T8 — Role-based budget policies in World Manifest v2** — GH #128
+  - `economic.policies` section: bind budget limits to roles, provenance classes, task types.
+  - Compiled into `CompiledPolicy`; evaluated alongside capability and provenance checks.
+  - Tests: `tests/compiler/test_economic_policies.py`, `tests/runtime/test_invariants.py`.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -217,28 +217,43 @@ The following phases extend beyond Stage 3. Each builds directly on evidence fro
 
 **Deliverables:**
 
+*Policy toolchain:*
+
 | Artifact | Description |
 | --- | --- |
-| `ahc validate` | Schema-level validation: required fields, type checks, cross-reference integrity, unknown action detection |
-| `ahc simulate` | Dry-run a trace or scenario set against a manifest without executing real tools; outputs a decision table |
-| `ahc diff` | Structural diff between two manifest versions: what actions were added/removed, what taint rules changed, what escalations changed |
-| `ahc coverage` | Given a benchmark result, annotate which manifest actions/rules were exercised, which were never triggered |
-| `ahc tune` | Interactive CLI: given a failing scenario, suggest manifest edits that would have blocked or allowed it |
+| `ahc validate` | Schema-level validation: required fields, type checks, cross-reference integrity, unknown action detection; includes budget sanity check (declared budgets must cover at least one known model) |
+| `ahc simulate` | Dry-run a trace or scenario set against a manifest without executing real tools; outputs a decision table with cost projection per step alongside policy decisions |
+| `ahc diff` | Structural diff between two manifest versions: what actions were added/removed, what taint rules changed, what escalations changed, what budget limits changed |
+| `ahc coverage` | Given a benchmark result, annotate which manifest actions/rules were exercised, which were never triggered; includes budget utilization — which budget buckets were hit, which are unreachable given the scenario set |
+| `ahc tune` | Interactive CLI: given a failing scenario, suggest manifest edits that would have blocked or allowed it; also suggests budget adjustments derived from trace cost profiles |
 | LLM authoring integration | `ahc draft --description "..."` uses LLM at design-time to generate a manifest draft from a natural-language description of the world |
 | Manifest test harness | `ahc test` runs a YAML-defined scenario set against the manifest and reports pass/fail per case |
 | Web UI integration (M5+) | Manifest editor tab in the Web UI with inline validation, simulation panel, diff viewer |
 | Manifest format stability | Freeze the v2 schema with a compatibility guarantee; document breaking change policy |
 
-**Architectural Significance:** This phase closes the Design → Compile → Learn → Redesign loop at the toolchain level. Without it, the loop exists in theory but requires manual work at every step. With it, a designer can iterate manifests in response to benchmark failures without touching runtime code.
+*Cost estimation toolchain (Economic Phases 4–5, delivered here):*
 
-**Dependencies:** v0.2 schema (v2 manifests are the compiler input), M4 benchmark suite (provides scenarios for simulation and coverage), M5 Web UI (surface for non-CLI users).
+| Artifact | Description |
+| --- | --- |
+| `ahc cost-profile <trace-set>` | Derive and print cost profiles (p50/p90/p99) from a trace set; feeds back into `CostEstimator` at design-time |
+| `ahc cost-estimate <plan>` | Estimate total cost for a declared plan using `CostProfileStore` percentiles before any execution |
+| `REPLAN` verdict wiring | Wire `EconomicPolicyEngine.evaluate_budget()` onto the runtime enforcement path; add `REPLAN` verdict alongside `ALLOW`/`DENY`/`ASK` |
+| Role-based budget policies | `economic.policies` section in World Manifest v2: bind budget limits to roles, provenance classes, and task types; compiled into `CompiledPolicy` |
+
+**Architectural Significance:** This phase closes the Design → Compile → Learn → Redesign loop at the toolchain level — for both policy decisions *and* cost. Without it, the loop exists in theory but requires manual work at every step. With it, a designer can iterate manifests and budgets in response to benchmark failures and cost overruns without touching runtime code.
+
+**Dependencies:** v0.2 schema (v2 manifests are the compiler input), M4 benchmark suite (provides scenarios for simulation and coverage), M5 Web UI (surface for non-CLI users), Economic Phase 3 (CostProfileStore with percentile summaries).
 
 **Success Criteria:**
 
 - Full Design→Compile→Learn→Redesign cycle completable without editing source code
 - `ahc simulate` produces the same decisions as the live runtime for a reference scenario set (simulation fidelity test)
-- `ahc coverage` identifies at least one dead manifest rule in the workspace manifest
+- `ahc simulate` also reports cost estimate per step consistent with `ahc cost-estimate`
+- `ahc coverage` identifies at least one dead manifest rule and one unused budget bucket in the workspace manifest
 - At least one manifest iteration driven by `ahc tune` output rather than manual analysis
+- `ahc cost-estimate` uses trace-derived profiles (not static defaults) when profiles exist
+- `REPLAN` verdict fires correctly when a plan exceeds budget; replan hint resolves to a cheaper path
+- A manifest with role-differentiated budgets compiles and enforces correctly; all decisions appear in the audit trace
 
 ---
 
@@ -501,9 +516,11 @@ artifacts, not live runtime lookups.
 
 ---
 
-### Phase 4 — Cost-Aware Replanning
+### Phase 4 — Cost-Aware Replanning *(delivered in v0.3 toolchain)*
 
 **Goal:** On a budget `DENY`, propose a cheaper alternative execution path — deterministically.
+
+> **Delivery note:** This phase is implemented as part of the v0.3 Manifest Designer / Compiler / Tuner toolchain, specifically the `REPLAN` verdict wiring and `ahc cost-estimate` CLI command. See v0.3 deliverables above.
 
 **Scope:**
 - New verdict: `REPLAN` (alongside `ALLOW`, `DENY`, `ASK`)
@@ -524,9 +541,11 @@ generated narrative.
 
 ---
 
-### Phase 5 — Economic Governance
+### Phase 5 — Economic Governance *(delivered in v0.3 toolchain)*
 
 **Goal:** Bind budget limits to roles, provenance classes, and task types in the World Manifest.
+
+> **Delivery note:** This phase is implemented as part of the v0.3 Manifest Designer / Compiler / Tuner toolchain, specifically the role-based budget policies in World Manifest v2. See v0.3 deliverables above.
 
 **Scope:**
 - Budget policies expressed in the manifest `economic.policies` section

--- a/wiki/code/economic.md
+++ b/wiki/code/economic.md
@@ -76,8 +76,23 @@ Compiled once at startup from the `economic` section of the world manifest. Immu
 5. **Immutable pricing table** — `PricingRegistry` is frozen after compilation.
 6. **First-class enforcement** — `BudgetExceeded` is a `ConstructionError` subclass; it fires before any handler code runs.
 
+## Toolchain Integration (v0.3)
+
+Cost CLI commands are delivered through the v0.3 toolchain as part of `compiler/cli.py`, not added directly to this package. The `economic/` package contains enforcement logic; the CLI surface lives in the compiler toolchain.
+
+| CLI Command | GH Issue | Status |
+|-------------|----------|--------|
+| `ahc cost-profile <trace-set>` | #122 | Planned |
+| `ahc cost-estimate <plan>` | #123 | Planned |
+| Cost projections in `ahc simulate` | #124 | Planned |
+| Budget utilization in `ahc coverage` | #126 | Planned |
+| Budget suggestions in `ahc tune` | #127 | Planned |
+
+**Known gap (as of 2026-04-22):** `EconomicPolicyEngine.evaluate_budget()` is not yet wired onto the runtime enforcement path. Cost enforcement is currently inert. This will be fixed in GH #122 (v0.3-T2).
+
 ## See Also
 
 - [Runtime package](runtime.md) — `BudgetExceeded` in the `ConstructionError` hierarchy
 - [IRBuilder module](modules/ir.md) — where economic constraints are checked at build time
 - [Compile Phase](modules/compile.md) — `CompiledBudget` compiled from manifest
+- [Compiler package](compiler.md) — v0.3 toolchain CLI commands

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -1,5 +1,37 @@
 # Wiki Log
 
+## [2026-04-22] planning | Merge cost estimation into v0.3 toolchain; create GH issues #120–#128
+
+Reconciled two previously separate roadmap tracks — toolchain expansion (v0.3) and Economic Phases 4–5 — into a single integrated direction.
+
+**What changed:**
+
+- `ROADMAP.md` — Expanded v0.3 deliverables table to include cost toolchain CLI commands (`ahc cost-profile`, `ahc cost-estimate`), cost projections in `ahc simulate` and `ahc coverage`, budget suggestions in `ahc tune`. Economic Phases 4 and 5 now carry a "Delivery note" cross-referencing v0.3 as the delivery vehicle.
+- `NEXT_TASKS.md` — Added integrated v0.3 task list (T1–T8) with GH issue references after the v0.2 Phase 4 blocker.
+- `CLAUDE.md` — Updated documentation map (added `NEXT_TASKS.md`, `MEMORY.md`, `wiki/index.md`), module responsibilities (clarified that cost CLI tools live in `compiler/cli.py`, not `economic/`), component maturity (added In Progress section for v0.2 Phase 4 and v0.3), issue→milestone mapping (added v0.2: #120, v0.3: #121–#128), and What NOT To Do (added rule about cost CLI placement).
+- `MEMORY.md` — **Created**: session quick-reference with current milestone, merged strategic direction, critical integration gaps, v0.3 task sequence with issue numbers.
+- `wiki/code/economic.md` — Added toolchain integration section.
+
+**Critical integration gaps identified** (to close in v0.3-T2, GH #122):
+1. `EconomicPolicyEngine.evaluate_budget()` is not wired onto the runtime enforcement path — cost enforcement is currently inert.
+2. No `ahc cost-profile` CLI command exists despite being in the roadmap.
+
+**GitHub issues created:**
+
+| Issue | Title |
+|-------|-------|
+| #120 | v0.2 Phase 4 — Compiler integration (v2 schema → M2 compiler) |
+| #121 | v0.3-T1 — `ahc validate` |
+| #122 | v0.3-T2 — `ahc cost-profile` + runtime enforcement wiring |
+| #123 | v0.3-T3 — `ahc cost-estimate` |
+| #124 | v0.3-T4 — `ahc simulate` (with cost projections) |
+| #125 | v0.3-T5 — `ahc diff` |
+| #126 | v0.3-T6 — `ahc coverage` (with budget utilization) |
+| #127 | v0.3-T7 — `ahc tune` (with budget suggestions) |
+| #128 | v0.3-T8 — Role-based budget policies in Manifest v2 |
+
+**Next immediate task:** #120 — v0.2 Phase 4 compiler integration (blocker for all v0.3 work).
+
 ## [2026-04-12] housekeeping | Roadmap/task reconciliation + wiki sync
 
 Performed a housekeeping pass to align planning docs and wiki summaries with current code state:


### PR DESCRIPTION
- ROADMAP.md: expand v0.3 deliverables to include cost CLI tools (ahc
  cost-profile, ahc cost-estimate) and cost dimensions in simulate/
  coverage/tune; add delivery notes to Economic Phases 4-5 pointing to v0.3
- NEXT_TASKS.md: add integrated v0.3 task list (T1-T8) with GH issue refs
  (#120-#128); Phase 4 v0.2 marked as blocker
- CLAUDE.md: update docs map, module responsibilities, component maturity,
  issue-milestone mapping, and What NOT To Do for cost CLI placement rule
- MEMORY.md: create session quick-reference with milestone status, critical
  integration gaps, and v0.3 task sequence
- wiki/log.md: log this planning reconciliation with full issue table
- wiki/code/economic.md: add toolchain integration section and known gap note

GH issues created: #120 (v0.2-P4), #121-#128 (v0.3 T1-T8)

https://claude.ai/code/session_01CgBG2dYBb8CCKPdzxfUuk2